### PR TITLE
Make email to be case-insensitive

### DIFF
--- a/app/api/auth/check-verification/route.ts
+++ b/app/api/auth/check-verification/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { checkVerificationSchema, validateRequest } from '@/lib/validations';
-import { parseRequestBody } from '@/lib/api-utils';
+import { parseRequestBody, normalizeEmail } from '@/lib/api-utils';
 
 export async function POST(request: Request) {
   try {
@@ -12,7 +12,8 @@ export async function POST(request: Request) {
       return validation.response;
     }
 
-    const { email } = validation.data;
+    // Normalize email to lowercase for case-insensitive lookup
+    const email = normalizeEmail(validation.data.email);
 
     const user = await prisma.user.findUnique({
       where: { email },

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { forgotPasswordSchema, validateRequest } from '@/lib/validations';
 import { checkRateLimit } from '@/lib/rate-limit';
-import { handleApiError, parseRequestBody } from '@/lib/api-utils';
+import { handleApiError, parseRequestBody, normalizeEmail } from '@/lib/api-utils';
 import { getAppUrl } from '@/lib/env';
 
 const TOKEN_EXPIRY_HOURS = 1;
@@ -29,7 +29,8 @@ export async function POST(request: Request) {
       return validation.response;
     }
 
-    const { email } = validation.data;
+    // Normalize email to lowercase for case-insensitive lookup
+    const email = normalizeEmail(validation.data.email);
 
     // Find user
     const user = await prisma.user.findUnique({

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -5,7 +5,7 @@ import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { registerSchema, validateRequest } from '@/lib/validations';
 import { checkRateLimit } from '@/lib/rate-limit-redis';
-import { handleApiError, parseRequestBody } from '@/lib/api-utils';
+import { handleApiError, parseRequestBody, normalizeEmail } from '@/lib/api-utils';
 import { logger } from '@/lib/logger';
 import { createFreeSubscription } from '@/lib/billing';
 import { createPreloadedRelationshipTypes } from '@/lib/relationship-types';
@@ -44,7 +44,10 @@ export async function POST(request: Request) {
       return validation.response;
     }
 
-    const { email, password, name, surname, nickname } = validation.data;
+    const { password, name, surname, nickname } = validation.data;
+
+    // Normalize email to lowercase to prevent case-sensitivity issues
+    const email = normalizeEmail(validation.data.email);
 
     // Check if user already exists
     const existingUser = await prisma.user.findUnique({

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -4,7 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { resendVerificationSchema, validateRequest } from '@/lib/validations';
 import { checkRateLimit } from '@/lib/rate-limit';
-import { handleApiError, parseRequestBody } from '@/lib/api-utils';
+import { handleApiError, parseRequestBody, normalizeEmail } from '@/lib/api-utils';
 import { getAppUrl } from '@/lib/env';
 
 const TOKEN_EXPIRY_HOURS = 24;
@@ -29,7 +29,8 @@ export async function POST(request: Request) {
       return validation.response;
     }
 
-    const { email } = validation.data;
+    // Normalize email to lowercase for case-insensitive lookup
+    const email = normalizeEmail(validation.data.email);
 
     // Find user
     const user = await prisma.user.findUnique({

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto';
 import { prisma } from '@/lib/prisma';
 import { sendEmail, emailTemplates } from '@/lib/email';
 import { updateProfileSchema, validateRequest } from '@/lib/validations';
-import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { apiResponse, handleApiError, parseRequestBody, withAuth, normalizeEmail } from '@/lib/api-utils';
 import { getAppUrl } from '@/lib/env';
 
 const TOKEN_EXPIRY_HOURS = 24;
@@ -20,7 +20,10 @@ export const PUT = withAuth(async (request, session) => {
       return validation.response;
     }
 
-    const { name, surname, nickname, email } = validation.data;
+    const { name, surname, nickname } = validation.data;
+
+    // Normalize email to lowercase for case-insensitive lookup
+    const email = normalizeEmail(validation.data.email);
 
     // Check if email is already taken by another user
     const existingUser = await prisma.user.findUnique({

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -193,6 +193,19 @@ export function getClientIp(request: Request): string {
 }
 
 /**
+ * Normalize email address to lowercase for consistent storage and lookup
+ * Prevents case-sensitivity issues where Bob@test.com and bob@test.com
+ * would be treated as different users
+ *
+ * @example
+ * normalizeEmail('Bob@Test.COM') // returns 'bob@test.com'
+ * normalizeEmail('user@DOMAIN.com') // returns 'user@domain.com'
+ */
+export function normalizeEmail(email: string): string {
+  return email.toLowerCase().trim();
+}
+
+/**
  * Session with guaranteed user (for authenticated handlers)
  */
 export interface AuthenticatedSession extends Session {


### PR DESCRIPTION
## Summary

This PR normalizes email addresses to make them case-insensitive and prevent issues like the one described in https://github.com/mattogodoy/nametag/issues/68


## Checklist

- [x] I've run tests locally (or explain why not)
- [x] I've updated documentation where needed
- [x] I've added/updated tests for the change (if applicable)
- [x] I've considered backwards compatibility / migrations (if applicable)
- [x] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings

## Related issues

Closes #68 


