### PR TITLE
Simplified locale setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -389,6 +389,9 @@ Nametag supports multiple languages. **All user-facing strings must be translate
 
 - English (`en`) - Default language
 - Spanish (`es-ES`)
+- Japanese (`ja-JP`)
+- Norwegian (`nb-NO`)
+- German (`de-DE`)
 
 ### Adding or Changing Strings
 
@@ -397,6 +400,9 @@ Nametag supports multiple languages. **All user-facing strings must be translate
 1. **Add translation keys to all locale files**:
    - `/locales/en.json` - English translations
    - `/locales/es-ES.json` - Spanish translations
+   - `/locales/ja-JP.json` - Japanese translations
+   - `/locales/nb-NO.json` - Norwegian translations
+   - `/locales/de-DE.json` - German translations
 
 2. **Use the translation hook in components**:
 
@@ -494,120 +500,25 @@ Translate all strings in the new file. Keep the same structure and keys as the E
 
 #### Step 2: Update Locale Configuration
 
-Edit `/lib/locale.ts`:
+Edit `/lib/locale-config.ts`:
 
-**Add to SUPPORTED_LOCALES array** (around line 7):
-
-```typescript
-export const SUPPORTED_LOCALES = ["en", "es-ES", "ja-JP", "fr-FR"] as const;
-//                                                        ^^^^^^^ Add your locale
-```
-
-**Add language mapping in `normalizeLocale()` function** (around line 48):
+**Add to LANGUAGES array** (around line 6):
 
 ```typescript
-if (languageCode === "ja") {
-  return "ja-JP";
-}
-
-// Add your language mapping
-if (languageCode === "fr") {
-  return "fr-FR";
-}
-```
-
-**Add language mapping in `detectBrowserLocale()` function** (around line 148):
-
-```typescript
-if (languageCode === "ja") {
-  return "ja-JP";
-}
-
-// Add your language mapping
-if (languageCode === "fr") {
-  return "fr-FR";
-}
-```
-
-#### Step 3: Update i18n Configuration
-
-Edit `/i18n.ts`:
-
-**Add language code mapping** (around line 48):
-
-```typescript
-if (languageCode === "ja") {
-  locale = "ja-JP";
-  break;
-}
-
-// Add your language mapping
-if (languageCode === "fr") {
-  locale = "fr-FR";
-  break;
-}
-```
-
-#### Step 4: Update LanguageSelector Component
-
-Edit `/components/LanguageSelector.tsx`:
-
-**Update TypeScript types** (line 9):
-
-```typescript
-interface LanguageSelectorProps {
-  currentLanguage: "en" | "es-ES" | "ja-JP" | "fr-FR";
-  //                                          ^^^^^^^ Add your locale
-}
-```
-
-**Add to LANGUAGES array** (around line 12):
-
-```typescript
-const LANGUAGES = [
-  { code: "en" as const, name: "English", flag: "gb" },
-  { code: "es-ES" as const, name: "Español (España)", flag: "es" },
-  { code: "ja-JP" as const, name: "日本語", flag: "jp" },
-  { code: "fr-FR" as const, name: "Français (France)", flag: "fr" },
+export const LANGUAGES = [
+  { code: 'en' as const, name: 'English', flag: 'gb' },
+  { code: 'es-ES' as const, name: 'Español (España)', flag: 'es' },
+  { code: 'ja-JP' as const, name: '日本語', flag: 'jp' },
+  { code: 'nb-NO' as const, name: 'Norsk bokmål', flag: 'no', aliases: ['no'] as const }, // aliases is optional
+  { code: 'de-DE' as const, name: 'Deutsch (German)', flag: 'de' },
+  { code: 'fr-FR' as const, name: 'Français (France)', flag: 'fr' },
   //                                                    ^^^^ Flag code from flag-icons
-];
+] as const;
 ```
 
-**Add to labelMap** (around line 18):
+#### Step 3: Add Language Names to All Translation Files
 
-```typescript
-const labelMap = {
-  en: "en",
-  "es-ES": "esES",
-  "ja-JP": "jaJP",
-  "fr-FR": "frFR", // Convert hyphen to camelCase: fr-FR → frFR
-} as const;
-```
-
-**Update handleLanguageChange type** (line 28):
-
-```typescript
-const handleLanguageChange = async (newLanguage: 'en' | 'es-ES' | 'ja-JP' | 'fr-FR') => {
-  //                                                                          ^^^^^^^ Add your locale
-```
-
-#### Step 5: Update API Route
-
-Edit `/app/api/user/language/route.ts`:
-
-**Update error message** (around line 27):
-
-```typescript
-return NextResponse.json(
-  { error: "Invalid language. Supported languages: en, es-ES, ja-JP, fr-FR" },
-  //                                                                 ^^^^^^^ Add your locale
-  { status: 400 },
-);
-```
-
-#### Step 6: Add Language Names to All Translation Files
-
-Add your language name to **ALL** locale files under `settings.appearance.language`:
+Add your language name to **ALL** locale files under `locales`:
 
 **In `/locales/en.json`**:
 
@@ -635,18 +546,7 @@ Add your language name to **ALL** locale files under `settings.appearance.langua
 }
 ```
 
-**In `/locales/ja-JP.json`**:
-
-```json
-"language": {
-  "title": "言語",
-  "description": "お好みの言語を選択してください",
-  "en": "English",
-  "esES": "Español (España)",
-  "jaJP": "日本語",
-  "frFR": "Français (France)"
-}
-```
+**...**
 
 **And in your new locale file** (e.g., `/locales/fr-FR.json`):
 
@@ -661,49 +561,53 @@ Add your language name to **ALL** locale files under `settings.appearance.langua
 }
 ```
 
-#### Step 7: Add Tests
+#### Step 4: Add Tests
 
 Edit `/tests/lib/locale.test.ts`:
 
-Add test cases for your new language:
+Add your language to the testcases:
 
 ```typescript
-// In isSupportedLocale tests
-it('should return true for "fr-FR"', () => {
-  expect(isSupportedLocale("fr-FR")).toBe(true);
-});
+const SUPPORTED = ['en', 'es-ES', 'ja-JP', 'nb-NO', 'de-DE'] as const;
+```
 
-// In normalizeLocale tests
-it('should pass through "fr-FR"', () => {
-  expect(normalizeLocale("fr-FR")).toBe("fr-FR");
-});
+Add all your aliases to the normalize map:
+```typescript
+const NORMALIZE_MAP = [
+  ['es', 'es-ES'],
+  ['ja', 'ja-JP'],
+  ['nb', 'nb-NO'],
+  ['no', 'nb-NO'],
+  ['de', 'de-DE']
+]
+```
 
-it('should map "fr" to "fr-FR"', () => {
-  expect(normalizeLocale("fr")).toBe("fr-FR");
-});
+#### Step 5: Adjust Documentation
 
-// In detectBrowserLocale tests
-it("should detect French from Accept-Language header", async () => {
-  const { headers } = await import("next/headers");
-  vi.mocked(headers).mockResolvedValue({
-    get: vi.fn().mockReturnValue("fr-FR,fr;q=0.9,en;q=0.8"),
-  } as any);
 
-  const locale = await detectBrowserLocale();
+Edit `README.md`:
+Add you locale to Features-Chapter
+```
+- Multiple languages (English, Spanish, ...)
+```
 
-  expect(locale).toBe("fr-FR");
-});
 
-it('should map "fr" to "fr-FR"', async () => {
-  const { headers } = await import("next/headers");
-  vi.mocked(headers).mockResolvedValue({
-    get: vi.fn().mockReturnValue("fr,en;q=0.9"),
-  } as any);
+Edit `CONTRIBUTING.md`:
 
-  const locale = await detectBrowserLocale();
+Add you locale to Internationalization-Chapter
+```
+### Supported Languages
 
-  expect(locale).toBe("fr-FR");
-});
+- English (`en`) - Default language
+- Spanish (`es-ES`)
+  ....
+```
+
+```
+1. **Add translation keys to all locale files**:
+   - `/locales/en.json` - English translations
+   - `/locales/es-ES.json` - Spanish translations
+     ....
 ```
 
 #### Important Notes

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -7,6 +7,7 @@ import { handleApiError } from '@/lib/api-utils';
 import { logger, securityLogger } from '@/lib/logger';
 import { getClientIp } from '@/lib/api-utils';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
+import { type SupportedLocale, DEFAULT_LOCALE} from '@/lib/locale-config';
 
 // This endpoint should be called by a cron job
 export async function GET(request: Request) {
@@ -69,7 +70,7 @@ export async function GET(request: Request) {
       if (shouldSend) {
         const { person } = importantDate;
         const userEmail = person.user.email;
-        const userLanguage = (person.user.language as 'en' | 'es-ES') || 'en';
+        const userLanguage = (person.user.language as SupportedLocale) || DEFAULT_LOCALE
         const personName = formatFullName(person);
         const formattedDate = formatDateForEmail(
           importantDate.date,
@@ -141,7 +142,7 @@ export async function GET(request: Request) {
       const shouldSend = shouldSendContactReminder(person, today);
 
       if (shouldSend) {
-        const userLanguage = (person.user.language as 'en' | 'es-ES') || 'en';
+        const userLanguage = (person.user.language as SupportedLocale) || DEFAULT_LOCALE
         const personName = formatFullName(person);
         const lastContactFormatted = person.lastContact
           ? formatDateForEmail(person.lastContact, person.user.dateFormat, userLanguage)
@@ -421,7 +422,7 @@ function formatInterval(interval: number, unit: string): string {
 function formatDateForEmail(
   date: Date,
   dateFormat: string | null,
-  locale: 'en' | 'es-ES' = 'en'
+  locale: SupportedLocale = DEFAULT_LOCALE
 ): string {
   const d = new Date(date);
   const localeCode = locale === 'es-ES' ? 'es-ES' : 'en-US';

--- a/app/api/user/language/route.ts
+++ b/app/api/user/language/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isSupportedLocale, setLocaleCookie } from '@/lib/locale';
+import { SUPPORTED_LOCALES } from '@/lib/locale-config';
 
 /**
  * PUT /api/user/language
@@ -20,11 +21,12 @@ export async function PUT(request: NextRequest) {
 
     const body = await request.json();
     const { language } = body;
+    
 
     // Validate language
     if (!language || !isSupportedLocale(language)) {
       return NextResponse.json(
-        { error: 'Invalid language. Supported languages: en, es-ES, ja-JP, nb-NO, de-DE' },
+        { error: 'Invalid language. Supported languages: ${SUPPORTED_LOCALES.join(", ")}' },
         { status: 400 }
       );
     }

--- a/app/settings/appearance/page.tsx
+++ b/app/settings/appearance/page.tsx
@@ -4,7 +4,8 @@ import ThemeToggle from '@/components/ThemeToggle';
 import DateFormatSelector from '@/components/DateFormatSelector';
 import LanguageSelector from '@/components/LanguageSelector';
 import { prisma } from '@/lib/prisma';
-import { getUserLocale, type SupportedLocale } from '@/lib/locale';
+import { getUserLocale } from '@/lib/locale';
+import { type SupportedLocale } from '@/lib/locale-config';
 import { getTranslations } from 'next-intl/server';
 
 export default async function AppearanceSettingsPage() {

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -4,20 +4,20 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import 'flag-icons/css/flag-icons.min.css';
+import { LANGUAGES, SupportedLocale } from "@/lib/locale-config";
 
 interface LanguageSelectorProps {
-  currentLanguage: 'en' | 'es-ES' | 'ja-JP' | 'nb-NO' | 'de-DE';
+  currentLanguage: SupportedLocale;
 }
 
-const LANGUAGES = [
-  { code: 'en' as const, name: 'English', flag: 'gb' },
-  { code: 'es-ES' as const, name: 'Español (España)', flag: 'es' },
-  { code: 'ja-JP' as const, name: '日本語', flag: 'jp' },
-  { code: 'nb-NO' as const, name: 'Norsk bokmål', flag: 'no' },
-  { code: 'de-DE' as const, name: 'Deutsch (German)', flag: 'de' },
-];
+type LocaleCode = (typeof LANGUAGES)[number]["code"];
 
-const labelMap = { en: 'en', 'es-ES': 'esES', 'ja-JP': 'jaJP', 'nb-NO': 'nbNO', 'de-DE': 'deDE' } as const;
+export const labelMap = Object.fromEntries(
+  LANGUAGES.map(({ code }) => {
+    const [lang, region] = code.split("-");
+    return [code, region ? `${lang}${region}` : lang];
+  }),
+) as Record<LocaleCode, string>;
 
 export default function LanguageSelector({ currentLanguage }: LanguageSelectorProps) {
   const t = useTranslations('settings.appearance.language');
@@ -27,7 +27,7 @@ export default function LanguageSelector({ currentLanguage }: LanguageSelectorPr
   const [selectedLanguage, setSelectedLanguage] = useState(currentLanguage);
   const [isLoading, setIsLoading] = useState(false);
 
-  const handleLanguageChange = async (newLanguage: 'en' | 'es-ES' | 'ja-JP' | 'nb-NO' | 'de-DE') => {
+  const handleLanguageChange = async (newLanguage: SupportedLocale) => {
     if (isLoading || newLanguage === selectedLanguage) return;
 
     setIsLoading(true);

--- a/i18n.ts
+++ b/i18n.ts
@@ -1,6 +1,7 @@
 import { getRequestConfig } from 'next-intl/server';
 import { cookies, headers } from 'next/headers';
-import { DEFAULT_LOCALE, type SupportedLocale, isSupportedLocale } from './lib/locale';
+import { isSupportedLocale, normalizeLocale } from './lib/locale';
+import { type SupportedLocale,  DEFAULT_LOCALE } from './lib/locale-config';
 
 /**
  * next-intl configuration
@@ -36,25 +37,10 @@ export default getRequestConfig(async () => {
             break;
           }
 
-          const languageCode = browserLocale.split('-')[0].toLowerCase();
-          if (languageCode === 'es') {
-            locale = 'es-ES';
-            break;
-          }
-          if (languageCode === 'en') {
-            locale = 'en';
-            break;
-          }
-          if (languageCode === 'ja') {
-            locale = 'ja-JP';
-            break;
-          }
-          if (languageCode === 'nb' || languageCode === 'no') {
-            locale = 'nb-NO';
-            break;
-          }
-           if (languageCode === 'de') {
-            locale = 'de-DE';
+          // Normalize by language code / aliases (e.g. "de" -> "de-DE", "no" -> "nb-NO")
+          const normalized = normalizeLocale(browserLocale);
+          if (normalized) {
+            locale = normalized;
             break;
           }
         }

--- a/lib/i18n-utils.ts
+++ b/lib/i18n-utils.ts
@@ -1,5 +1,6 @@
 import { getTranslations as getT } from 'next-intl/server';
-import { getUserLocale, type SupportedLocale } from './locale';
+import { getUserLocale} from './locale';
+import { type SupportedLocale } from './locale-config';
 
 // Re-export SupportedLocale for convenience
 export type { SupportedLocale };

--- a/lib/locale-config.ts
+++ b/lib/locale-config.ts
@@ -1,0 +1,28 @@
+/**
+ * Central list of supported languages/locales for the UI (display name/flag) plus the technical locale code.
+ * `as const` keeps literal types (e.g. "en" instead of just `string`) so we can derive unions from it.
+ * There is an optional field aliases as needed for no and np.
+ */
+export const LANGUAGES = [
+  { code: 'en' as const, name: 'English', flag: 'gb' },
+  { code: 'es-ES' as const, name: 'Español (España)', flag: 'es' },
+  { code: 'ja-JP' as const, name: '日本語', flag: 'jp' },
+  { code: 'nb-NO' as const, name: 'Norsk bokmål', flag: 'no', aliases: ['no'] as const },
+  { code: 'de-DE' as const, name: 'Deutsch (German)', flag: 'de' },
+] as const;
+
+/**
+ * Supported Locales generated out of the list above
+ */
+export const SUPPORTED_LOCALES = LANGUAGES.map(l => l.code) as readonly typeof LANGUAGES[number]['code'][];
+
+/**
+ * Supported Locales type generated out of the list above
+ */
+
+export type SupportedLocale = typeof SUPPORTED_LOCALES[number];
+
+/**
+ * Default locale
+ */
+export const DEFAULT_LOCALE: SupportedLocale = 'en';

--- a/scripts/test-reminder-email.ts
+++ b/scripts/test-reminder-email.ts
@@ -9,6 +9,7 @@ import { prisma } from '../lib/prisma';
 import { sendEmail, emailTemplates } from '../lib/email';
 import { createUnsubscribeToken } from '../lib/unsubscribe-tokens';
 import { formatFullName } from '../lib/nameUtils';
+import { type SupportedLocale, DEFAULT_LOCALE } from '../lib/locale-config';
 
 async function testReminderEmail() {
   try {
@@ -68,7 +69,7 @@ async function testReminderEmail() {
         importantDate.title,
         formattedDate,
         unsubscribeUrl,
-        (importantDate.person.user.language as 'en' | 'es-ES') || 'en'
+        (importantDate.person.user.language as SupportedLocale) || DEFAULT_LOCALE
       );
 
       console.log('📧 Sending test email...');
@@ -146,7 +147,7 @@ async function testReminderEmail() {
         lastContactFormatted,
         intervalText,
         unsubscribeUrl,
-        (person.user.language as 'en' | 'es-ES') || 'en'
+        (person.user.language as SupportedLocale) || DEFAULT_LOCALE
       );
 
       console.log('📧 Sending test email...');

--- a/tests/lib/locale.test.ts
+++ b/tests/lib/locale.test.ts
@@ -2,6 +2,27 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getUserLocale, detectBrowserLocale, isSupportedLocale, normalizeLocale } from '@/lib/locale';
 import { prisma } from '@/lib/prisma';
 
+// Supported languages for the testcases
+const SUPPORTED = [
+  'en',
+  'es-ES',
+  'ja-JP',
+  'nb-NO',
+  'de-DE',
+] as const;
+
+// Normalization mapping for the testcases including one line for each alias
+const NORMALIZE_MAP = [
+  ['es', 'es-ES'],
+  ['ja', 'ja-JP'],
+  ['nb', 'nb-NO'],
+  ['no', 'nb-NO'],
+  ['de', 'de-DE'],
+]
+
+// Unsupported languages for the testcases
+const UNSUPPORTED = ['fr-FR', 'it'] as const;
+
 // Mock prisma
 vi.mock('@/lib/prisma', () => ({
   prisma: {
@@ -23,65 +44,36 @@ describe('Locale Utilities', () => {
   });
 
   describe('isSupportedLocale', () => {
-    it('should return true for "en"', () => {
-      expect(isSupportedLocale('en')).toBe(true);
+    for (const locale of SUPPORTED) {
+      it(`should return true for "${locale}"`, () => {
+        expect(isSupportedLocale(locale)).toBe(true);
+      });
+    }
+    
+    it(`should return false for unsupported locales`, () => {
+      for (const locale of UNSUPPORTED) {
+        expect(isSupportedLocale(locale)).toBe(false);
+      }
     });
-
-    it('should return true for "es-ES"', () => {
-      expect(isSupportedLocale('es-ES')).toBe(true);
-    });
-
-    it('should return true for "ja-JP"', () => {
-      expect(isSupportedLocale('ja-JP')).toBe(true);
-    });
-
-    it('should return true for "nb-NO"', () => {
-      expect(isSupportedLocale('nb-NO')).toBe(true);
-    });
-
-    it('should return true for "de-DE"', () => {
-      expect(isSupportedLocale('de-DE')).toBe(true);
-    });
-
-    it('should return false for unsupported locales', () => {
-      expect(isSupportedLocale('fr-FR')).toBe(false);
-      expect(isSupportedLocale('it')).toBe(false);
-    });
+ 
   });
 
   describe('normalizeLocale', () => {
     it('should pass through exact matches', () => {
-      expect(normalizeLocale('en')).toBe('en');
-      expect(normalizeLocale('es-ES')).toBe('es-ES');
-      expect(normalizeLocale('ja-JP')).toBe('ja-JP');
-      expect(normalizeLocale('nb-NO')).toBe('nb-NO');
-      expect(normalizeLocale('de-DE')).toBe('de-DE');
-    });
-
-    it('should map "es" to "es-ES"', () => {
-      expect(normalizeLocale('es')).toBe('es-ES');
+      for (const locale of SUPPORTED) {
+        expect(normalizeLocale(locale)).toBe(locale);
+      }
     });
 
     it('should map "en-US" to "en"', () => {
       expect(normalizeLocale('en-US')).toBe('en');
     });
 
-    it('should map "ja" to "ja-JP"', () => {
-      expect(normalizeLocale('ja')).toBe('ja-JP');
-    });
-
-    it('should map "nb" to "nb-NO"', () => {
-      expect(normalizeLocale('nb')).toBe('nb-NO');
-    });
-
-    it('should map "no" to "nb-NO"', () => {
-      expect(normalizeLocale('no')).toBe('nb-NO');
-    });
-
-    it('should map "de" to "de-DE"', () => {
-      expect(normalizeLocale('de')).toBe('de-DE');
-    });
-
+    for (const [input, expected] of NORMALIZE_MAP) {
+      it(`should map "${input}" to "${expected}"`, () => {
+        expect(normalizeLocale(input)).toBe(expected);
+      });
+    }
     it('should default to "en" for unsupported locales', () => {
       expect(normalizeLocale('fr-FR')).toBe('en');
       expect(normalizeLocale('it')).toBe('en');


### PR DESCRIPTION
## Summary
I simplified the process to add a locale by centralizing the information in a single file (lib/locale-config.ts) and modified the rest to use this information. Furthermore, the locale testcases are now simplified, when adding a new locale you only have to add values to two arrays in locale.test.ts

In Detail:
- Added lib/locale-config.ts with the locale information
- Made use of the locales dynamic according to the information in locale-config
- Simplified testcases
- Added languages to the Documentation
- Updated Contributing.md with new, simplified instructions

**Important: 3 of the Email-Testcases are failing at my place locally but that is not related to the changes, it was there before already. Please check if my chances somehow affected the reminder and email functionality as I am not able to test this locally.**

## Checklist

- [x] I've run tests locally (or explain why not)
- [x] I've updated documentation where needed
- [x] I've added/updated tests for the change (if applicable)
- [x] I've considered backwards compatibility / migrations (if applicable)
- [x] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings

## Screenshots (if UI changes)

## Related issues



