### PR TITLE
Add option to disable registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,16 @@ NODE_ENV=development
 LOG_LEVEL=info
 
 # ===========================================
+# Optional: Registration Control
+# ===========================================
+# Disable registration after the first user registers.
+# When set to true:
+# - The first user (when user count is 0) can still register
+# - All subsequent registration attempts will be blocked
+# This is useful for public-facing self-hosted instances
+# DISABLE_REGISTRATION=false
+
+# ===========================================
 # Optional: Redis (For Production Rate Limiting)
 # ===========================================
 # Uncomment and configure for production use

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The database will be automatically set up on first run.
 |----------|-------------|---------|
 | `RESEND_API_KEY` | API key from [Resend](https://resend.com) for email functionality | Not required for self-hosted |
 | `EMAIL_DOMAIN` | Verified domain for sending emails | Not required for self-hosted |
+| `DISABLE_REGISTRATION` | Disable user registration after first user | `false` |
 | `NODE_ENV` | Environment mode | `production` |
 | `LOG_LEVEL` | Logging verbosity | `info` |
 
@@ -209,6 +210,18 @@ If you want email functionality:
 4. Add `RESEND_API_KEY` and `EMAIL_DOMAIN` to your `.env` file
 
 **Note**: The hosted service at [nametag.one](https://nametag.one) requires email verification for security, but self-hosted instances are designed for personal use and auto-verify all accounts.
+
+### Restricting Registration (Optional)
+
+For public-facing instances, you may want to prevent strangers from creating accounts.
+
+Set `DISABLE_REGISTRATION=true` in your `.env` file. This allows:
+- The first user to register normally (when no users exist)
+- All subsequent registration attempts are blocked
+
+This is ideal for personal instances where only you (and potentially family members you manually add) should have access. The instance owner can register first, then registration automatically closes.
+
+To allow additional users later, set `DISABLE_REGISTRATION=false` and restart the service.
 
 ### Reverse Proxy (Production)
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -24,6 +24,17 @@ export async function POST(request: Request) {
     return rateLimitResponse;
   }
 
+  // Check if registration is disabled
+  if (process.env.DISABLE_REGISTRATION === 'true') {
+    const userCount = await prisma.user.count();
+    if (userCount > 0) {
+      return NextResponse.json(
+        { error: 'Registration is currently disabled' },
+        { status: 403 }
+      );
+    }
+  }
+
   try {
     const body = await parseRequestBody(request);
     const validation = validateRequest(registerSchema, body);

--- a/app/api/auth/registration-status/route.ts
+++ b/app/api/auth/registration-status/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { handleApiError } from '@/lib/api-utils';
+
+export async function GET() {
+  try {
+    // If registration is not disabled, always allow
+    if (process.env.DISABLE_REGISTRATION !== 'true') {
+      return NextResponse.json({ enabled: true });
+    }
+
+    // If registration is disabled, check if this would be the first user
+    const userCount = await prisma.user.count();
+
+    if (userCount === 0) {
+      // First user can still register
+      return NextResponse.json({ enabled: true });
+    }
+
+    // Registration is disabled and there are already users
+    return NextResponse.json({
+      enabled: false,
+      message: 'Registration is currently disabled',
+    });
+  } catch (error) {
+    return handleApiError(error, 'registration-status');
+  }
+}

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -24,6 +24,25 @@ export default function RegisterPage() {
   const [success, setSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [showGoogleAuth, setShowGoogleAuth] = useState(false);
+  const [registrationEnabled, setRegistrationEnabled] = useState(true);
+  const [checkingStatus, setCheckingStatus] = useState(true);
+
+  // Check if registration is enabled
+  useEffect(() => {
+    async function checkRegistrationStatus() {
+      try {
+        const response = await fetch('/api/auth/registration-status');
+        const data = await response.json();
+        setRegistrationEnabled(data.enabled);
+      } catch {
+        // If check fails, default to enabled to avoid blocking legitimate users
+        setRegistrationEnabled(true);
+      } finally {
+        setCheckingStatus(false);
+      }
+    }
+    checkRegistrationStatus();
+  }, []);
 
   // Fetch available providers
   useEffect(() => {
@@ -95,6 +114,48 @@ export default function RegisterPage() {
     } finally {
       setIsLoading(false);
     }
+  }
+
+  // Show loading state while checking registration status
+  if (checkingStatus) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background px-4">
+        <div className="max-w-md w-full space-y-8 text-center">
+          <p className="text-muted">{tCommon('loading')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Show disabled message if registration is not enabled
+  if (!registrationEnabled) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-background px-4">
+        <div className="max-w-md w-full space-y-8 text-center">
+          <div className="flex flex-col items-center">
+            <Image
+              src="/logo.svg"
+              alt="Nametag Logo"
+              width={96}
+              height={96}
+              priority
+            />
+            <h2 className="mt-6 text-center text-3xl font-bold text-foreground">
+              {t('registrationDisabled')}
+            </h2>
+          </div>
+          <div className="bg-warning/10 border-2 border-warning text-warning px-6 py-4 rounded-lg">
+            <p className="text-sm">{t('registrationDisabledMessage')}</p>
+          </div>
+          <Link
+            href="/login"
+            className="inline-block text-blue-600 hover:text-blue-500 dark:text-blue-400 dark:hover:text-blue-300"
+          >
+            {t('backToLogin')}
+          </Link>
+        </div>
+      </div>
+    );
   }
 
   if (success) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
       - REDIS_URL=redis://:${REDIS_PASSWORD}@redis:6379
       - REDIS_PASSWORD=${REDIS_PASSWORD:?Redis password required}
       - SAAS_MODE=${SAAS_MODE:-false}
+      - DISABLE_REGISTRATION=${DISABLE_REGISTRATION:-false}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
     volumes:

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -38,6 +38,9 @@ const envSchema = z.object({
   // SaaS mode - enables billing and tier limits (undocumented, for internal use)
   SAAS_MODE: z.coerce.boolean().default(false),
 
+  // Disable registration after first user (useful for public-facing self-hosted instances)
+  DISABLE_REGISTRATION: z.coerce.boolean().default(false),
+
   // Application URL for generating links in emails
   NEXT_PUBLIC_APP_URL: z.string().url().optional(),
 });

--- a/locales/en.json
+++ b/locales/en.json
@@ -720,6 +720,8 @@
     "invalidResetLink": "Invalid Reset Link",
     "resetLinkInvalidOrExpired": "This password reset link is invalid or has expired.",
     "requestNewResetLink": "Request a new reset link",
+    "registrationDisabled": "Registration Disabled",
+    "registrationDisabledMessage": "Registration is currently disabled by the administrator. Please contact the site owner for access.",
     "passwordResetSuccessful": "Password Reset Successful",
     "passwordResetSuccessMessage": "Your password has been updated. You can now log in with your new password.",
     "goToLoginButton": "Go to login",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -720,6 +720,8 @@
     "invalidResetLink": "Enlace de Restablecimiento Inválido",
     "resetLinkInvalidOrExpired": "Este enlace de restablecimiento de contraseña es inválido o ha expirado.",
     "requestNewResetLink": "Solicitar un nuevo enlace de restablecimiento",
+    "registrationDisabled": "Registro Deshabilitado",
+    "registrationDisabledMessage": "El registro está actualmente deshabilitado por el administrador. Por favor, contacte al propietario del sitio para obtener acceso.",
     "passwordResetSuccessful": "Contraseña Restablecida con Éxito",
     "passwordResetSuccessMessage": "Tu contraseña ha sido actualizada. Ahora puedes iniciar sesión con tu nueva contraseña.",
     "goToLoginButton": "Ir a iniciar sesión",

--- a/tests/api/registration-status.test.ts
+++ b/tests/api/registration-status.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Use vi.hoisted to create mocks before hoisting
+const mocks = vi.hoisted(() => ({
+  userCount: vi.fn(),
+}));
+
+// Mock Prisma
+vi.mock('../../lib/prisma', () => ({
+  prisma: {
+    user: {
+      count: mocks.userCount,
+    },
+  },
+}));
+
+// Import after mocking
+import { GET as registrationStatus } from '../../app/api/auth/registration-status/route';
+
+describe('Registration Status API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset environment variable
+    delete process.env.DISABLE_REGISTRATION;
+  });
+
+  describe('GET /api/auth/registration-status', () => {
+    it('should return enabled when DISABLE_REGISTRATION is not set', async () => {
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.enabled).toBe(true);
+      expect(body.message).toBeUndefined();
+      expect(mocks.userCount).not.toHaveBeenCalled();
+    });
+
+    it('should return enabled when DISABLE_REGISTRATION is false', async () => {
+      process.env.DISABLE_REGISTRATION = 'false';
+
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.enabled).toBe(true);
+      expect(body.message).toBeUndefined();
+      expect(mocks.userCount).not.toHaveBeenCalled();
+    });
+
+    it('should return enabled when DISABLE_REGISTRATION is true but no users exist', async () => {
+      process.env.DISABLE_REGISTRATION = 'true';
+      mocks.userCount.mockResolvedValue(0);
+
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.enabled).toBe(true);
+      expect(body.message).toBeUndefined();
+      expect(mocks.userCount).toHaveBeenCalled();
+    });
+
+    it('should return disabled when DISABLE_REGISTRATION is true and users exist', async () => {
+      process.env.DISABLE_REGISTRATION = 'true';
+      mocks.userCount.mockResolvedValue(1);
+
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.enabled).toBe(false);
+      expect(body.message).toBe('Registration is currently disabled');
+      expect(mocks.userCount).toHaveBeenCalled();
+    });
+
+    it('should return disabled when DISABLE_REGISTRATION is true and multiple users exist', async () => {
+      process.env.DISABLE_REGISTRATION = 'true';
+      mocks.userCount.mockResolvedValue(5);
+
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.enabled).toBe(false);
+      expect(body.message).toBe('Registration is currently disabled');
+      expect(mocks.userCount).toHaveBeenCalled();
+    });
+
+    it('should handle database errors gracefully', async () => {
+      process.env.DISABLE_REGISTRATION = 'true';
+      mocks.userCount.mockRejectedValue(new Error('Database error'));
+
+      const request = new Request('http://localhost/api/auth/registration-status');
+      const response = await registrationStatus();
+
+      expect(response.status).toBe(500);
+    });
+  });
+});

--- a/tests/e2e/registration-disabled.spec.ts
+++ b/tests/e2e/registration-disabled.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E Test: Registration Disabled Feature (DISABLE_REGISTRATION)
+ * Tests: Registration control when DISABLE_REGISTRATION=true
+ *
+ * NOTE: These tests require manual setup of DISABLE_REGISTRATION env var
+ * For CI/CD, you may want to skip these or run them in a separate environment
+ */
+
+test.describe('Registration Disabled Feature', () => {
+  test.describe('When registration is enabled (default)', () => {
+    test('should show registration form', async ({ page }) => {
+      await page.goto('/register');
+
+      // Should show the registration form
+      await expect(page.locator('input[name="email"]')).toBeVisible();
+      await expect(page.locator('input[name="password"]')).toBeVisible();
+      await expect(page.locator('input[name="name"]')).toBeVisible();
+      await expect(page.locator('button[type="submit"]')).toBeVisible();
+    });
+
+    test('should allow user registration', async ({ page }) => {
+      const testEmail = `test-${Date.now()}@example.com`;
+      const testPassword = 'TestPassword123!';
+      const testName = 'Test User';
+
+      await page.goto('/register');
+
+      await page.fill('input[name="email"]', testEmail);
+      await page.fill('input[name="password"]', testPassword);
+      await page.fill('input[name="confirmPassword"]', testPassword);
+      await page.fill('input[name="name"]', testName);
+
+      await page.click('button[type="submit"]');
+
+      // Should show success message (either verification email or success)
+      await expect(
+        page.getByText(/check your email|created successfully/i)
+      ).toBeVisible({ timeout: 5000 });
+    });
+  });
+
+  test.describe.skip('When DISABLE_REGISTRATION=true', () => {
+    // These tests require DISABLE_REGISTRATION to be set in the environment
+    // Skip by default as they require specific setup
+    // To run: Set DISABLE_REGISTRATION=true in .env and remove .skip
+
+    test('should show disabled message when users exist', async ({ page }) => {
+      await page.goto('/register');
+
+      // Should show "Registration Disabled" message
+      await expect(page.getByText(/registration.*disabled/i)).toBeVisible({
+        timeout: 3000,
+      });
+
+      // Should NOT show the registration form
+      await expect(page.locator('input[name="email"]')).not.toBeVisible();
+      await expect(page.locator('input[name="password"]')).not.toBeVisible();
+      await expect(page.locator('button[type="submit"]')).not.toBeVisible();
+
+      // Should show link back to login
+      await expect(page.getByText(/back to login/i)).toBeVisible();
+    });
+
+    test('should allow first user registration when no users exist', async ({ page }) => {
+      // This test requires a clean database with no users
+      // Typically only useful in isolated test environments
+
+      await page.goto('/register');
+
+      // Should show the registration form (because user count is 0)
+      await expect(page.locator('input[name="email"]')).toBeVisible();
+      await expect(page.locator('input[name="password"]')).toBeVisible();
+      await expect(page.locator('input[name="name"]')).toBeVisible();
+
+      const testEmail = `first-user-${Date.now()}@example.com`;
+      const testPassword = 'FirstUser123!';
+      const testName = 'First User';
+
+      await page.fill('input[name="email"]', testEmail);
+      await page.fill('input[name="password"]', testPassword);
+      await page.fill('input[name="confirmPassword"]', testPassword);
+      await page.fill('input[name="name"]', testName);
+
+      await page.click('button[type="submit"]');
+
+      // Should complete registration successfully
+      await expect(
+        page.getByText(/check your email|created successfully/i)
+      ).toBeVisible({ timeout: 5000 });
+    });
+
+    test('should show disabled message immediately after first user registers', async ({ page }) => {
+      // This test assumes the first user has already registered
+      // The registration-status endpoint should now return disabled
+
+      await page.goto('/register');
+
+      // Should show "Registration Disabled" message
+      await expect(page.getByText(/registration.*disabled/i)).toBeVisible({
+        timeout: 3000,
+      });
+
+      // Should NOT show the registration form
+      await expect(page.locator('input[name="email"]')).not.toBeVisible();
+    });
+
+    test('should not allow API registration when disabled', async ({ page, request }) => {
+      // Try to register directly via API
+      const response = await request.post('/api/auth/register', {
+        data: {
+          email: `blocked-${Date.now()}@example.com`,
+          password: 'BlockedUser123!',
+          name: 'Blocked User',
+        },
+      });
+
+      // Should return 403 Forbidden
+      expect(response.status()).toBe(403);
+
+      const body = await response.json();
+      expect(body.error).toContain('disabled');
+    });
+
+    test('should check status endpoint correctly', async ({ page, request }) => {
+      // Check the registration-status endpoint
+      const response = await request.get('/api/auth/registration-status');
+
+      expect(response.status()).toBe(200);
+
+      const body = await response.json();
+      expect(body.enabled).toBe(false);
+      expect(body.message).toBe('Registration is currently disabled');
+    });
+
+    test('should allow navigation back to login', async ({ page }) => {
+      await page.goto('/register');
+
+      // Wait for disabled message
+      await expect(page.getByText(/registration.*disabled/i)).toBeVisible();
+
+      // Click back to login link
+      await page.click('a:has-text("Back to login")');
+
+      // Should navigate to login page
+      await expect(page).toHaveURL('/login', { timeout: 3000 });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds a feature that allows disabling the registration entirely. This is especially useful for internet facing instances of the app.

How it works:
Set `DISABLE_REGISTRATION=true` in your `.env` file. This allows:
- The first user to register normally (when no users exist). This is useful for setting up the app for the first time use.
- All subsequent registration attempts are blocked

## Checklist

- [x] I've run tests locally (or explain why not)
- [x] I've updated documentation where needed
- [x] I've added/updated tests for the change (if applicable)
- [x] I've considered backwards compatibility / migrations (if applicable)
- [x] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings

## Screenshots (if UI changes)

<img width="715" height="520" alt="image" src="https://github.com/user-attachments/assets/f861d168-221f-4b62-906e-b2f2a3bcf1c0" />

## Related issues

https://github.com/mattogodoy/nametag/issues/9


