### PR TITLE
fix: filter soft-deleted importantDates from API responses

### DIFF
--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -44,7 +44,10 @@ export const GET = withAuth(async (_request, session, context) => {
         imHandles: true,
         locations: true,
         customFields: true,
-        importantDates: true,
+        importantDates: {
+          where: { deletedAt: null },
+          orderBy: { date: 'asc' as const },
+        },
       },
     });
 
@@ -345,7 +348,10 @@ export const PUT = withAuth(async (request, session, context) => {
         imHandles: true,
         locations: true,
         customFields: true,
-        importantDates: true,
+        importantDates: {
+          where: { deletedAt: null },
+          orderBy: { date: 'asc' as const },
+        },
       },
     });
 


### PR DESCRIPTION
## Summary
- `GET /api/people/[id]` and `PUT /api/people/[id]` were using bare `importantDates: true` in Prisma includes, which returned soft-deleted important dates
- Changed both to filter `deletedAt: null` and order by `date: 'asc'`, matching the behavior of the dedicated `/api/people/[id]/important-dates` endpoint and the list endpoint

## Test plan
- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `vitest run` passes (52/52 tests across important-dates, people, and soft-delete suites)
- [ ] Manual: create a person with important dates, soft-delete one, verify GET response excludes it

Fixes #56