### PR TITLE
fix: only include provided fields in the update query

### DIFF
--- a/tests/api/people.test.ts
+++ b/tests/api/people.test.ts
@@ -346,6 +346,35 @@ describe('People API', () => {
         })
       );
     });
+
+    it('should not override other fields when updating a single field', async () => {
+      const existingPerson = {
+        id: 'person-1',
+        name: 'John',
+        surname: 'Doe',
+        middleName: 'Michael',
+        nickname: 'Johnny',
+        userId: 'user-123',
+        contactReminderEnabled: false,
+      };
+      const updatedPerson = { ...existingPerson, name: 'John Updated' };
+
+      mocks.personFindUnique.mockResolvedValue(existingPerson);
+      mocks.importantDateCount.mockResolvedValue(0);
+      mocks.personUpdate.mockResolvedValue(updatedPerson);
+
+      const request = new Request('http://localhost/api/people/person-1', {
+        method: 'PUT',
+        body: JSON.stringify({ name: 'John Updated' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      const context = { params: Promise.resolve({ id: 'person-1' }) };
+      await PUT(request, context);
+
+      // Ensure other properties are NOT in the update data
+      const updateCall = mocks.personUpdate.mock.calls[0][0];
+      expect(updateCall.data).toStrictEqual({ name: 'John Updated' });
+    });
   });
 
   describe('DELETE /api/people/[id]', () => {


### PR DESCRIPTION
## Summary

The `PUT` request in `api/peopel/[id]` route was including all fields in the `update` query, even the ones not provided in the request body. This PR builds the update query by checking the properties one by one, whether they were provided in the request or not.

## Checklist

- [x] I've run tests locally
- [x] I've updated documentation where needed - n/a
- [x] I've added/updated tests for the change
- [x] I've considered backwards compatibility / migrations - n/a
- [x] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings - n/a

## Screenshots (if UI changes)

## Related issues

Closes #79 


