### PR TITLE
Add relationship-to-user assignment during contact import

### DIFF
--- a/app/carddav/import/page.tsx
+++ b/app/carddav/import/page.tsx
@@ -63,15 +63,18 @@ export default async function ImportPage({
     redirect('/settings/account');
   }
 
-  // Get user's groups for assignment
-  const groups = await prisma.group.findMany({
-    where: {
-      userId: session.user.id,
-    },
-    orderBy: {
-      name: 'asc',
-    },
-  });
+  // Get user's groups and relationship types for assignment
+  const [groups, relationshipTypes] = await Promise.all([
+    prisma.group.findMany({
+      where: { userId: session.user.id },
+      orderBy: { name: 'asc' },
+    }),
+    prisma.relationshipType.findMany({
+      where: { userId: session.user.id },
+      orderBy: { label: 'asc' },
+      select: { id: true, label: true, color: true },
+    }),
+  ]);
 
   return (
     <>
@@ -107,6 +110,7 @@ export default async function ImportPage({
               <ImportContactsList
                 pendingImports={pendingImports}
                 groups={groups}
+                relationshipTypes={relationshipTypes}
                 isFileImport={isFileImport}
               />
             </>

--- a/components/CompactContactRow.tsx
+++ b/components/CompactContactRow.tsx
@@ -32,6 +32,12 @@ interface Group {
   color: string | null;
 }
 
+interface RelationshipType {
+  id: string;
+  label: string;
+  color: string | null;
+}
+
 interface CompactContactRowProps {
   pendingImport: PendingImport;
   isSelected: boolean;
@@ -41,6 +47,9 @@ interface CompactContactRowProps {
   onGroupsChange: (contactId: string, groupIds: string[]) => void;
   onGroupCreated?: (group: Group) => void;
   parsedData: ParsedVCardData | null;
+  relationshipTypes: RelationshipType[];
+  selectedRelationshipTypeId: string;
+  onRelationshipChange: (contactId: string, relationshipTypeId: string) => void;
 }
 
 export default function CompactContactRow({
@@ -52,6 +61,9 @@ export default function CompactContactRow({
   onGroupsChange,
   onGroupCreated,
   parsedData,
+  relationshipTypes,
+  selectedRelationshipTypeId,
+  onRelationshipChange,
 }: CompactContactRowProps) {
   const t = useTranslations('settings.carddav.import');
   const [isExpanded, setIsExpanded] = useState(false);
@@ -145,6 +157,21 @@ export default function CompactContactRow({
             })}
           </div>
         )}
+
+        {/* Relationship pill (read-only display) */}
+        {selectedRelationshipTypeId && selectedRelationshipTypeId !== '__none__' && (() => {
+          const relType = relationshipTypes.find((rt) => rt.id === selectedRelationshipTypeId);
+          if (!relType) return null;
+          return (
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 bg-surface-elevated rounded-full text-xs font-medium text-foreground flex-shrink-0">
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: relType.color || '#9CA3AF' }}
+              />
+              {relType.label}
+            </span>
+          );
+        })()}
       </div>
 
       {/* Expanded details */}
@@ -190,6 +217,26 @@ export default function CompactContactRow({
               showCreateHint={false}
             />
           </div>
+          {relationshipTypes.length > 0 && (
+            <div className="mt-3">
+              <label className="block text-sm font-medium text-foreground mb-1">
+                {t('contactRelationship')}
+              </label>
+              <select
+                value={selectedRelationshipTypeId}
+                onChange={(e) => onRelationshipChange(pendingImport.id, e.target.value)}
+                className="w-full max-w-xs px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-surface text-foreground text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="">{t('useGlobalRelationship')}</option>
+                <option value="__none__">{t('noRelationship')}</option>
+                {relationshipTypes.map((rt) => (
+                  <option key={rt.id} value={rt.id}>
+                    {rt.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -320,7 +320,13 @@
         "groupsCount": "{count, plural, =0 {Keine Gruppen} =1 {1 Gruppe} other {# Gruppen}}",
         "importSuccessToast": "{imported, plural, =1 {1 Kontakt erfolgreich importiert} other {# Kontakte erfolgreich importiert}}{skipped, plural, =0 {} =1 {, 1 Duplikat übersprungen} other {, # Duplikate übersprungen}}",
         "importCompleteWithErrors": "{imported, plural, =0 {Keine Kontakte importiert} =1 {1 Kontakt importiert} other {# Kontakte importiert}}, {errors, plural, =1 {1 Fehler aufgetreten} other {# Fehler aufgetreten}}",
-        "importFailed": "Kontakte konnten nicht importiert werden"
+        "importFailed": "Kontakte konnten nicht importiert werden",
+        "assignRelationship": "Beziehung zu dir (Optional)",
+        "assignRelationshipDescription": "Den ausgewählten Kontakten wird diese Beziehung zu dir zugewiesen",
+        "noRelationship": "Keine",
+        "relationshipPrecedenceHelp": "Du kannst dies für einzelne Kontakte überschreiben, indem du sie aufklappst und eine andere Beziehung auswählst.",
+        "contactRelationship": "Beziehung zu dir",
+        "useGlobalRelationship": "Globale Einstellung verwenden"
       },
       "notifications": {
         "newContactsFound": "{count} neue Kontakte gefunden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -320,7 +320,13 @@
         "groupsCount": "{count, plural, =0 {No groups} =1 {1 group} other {# groups}}",
         "importSuccessToast": "{imported, plural, =1 {1 contact imported successfully} other {# contacts imported successfully}}{skipped, plural, =0 {} =1 {, 1 duplicate skipped} other {, # duplicates skipped}}",
         "importCompleteWithErrors": "{imported, plural, =0 {No contacts imported} =1 {1 contact imported} other {# contacts imported}}, {errors, plural, =1 {1 error occurred} other {# errors occurred}}",
-        "importFailed": "Failed to import contacts"
+        "importFailed": "Failed to import contacts",
+        "assignRelationship": "Relationship to You (Optional)",
+        "assignRelationshipDescription": "Selected contacts will be assigned this relationship to you",
+        "noRelationship": "None",
+        "relationshipPrecedenceHelp": "You can override this for individual contacts by expanding them and selecting a different relationship.",
+        "contactRelationship": "Relationship to You",
+        "useGlobalRelationship": "Use global setting"
       },
       "notifications": {
         "newContactsFound": "{count} new contacts found",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -320,7 +320,13 @@
         "groupsCount": "{count, plural, =0 {Sin grupos} =1 {1 grupo} other {# grupos}}",
         "importSuccessToast": "{imported, plural, =1 {1 contacto importado exitosamente} other {# contactos importados exitosamente}}{skipped, plural, =0 {} =1 {, 1 duplicado omitido} other {, # duplicados omitidos}}",
         "importCompleteWithErrors": "{imported, plural, =0 {No se importaron contactos} =1 {1 contacto importado} other {# contactos importados}}, {errors, plural, =1 {ocurrió 1 error} other {ocurrieron # errores}}",
-        "importFailed": "Error al importar los contactos"
+        "importFailed": "Error al importar los contactos",
+        "assignRelationship": "Relación contigo (Opcional)",
+        "assignRelationshipDescription": "A los contactos seleccionados se les asignará esta relación contigo",
+        "noRelationship": "Ninguna",
+        "relationshipPrecedenceHelp": "Puedes anular esto para contactos individuales expandiéndolos y seleccionando una relación diferente.",
+        "contactRelationship": "Relación contigo",
+        "useGlobalRelationship": "Usar configuración global"
       },
       "notifications": {
         "newContactsFound": "{count} contactos nuevos encontrados",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -320,7 +320,13 @@
         "groupsCount": "{count, plural, =0 {グループなし} =1 {1グループ} other {#グループ}}",
         "importSuccessToast": "{imported, plural, =1 {1件の連絡先を正常にインポート} other {#件の連絡先を正常にインポート}}{skipped, plural, =0 {} =1 {、1件の重複をスキップ} other {、#件の重複をスキップ}}",
         "importCompleteWithErrors": "{imported, plural, =0 {インポートされた連絡先なし} =1 {1件の連絡先をインポート} other {#件の連絡先をインポート}}、{errors, plural, =1 {1件のエラーが発生} other {#件のエラーが発生}}",
-        "importFailed": "連絡先のインポートに失敗しました"
+        "importFailed": "連絡先のインポートに失敗しました",
+        "assignRelationship": "あなたとの関係（任意）",
+        "assignRelationshipDescription": "選択した連絡先にこの関係が割り当てられます",
+        "noRelationship": "なし",
+        "relationshipPrecedenceHelp": "個別の連絡先を展開して別の関係を選択することで、これを上書きできます。",
+        "contactRelationship": "あなたとの関係",
+        "useGlobalRelationship": "グローバル設定を使用"
       },
       "notifications": {
         "newContactsFound": "{count}件の新しい連絡先が見つかりました",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -320,7 +320,13 @@
         "groupsCount": "{count, plural, =0 {Ingen grupper} =1 {1 gruppe} other {# grupper}}",
         "importSuccessToast": "{imported, plural, =1 {1 kontakt importert} other {# kontakter importert}}{skipped, plural, =0 {} =1 {, 1 duplikat hoppet over} other {, # duplikater hoppet over}}",
         "importCompleteWithErrors": "{imported, plural, =0 {Ingen kontakter importert} =1 {1 kontakt importert} other {# kontakter importert}}, {errors, plural, =1 {1 feil oppstod} other {# feil oppstod}}",
-        "importFailed": "Kunne ikke importere kontakter"
+        "importFailed": "Kunne ikke importere kontakter",
+        "assignRelationship": "Relasjon til deg (valgfritt)",
+        "assignRelationshipDescription": "Valgte kontakter vil bli tildelt denne relasjonen til deg",
+        "noRelationship": "Ingen",
+        "relationshipPrecedenceHelp": "Du kan overstyre dette for individuelle kontakter ved å utvide dem og velge en annen relasjon.",
+        "contactRelationship": "Relasjon til deg",
+        "useGlobalRelationship": "Bruk global innstilling"
       },
       "notifications": {
         "newContactsFound": "{count} nye kontakter funnet",

--- a/tests/app/api/carddav/import-relationship.test.ts
+++ b/tests/app/api/carddav/import-relationship.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Tests for /api/carddav/import endpoint — relationship assignment.
+ *
+ * Verifies that the import correctly handles:
+ * - Global relationship type assignment
+ * - Per-contact relationship overrides
+ * - __none__ sentinel preventing assignment even with global set
+ * - Invalid relationship type IDs (wrong user) are ignored
+ * - No relationship fields = no person.update for relationship
+ * - Works with soft-deleted person restoration
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '@/app/api/carddav/import/route';
+import { auth } from '@/lib/auth';
+
+// ── hoisted mocks ───────────────────────────────────────────────────────────
+const mocks = vi.hoisted(() => ({
+  findUniqueConnection: vi.fn(),
+  findManyPending: vi.fn(),
+  findManyMapping: vi.fn(),
+  findManyPerson: vi.fn(),
+  updatePerson: vi.fn(),
+  deletePending: vi.fn(),
+  createMapping: vi.fn(),
+  findManyGroup: vi.fn(),
+  findManyPersonGroup: vi.fn(),
+  createManyPersonGroup: vi.fn(),
+  findManyRelationshipType: vi.fn(),
+  createPersonFromVCardData: vi.fn(),
+  restorePersonFromVCardData: vi.fn(),
+  rawFindMany: vi.fn(),
+  rawDisconnect: vi.fn(),
+}));
+
+vi.mock('@/lib/auth');
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    cardDavConnection: { findUnique: mocks.findUniqueConnection },
+    cardDavPendingImport: {
+      findMany: mocks.findManyPending,
+      delete: mocks.deletePending,
+    },
+    cardDavMapping: {
+      findMany: mocks.findManyMapping,
+      create: mocks.createMapping,
+    },
+    person: {
+      findMany: mocks.findManyPerson,
+      update: mocks.updatePerson,
+    },
+    group: { findMany: mocks.findManyGroup },
+    personGroup: {
+      findMany: mocks.findManyPersonGroup,
+      createMany: mocks.createManyPersonGroup,
+    },
+    relationshipType: { findMany: mocks.findManyRelationshipType },
+  },
+  withDeleted: () => ({
+    person: { findMany: mocks.rawFindMany },
+    $disconnect: mocks.rawDisconnect,
+  }),
+}));
+
+vi.mock('@/lib/carddav/person-from-vcard', () => ({
+  createPersonFromVCardData: mocks.createPersonFromVCardData,
+  restorePersonFromVCardData: mocks.restorePersonFromVCardData,
+}));
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+function makeVCard(uid: string, name: string) {
+  return `BEGIN:VCARD\r\nVERSION:3.0\r\nFN:${name}\r\nN:;${name};;;\r\nUID:${uid}\r\nEND:VCARD`;
+}
+
+function makePendingImport(id: string, uid: string, name: string) {
+  return {
+    id,
+    connectionId: null,
+    uploadedByUserId: 'user-1',
+    uid,
+    href: `file-import-${id}`,
+    etag: 'etag',
+    vCardData: makeVCard(uid, name),
+    displayName: name,
+    discoveredAt: new Date(),
+    notifiedAt: null,
+  };
+}
+
+function postImport(body: Record<string, unknown>) {
+  return POST(
+    new Request('http://localhost/api/carddav/import', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+// ── tests ───────────────────────────────────────────────────────────────────
+describe('POST /api/carddav/import — relationship assignment', () => {
+  const session = { user: { id: 'user-1', email: 'u@example.com' } };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (auth as ReturnType<typeof vi.fn>).mockResolvedValue(session);
+
+    // Default: no CardDAV connection (file-import-only user)
+    mocks.findUniqueConnection.mockResolvedValue(null);
+    // Default: no existing mappings / persons / soft-deleted
+    mocks.findManyMapping.mockResolvedValue([]);
+    mocks.findManyPerson.mockResolvedValue([]);
+    mocks.rawFindMany.mockResolvedValue([]);
+    mocks.rawDisconnect.mockResolvedValue(undefined);
+    // Default: no groups
+    mocks.findManyGroup.mockResolvedValue([]);
+    mocks.findManyPersonGroup.mockResolvedValue([]);
+    // Default: no relationship types
+    mocks.findManyRelationshipType.mockResolvedValue([]);
+    // Default: delete and update succeed
+    mocks.deletePending.mockResolvedValue({});
+    mocks.updatePerson.mockResolvedValue({});
+  });
+
+  it('should set relationshipToUserId on imported contacts using global value', async () => {
+    const pending = [makePendingImport('p-1', 'uid-1', 'Alice')];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    mocks.findManyRelationshipType.mockResolvedValue([{ id: 'rel-friend' }]);
+    mocks.createPersonFromVCardData.mockResolvedValueOnce({
+      id: 'person-1',
+      uid: 'uid-1',
+    });
+
+    const res = await postImport({
+      importIds: ['p-1'],
+      globalRelationshipTypeId: 'rel-friend',
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(1);
+    expect(mocks.updatePerson).toHaveBeenCalledWith({
+      where: { id: 'person-1' },
+      data: { relationshipToUserId: 'rel-friend' },
+    });
+  });
+
+  it('should allow per-contact relationship to override global', async () => {
+    const pending = [
+      makePendingImport('p-1', 'uid-1', 'Alice'),
+      makePendingImport('p-2', 'uid-2', 'Bob'),
+    ];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    mocks.findManyRelationshipType.mockResolvedValue([
+      { id: 'rel-friend' },
+      { id: 'rel-family' },
+    ]);
+    mocks.createPersonFromVCardData
+      .mockResolvedValueOnce({ id: 'person-1', uid: 'uid-1' })
+      .mockResolvedValueOnce({ id: 'person-2', uid: 'uid-2' });
+
+    const res = await postImport({
+      importIds: ['p-1', 'p-2'],
+      globalRelationshipTypeId: 'rel-friend',
+      perContactRelationshipTypeId: { 'p-2': 'rel-family' },
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(2);
+
+    // Alice gets global
+    expect(mocks.updatePerson).toHaveBeenCalledWith({
+      where: { id: 'person-1' },
+      data: { relationshipToUserId: 'rel-friend' },
+    });
+
+    // Bob gets per-contact override
+    expect(mocks.updatePerson).toHaveBeenCalledWith({
+      where: { id: 'person-2' },
+      data: { relationshipToUserId: 'rel-family' },
+    });
+  });
+
+  it('should not set relationship when __none__ sentinel is used, even with global set', async () => {
+    const pending = [makePendingImport('p-1', 'uid-1', 'Alice')];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    mocks.findManyRelationshipType.mockResolvedValue([{ id: 'rel-friend' }]);
+    mocks.createPersonFromVCardData.mockResolvedValueOnce({
+      id: 'person-1',
+      uid: 'uid-1',
+    });
+
+    const res = await postImport({
+      importIds: ['p-1'],
+      globalRelationshipTypeId: 'rel-friend',
+      perContactRelationshipTypeId: { 'p-1': '__none__' },
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(1);
+    // __none__ should prevent the update call
+    expect(mocks.updatePerson).not.toHaveBeenCalled();
+  });
+
+  it('should ignore invalid relationship type ID (wrong user)', async () => {
+    const pending = [makePendingImport('p-1', 'uid-1', 'Alice')];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    // The pre-fetch returns empty — the ID doesn't belong to this user
+    mocks.findManyRelationshipType.mockResolvedValue([]);
+    mocks.createPersonFromVCardData.mockResolvedValueOnce({
+      id: 'person-1',
+      uid: 'uid-1',
+    });
+
+    const res = await postImport({
+      importIds: ['p-1'],
+      globalRelationshipTypeId: 'rel-wrong-user',
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(1);
+    // Invalid ID should not trigger update
+    expect(mocks.updatePerson).not.toHaveBeenCalled();
+  });
+
+  it('should not call person.update when no relationship fields are provided', async () => {
+    const pending = [makePendingImport('p-1', 'uid-1', 'Alice')];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    mocks.createPersonFromVCardData.mockResolvedValueOnce({
+      id: 'person-1',
+      uid: 'uid-1',
+    });
+
+    const res = await postImport({
+      importIds: ['p-1'],
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(1);
+    expect(mocks.updatePerson).not.toHaveBeenCalled();
+  });
+
+  it('should work with soft-deleted person restoration', async () => {
+    const pending = [makePendingImport('p-1', 'deleted-uid', 'Restored')];
+    mocks.findManyPending.mockResolvedValue(pending);
+
+    // No active person, but a soft-deleted one exists
+    mocks.findManyPerson.mockResolvedValue([]);
+    mocks.rawFindMany.mockResolvedValue([
+      { id: 'soft-deleted-person', uid: 'deleted-uid', deletedAt: new Date() },
+    ]);
+
+    mocks.findManyRelationshipType.mockResolvedValue([{ id: 'rel-friend' }]);
+    mocks.restorePersonFromVCardData.mockResolvedValueOnce({
+      id: 'soft-deleted-person',
+      uid: 'deleted-uid',
+    });
+
+    const res = await postImport({
+      importIds: ['p-1'],
+      globalRelationshipTypeId: 'rel-friend',
+    });
+    const data = await res.json();
+
+    expect(data.imported).toBe(1);
+    expect(mocks.restorePersonFromVCardData).toHaveBeenCalledTimes(1);
+    expect(mocks.updatePerson).toHaveBeenCalledWith({
+      where: { id: 'soft-deleted-person' },
+      data: { relationshipToUserId: 'rel-friend' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds global and per-contact relationship type assignment to the CardDAV/file import flow, mirroring the existing group assignment pattern
- Global groups and relationship selectors are laid out side-by-side on medium+ screens for better space utilization
- Per-contact overrides are available in the expanded contact row, with a `__none__` sentinel to explicitly opt out of the global setting
- API validates relationship type IDs belong to the current user before applying
- All 5 locale files updated (en, es-ES, de-DE, ja-JP, nb-NO)

## Test plan
- [x] 1330 tests pass (10 new: 6 API relationship tests + 4 component tests)
- [x] Production build succeeds with no TypeScript errors
- [x] Manual: navigate to `/carddav/import`, verify both dropdowns render side-by-side
- [x] Manual: select global relationship, import, verify `Person.relationshipToUserId` is set
- [x] Manual: set per-contact override, verify it takes precedence over global
- [x] Manual: use "None" per-contact override with global set, verify no relationship assigned