### PR TITLE
Solve timezone conversion issue

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -7,6 +7,7 @@ import { handleApiError } from '@/lib/api-utils';
 import { logger, securityLogger } from '@/lib/logger';
 import { getClientIp } from '@/lib/api-utils';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
+import { parseAsLocalDate } from '@/lib/date-format';
 
 // This endpoint should be called by a cron job
 export async function GET(request: Request) {
@@ -249,7 +250,7 @@ async function shouldSendImportantDateReminder(
   },
   today: Date
 ): Promise<boolean> {
-  const eventDate = new Date(importantDate.date);
+  const eventDate = parseAsLocalDate(importantDate.date);
 
   if (importantDate.reminderType === 'ONCE') {
     // For one-time reminders, send on the exact date if not already sent

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import Navigation from '@/components/Navigation';
 import { prisma } from '@/lib/prisma';
 import UnifiedNetworkGraph from '@/components/UnifiedNetworkGraph';
-import { formatDate } from '@/lib/date-format';
+import { formatDate, parseAsLocalDate } from '@/lib/date-format';
 import { formatFullName } from '@/lib/nameUtils';
 import { getTranslations } from 'next-intl/server';
 
@@ -168,13 +168,13 @@ export default async function DashboardPage() {
     let eventDate: Date;
 
     if (importantDate.reminderType === 'ONCE') {
-      eventDate = new Date(importantDate.date);
+      eventDate = parseAsLocalDate(importantDate.date);
     } else {
       // Recurring - get next occurrence based on interval
       const interval = importantDate.reminderInterval || 1;
       const intervalUnit = importantDate.reminderIntervalUnit || 'YEARS';
       eventDate = getNextOccurrence(
-        new Date(importantDate.date),
+        parseAsLocalDate(importantDate.date),
         today,
         interval,
         intervalUnit,

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -7,7 +7,7 @@ import DeleteUserRelationshipButton from '@/components/DeleteUserRelationshipBut
 import RelationshipManager from '@/components/RelationshipManager';
 import UnifiedNetworkGraph from '@/components/UnifiedNetworkGraph';
 import Navigation from '@/components/Navigation';
-import { formatDate } from '@/lib/date-format';
+import { formatDate, parseAsLocalDate } from '@/lib/date-format';
 import { formatFullName } from '@/lib/nameUtils';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { getTranslations } from 'next-intl/server';
@@ -311,7 +311,7 @@ export default async function PersonDetailsPage({
                   <div className="space-y-2">
                     {person.importantDates.map((date) => {
                       const reminderDesc = getReminderDescription(date, t);
-                      const dateObj = new Date(date.date);
+                      const dateObj = parseAsLocalDate(date.date);
                       const yearsAgo = getYearsAgo(dateObj, t);
                       return (
                         <div

--- a/components/ImportantDatesManager.tsx
+++ b/components/ImportantDatesManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { parseAsLocalDate } from '@/lib/date-format';
 
 type ReminderType = 'ONCE' | 'RECURRING';
 type ReminderIntervalUnit = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
@@ -65,7 +66,7 @@ export default function ImportantDatesManager({
 
   const isDateInFuture = (dateStr: string) => {
     if (!dateStr) return false;
-    const date = new Date(dateStr);
+    const date = parseAsLocalDate(dateStr);
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     return date >= today;
@@ -385,7 +386,7 @@ export default function ImportantDatesManager({
                     {date.title}
                   </div>
                   <div className="text-xs text-muted">
-                    {new Date(date.date).toLocaleDateString('en-US', {
+                    {parseAsLocalDate(date.date).toLocaleDateString('en-US', {
                       year: 'numeric',
                       month: 'long',
                       day: 'numeric',

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,7 +1,24 @@
 type DateFormat = 'MDY' | 'DMY' | 'YMD';
 
+/**
+ * Parse a date string or Date object as a local date, avoiding timezone issues.
+ * Date-only strings (YYYY-MM-DD) are parsed as local dates instead of UTC.
+ */
+export function parseAsLocalDate(date: Date | string): Date {
+  if (typeof date === 'string') {
+    // Parse date-only strings (YYYY-MM-DD) as local dates to avoid timezone issues
+    const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
+    if (dateOnlyPattern.test(date)) {
+      const [year, month, day] = date.split('-').map(Number);
+      return new Date(year, month - 1, day);
+    }
+    return new Date(date);
+  }
+  return date;
+}
+
 export function formatDate(date: Date | string, format: DateFormat): string {
-  const d = typeof date === 'string' ? new Date(date) : date;
+  const d = parseAsLocalDate(date);
 
   if (isNaN(d.getTime())) {
     return 'Invalid Date';

--- a/scripts/test-reminder-email.ts
+++ b/scripts/test-reminder-email.ts
@@ -9,6 +9,7 @@ import { prisma } from '../lib/prisma';
 import { sendEmail, emailTemplates } from '../lib/email';
 import { createUnsubscribeToken } from '../lib/unsubscribe-tokens';
 import { formatFullName } from '../lib/nameUtils';
+import { parseAsLocalDate } from '../lib/date-format';
 
 async function testReminderEmail() {
   try {
@@ -55,7 +56,7 @@ async function testReminderEmail() {
       console.log(`🔗 Unsubscribe URL: ${unsubscribeUrl}\n`);
 
       // Format date
-      const date = new Date(importantDate.date);
+      const date = parseAsLocalDate(importantDate.date);
       const formattedDate = date.toLocaleDateString('en-US', {
         month: 'long',
         day: 'numeric',


### PR DESCRIPTION
## Summary

When a date string like "2024-02-08" is passed to `new Date()`, JavaScript interprets it as UTC midnight. But then when `getDate()` and `getMonth()` are called, they return values in the local timezone. For users in timezones west of UTC (like EST, which is UTC-5), this causes the date to shift to the previous day.


## Checklist

- [X] I've run tests locally (or explain why not)
- [X] I've updated documentation where needed
- [X] I've added/updated tests for the change (if applicable)
- [X] I've considered backwards compatibility / migrations (if applicable)
- [X] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings

## Related issues

#57 


