### PR TITLE
chore: Prevent PRs from automatically bumping the release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ permissions:
 jobs:
   check-commits:
     runs-on: ubuntu-latest
+    # Only run on the main repository, not on forks
+    if: github.repository == 'mattogodoy/nametag'
     outputs:
       should_release: ${{ steps.check.outputs.should_release }}
     steps:


### PR DESCRIPTION
## Summary

This PR is to prevent other PRs to automatically bump release versions


