### PR TITLE
fix: include all person fields in JSON export

### DIFF
--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -70,6 +70,42 @@ export const GET = withAuth(async (request, session) => {
               },
             },
           },
+          importantDates: {
+            where: { deletedAt: null },
+            select: {
+              title: true,
+              date: true,
+            },
+          },
+          phoneNumbers: {
+            select: { type: true, number: true },
+          },
+          emails: {
+            select: { type: true, email: true },
+          },
+          addresses: {
+            select: {
+              type: true,
+              streetLine1: true,
+              streetLine2: true,
+              locality: true,
+              region: true,
+              postalCode: true,
+              country: true,
+            },
+          },
+          urls: {
+            select: { type: true, url: true },
+          },
+          imHandles: {
+            select: { protocol: true, handle: true },
+          },
+          locations: {
+            select: { type: true, latitude: true, longitude: true, label: true },
+          },
+          customFields: {
+            select: { key: true, value: true, type: true },
+          },
         },
       }),
       prisma.group.findMany({
@@ -121,10 +157,62 @@ export const GET = withAuth(async (request, session) => {
       people: people.map((person) => ({
         id: person.id,
         name: person.name,
+        middleName: person.middleName,
+        secondLastName: person.secondLastName,
         surname: person.surname,
         nickname: person.nickname,
+        prefix: person.prefix,
+        suffix: person.suffix,
+        organization: person.organization,
+        jobTitle: person.jobTitle,
+        photo: person.photo,
+        gender: person.gender,
+        anniversary: person.anniversary,
         lastContact: person.lastContact,
         notes: person.notes,
+        contactReminderEnabled: person.contactReminderEnabled,
+        contactReminderInterval: person.contactReminderInterval,
+        contactReminderIntervalUnit: person.contactReminderIntervalUnit,
+        importantDates: person.importantDates.map((d) => ({
+          title: d.title,
+          date: d.date,
+        })),
+        phoneNumbers: person.phoneNumbers.map((p) => ({
+          type: p.type,
+          number: p.number,
+        })),
+        emails: person.emails.map((e) => ({
+          type: e.type,
+          email: e.email,
+        })),
+        addresses: person.addresses.map((a) => ({
+          type: a.type,
+          streetLine1: a.streetLine1,
+          streetLine2: a.streetLine2,
+          locality: a.locality,
+          region: a.region,
+          postalCode: a.postalCode,
+          country: a.country,
+        })),
+        urls: person.urls.map((u) => ({
+          type: u.type,
+          url: u.url,
+        })),
+        imHandles: person.imHandles.map((im) => ({
+          protocol: im.protocol,
+          handle: im.handle,
+        })),
+        locations: person.locations.map((l) => ({
+          type: l.type,
+          latitude: l.latitude,
+          longitude: l.longitude,
+          label: l.label,
+        })),
+        customFields: person.customFields.map((cf) => ({
+          key: cf.key,
+          value: cf.value,
+          type: cf.type,
+        })),
         relationshipToUser: person.relationshipToUser
           ? {
               name: person.relationshipToUser.name,


### PR DESCRIPTION
## Summary
- The JSON export was missing most person fields that were added after the initial export implementation
- Added all missing scalar fields: `middleName`, `secondLastName`, `prefix`, `suffix`, `organization`, `jobTitle`, `photo`, `gender`, `anniversary`, `contactReminderEnabled`, `contactReminderInterval`, `contactReminderIntervalUnit`
- Added all missing multi-value relations: `importantDates`, `phoneNumbers`, `emails`, `addresses`, `urls`, `imHandles`, `locations`, `customFields`

Fixes #106
Fixes #107

## Test plan
- [x] Updated export test mock data to include all new fields
- [x] Added test asserting all scalar and multi-value fields appear in export output
- [x] Verified empty multi-value arrays export correctly
- [x] All 8 export tests passing