### PR TITLE
feat: add event planning and last-contact processing

### DIFF
--- a/app/api/cron/process-past-events/route.ts
+++ b/app/api/cron/process-past-events/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { env } from '@/lib/env';
+import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
+import { securityLogger } from '@/lib/logger';
+
+// GET /api/cron/process-past-events
+// Called by cron job to auto-update lastContact for linked people when an event date passes.
+export const GET = withLogging(async function GET(request: Request) {
+  const startTime = Date.now();
+  let cronLogId: string | null = null;
+
+  try {
+    const authHeader = request.headers.get('authorization');
+    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+      securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
+        endpoint: 'process-past-events',
+      });
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const cronLog = await prisma.cronJobLog.create({
+      data: { jobName: 'process-past-events', status: 'started' },
+    });
+    cronLogId = cronLog.id;
+
+    const now = new Date();
+
+    // Find unprocessed events whose date has passed
+    const pastEvents = await prisma.event.findMany({
+      where: {
+        date: { lte: now },
+        lastContactProcessed: false,
+      },
+      include: {
+        people: {
+          where: { deletedAt: null },
+          select: { id: true },
+        },
+      },
+    });
+
+    let processed = 0;
+
+    for (const event of pastEvents) {
+      if (event.people.length === 0) {
+        // No linked people — just mark processed
+        await prisma.event.update({
+          where: { id: event.id },
+          data: { lastContactProcessed: true },
+        });
+        processed++;
+        continue;
+      }
+
+      // Update lastContact for each linked person if event date is more recent
+      await prisma.$transaction([
+        ...event.people.map((person) =>
+          prisma.person.updateMany({
+            where: {
+              id: person.id,
+              userId: event.userId,
+              OR: [
+                { lastContact: null },
+                { lastContact: { lt: event.date } },
+              ],
+            },
+            data: { lastContact: event.date },
+          })
+        ),
+        prisma.event.update({
+          where: { id: event.id },
+          data: { lastContactProcessed: true },
+        }),
+      ]);
+
+      processed++;
+    }
+
+    await prisma.cronJobLog.update({
+      where: { id: cronLogId },
+      data: {
+        status: 'completed',
+        message: `Processed ${processed} past events`,
+        duration: Date.now() - startTime,
+      },
+    });
+
+    return NextResponse.json({ success: true, processed });
+  } catch (error) {
+    if (cronLogId) {
+      await prisma.cronJobLog.update({
+        where: { id: cronLogId },
+        data: { status: 'failed', message: String(error), duration: Date.now() - startTime },
+      }).catch(() => {});
+    }
+    return handleApiError(error, 'process-past-events');
+  }
+});

--- a/app/api/events/[id]/route.ts
+++ b/app/api/events/[id]/route.ts
@@ -1,0 +1,46 @@
+import { updateEventSchema, validateRequest } from '@/lib/validations';
+import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { getEvent, updateEvent, deleteEvent, InvalidEventPeopleError } from '@/lib/services/event';
+
+// GET /api/events/[id]
+export const GET = withAuth(async (_request, session, context) => {
+  try {
+    const { id } = await context.params;
+    const event = await getEvent(session.user.id, id);
+    if (!event) return apiResponse.notFound('Event not found');
+    return apiResponse.ok({ event });
+  } catch (error) {
+    return handleApiError(error, 'events-get');
+  }
+});
+
+// PUT /api/events/[id]
+export const PUT = withAuth(async (request, session, context) => {
+  try {
+    const { id } = await context.params;
+    const body = await parseRequestBody(request);
+    const validation = validateRequest(updateEventSchema, body);
+    if (!validation.success) return validation.response;
+
+    const event = await updateEvent(session.user.id, id, validation.data);
+    if (!event) return apiResponse.notFound('Event not found');
+    return apiResponse.ok({ event });
+  } catch (error) {
+    if (error instanceof InvalidEventPeopleError) {
+      return apiResponse.error(error.message, 400);
+    }
+    return handleApiError(error, 'events-update');
+  }
+});
+
+// DELETE /api/events/[id]
+export const DELETE = withAuth(async (_request, session, context) => {
+  try {
+    const { id } = await context.params;
+    const result = await deleteEvent(session.user.id, id);
+    if (!result) return apiResponse.notFound('Event not found');
+    return apiResponse.ok({ success: true });
+  } catch (error) {
+    return handleApiError(error, 'events-delete');
+  }
+});

--- a/app/api/events/route.ts
+++ b/app/api/events/route.ts
@@ -1,0 +1,30 @@
+import { createEventSchema, validateRequest } from '@/lib/validations';
+import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { createEvent, getEvents, InvalidEventPeopleError } from '@/lib/services/event';
+
+// GET /api/events - List all events for the current user
+export const GET = withAuth(async (_request, session) => {
+  try {
+    const events = await getEvents(session.user.id);
+    return apiResponse.ok({ events });
+  } catch (error) {
+    return handleApiError(error, 'events-list');
+  }
+});
+
+// POST /api/events - Create a new event
+export const POST = withAuth(async (request, session) => {
+  try {
+    const body = await parseRequestBody(request);
+    const validation = validateRequest(createEventSchema, body);
+    if (!validation.success) return validation.response;
+
+    const event = await createEvent(session.user.id, validation.data);
+    return apiResponse.created({ event });
+  } catch (error) {
+    if (error instanceof InvalidEventPeopleError) {
+      return apiResponse.error(error.message, 400);
+    }
+    return handleApiError(error, 'events-create');
+  }
+});

--- a/app/events/[id]/edit/page.tsx
+++ b/app/events/[id]/edit/page.tsx
@@ -1,0 +1,84 @@
+import { auth } from '@/lib/auth';
+import { redirect, notFound } from 'next/navigation';
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import Navigation from '@/components/Navigation';
+import EventForm from '@/components/events/EventForm';
+import { getTranslations } from 'next-intl/server';
+
+export default async function EditEventPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const session = await auth();
+  const t = await getTranslations('events');
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const { id } = await params;
+
+  const [user, event, people] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { nameOrder: true },
+    }),
+    prisma.event.findUnique({
+      where: { id },
+      include: {
+        people: {
+          where: { deletedAt: null },
+          select: { id: true, name: true, surname: true, nickname: true, photo: true },
+        },
+      },
+    }),
+    prisma.person.findMany({
+      where: { userId: session.user.id, deletedAt: null },
+      select: { id: true, name: true, surname: true, nickname: true },
+      orderBy: { name: 'asc' },
+    }),
+  ]);
+
+  if (!event || event.userId !== session.user.id) {
+    notFound();
+  }
+
+  const serializedEvent = {
+    ...event,
+    date: event.date.toISOString(),
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation
+        userEmail={session.user.email || undefined}
+        userName={session.user.name}
+        userNickname={session.user.nickname}
+        userPhoto={session.user.photo}
+        currentPath="/events"
+      />
+
+      <main className="max-w-2xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="mb-6">
+            <Link href="/events" className="text-primary hover:underline text-sm">
+              ← {t('backToEvents')}
+            </Link>
+          </div>
+
+          <div className="bg-surface shadow rounded-lg p-6">
+            <h1 className="text-2xl font-bold text-foreground mb-6">{t('editEvent')}</h1>
+            <EventForm
+              mode="edit"
+              event={serializedEvent}
+              availablePeople={people}
+              nameOrder={user?.nameOrder}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/events/new/page.tsx
+++ b/app/events/new/page.tsx
@@ -1,0 +1,59 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import Navigation from '@/components/Navigation';
+import EventForm from '@/components/events/EventForm';
+import { getTranslations } from 'next-intl/server';
+
+export default async function NewEventPage() {
+  const session = await auth();
+  const t = await getTranslations('events');
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const [user, people] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { nameOrder: true },
+    }),
+    prisma.person.findMany({
+      where: { userId: session.user.id, deletedAt: null },
+      select: { id: true, name: true, surname: true, nickname: true },
+      orderBy: { name: 'asc' },
+    }),
+  ]);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation
+        userEmail={session.user.email || undefined}
+        userName={session.user.name}
+        userNickname={session.user.nickname}
+        userPhoto={session.user.photo}
+        currentPath="/events"
+      />
+
+      <main className="max-w-2xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="mb-6">
+            <Link href="/events" className="text-primary hover:underline text-sm">
+              ← {t('backToEvents')}
+            </Link>
+          </div>
+
+          <div className="bg-surface shadow rounded-lg p-6">
+            <h1 className="text-2xl font-bold text-foreground mb-6">{t('newEvent')}</h1>
+            <EventForm
+              mode="create"
+              availablePeople={people}
+              nameOrder={user?.nameOrder}
+            />
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,0 +1,75 @@
+import { auth } from '@/lib/auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import Navigation from '@/components/Navigation';
+import EventList from '@/components/events/EventList';
+import { getTranslations } from 'next-intl/server';
+import type { DateFormat } from '@/lib/date-format';
+
+export default async function EventsPage() {
+  const session = await auth();
+  const t = await getTranslations('events');
+
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const [user, events] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: session.user.id },
+      select: { dateFormat: true, nameOrder: true },
+    }),
+    prisma.event.findMany({
+      where: { userId: session.user.id },
+      include: {
+        people: {
+          where: { deletedAt: null },
+          select: { id: true, name: true, surname: true, nickname: true, photo: true },
+        },
+      },
+      orderBy: { date: 'asc' },
+    }),
+  ]);
+
+  const dateFormat = (user?.dateFormat ?? 'MDY') as DateFormat;
+  const nameOrder = user?.nameOrder;
+
+  // Serialize dates for client components
+  const serializedEvents = events.map((e) => ({
+    ...e,
+    date: e.date.toISOString(),
+  }));
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation
+        userEmail={session.user.email || undefined}
+        userName={session.user.name}
+        userNickname={session.user.nickname}
+        userPhoto={session.user.photo}
+        currentPath="/events"
+      />
+
+      <main className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <div className="flex items-center justify-between mb-6">
+            <h1 className="text-2xl font-bold text-foreground">{t('title')}</h1>
+            <Link
+              href="/events/new"
+              className="px-4 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors shadow-lg hover:shadow-primary/50"
+            >
+              {t('addEvent')}
+            </Link>
+          </div>
+
+          <EventList
+            events={serializedEvents}
+            dateFormat={dateFormat}
+            nameOrder={nameOrder}
+          />
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -3,6 +3,7 @@ import { redirect, notFound } from 'next/navigation';
 import Link from 'next/link';
 import BackLink from '@/components/BackLink';
 import { prisma } from '@/lib/prisma';
+import PersonEventsSection from '@/components/events/PersonEventsSection';
 import UserRelationshipCard from '@/components/UserRelationshipCard';
 import RelationshipManager from '@/components/RelationshipManager';
 import UnifiedNetworkGraph from '@/components/UnifiedNetworkGraph';
@@ -111,7 +112,7 @@ export default async function PersonDetailsPage({
   const dateFormat = user?.dateFormat || 'MDY';
   const nameOrder = user?.nameOrder;
 
-  const [person, allPeople, relationshipTypes, cardDavConnection] = await Promise.all([
+  const [person, allPeople, relationshipTypes, cardDavConnection, personEvents] = await Promise.all([
     prisma.person.findUnique({
       where: {
         id,
@@ -217,6 +218,19 @@ export default async function PersonDetailsPage({
     prisma.cardDavConnection.findUnique({
       where: { userId: session.user.id },
       select: { id: true },
+    }),
+    prisma.event.findMany({
+      where: {
+        userId: session.user.id,
+        people: { some: { id } },
+      },
+      include: {
+        people: {
+          where: { deletedAt: null },
+          select: { id: true, name: true, surname: true, nickname: true, photo: true },
+        },
+      },
+      orderBy: { date: 'asc' },
     }),
   ]);
 
@@ -669,6 +683,13 @@ export default async function PersonDetailsPage({
                   <MarkdownRenderer content={person.notes} />
                 </div>
               )}
+
+              {/* Events Section */}
+              <PersonEventsSection
+                events={personEvents.map((e) => ({ ...e, date: e.date.toISOString() }))}
+                dateFormat={dateFormat as import('@/lib/date-format').DateFormat}
+                nameOrder={nameOrder}
+              />
 
               {/* Relationship Network Section */}
               <div className="border border-border rounded-lg p-4">

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -38,6 +38,7 @@ export default function Navigation({ userEmail, userName, userNickname, userPhot
     { href: '/dashboard', labelKey: 'dashboard' },
     { href: '/people', labelKey: 'people', createHref: '/people/new', createLabelKey: 'people' },
     { href: '/groups', labelKey: 'groups', createHref: '/groups/new', createLabelKey: 'groups' },
+    { href: '/events', labelKey: 'events', createHref: '/events/new', createLabelKey: 'events' },
     { href: '/relationship-types', labelKey: 'relationshipTypes', createHref: '/relationship-types/new', createLabelKey: 'relationshipTypes' },
   ];
 

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { formatDate, type DateFormat } from '@/lib/date-format';
+import { formatFullName } from '@/lib/nameUtils';
+import type { NameOrder } from '@prisma/client';
+
+interface EventPerson {
+  id: string;
+  name: string;
+  surname: string | null;
+  nickname: string | null;
+  photo: string | null;
+}
+
+interface EventCardProps {
+  event: {
+    id: string;
+    title: string;
+    date: string;
+    people: EventPerson[];
+  };
+  dateFormat: DateFormat;
+  nameOrder: NameOrder | undefined;
+  onDelete?: (id: string) => void;
+}
+
+export default function EventCard({ event, dateFormat, nameOrder, onDelete }: EventCardProps) {
+  const t = useTranslations('events');
+  const date = new Date(event.date);
+  const isPast = date < new Date();
+
+  return (
+    <div className={`flex items-start justify-between p-4 rounded-lg border ${isPast ? 'border-border bg-surface-elevated' : 'border-primary/30 bg-primary/5'}`}>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${isPast ? 'bg-surface text-muted' : 'bg-primary/15 text-primary'}`}>
+            {isPast ? t('past') : t('upcoming')}
+          </span>
+          <h3 className="font-semibold text-foreground truncate">{event.title}</h3>
+        </div>
+        <p className="text-sm text-muted mt-1">
+          {formatDate(date, dateFormat)}{' '}
+          {date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+        </p>
+        {event.people.length > 0 && (
+          <div className="flex flex-wrap gap-1 mt-2">
+            {event.people.map((person) => (
+              <Link
+                key={person.id}
+                href={`/people/${person.id}`}
+                className="text-xs bg-surface text-foreground border border-border rounded-full px-2 py-0.5 hover:border-primary/50 transition-colors"
+              >
+                {formatFullName(person, nameOrder)}
+              </Link>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2 ml-4 flex-shrink-0">
+        <Link
+          href={`/events/${event.id}/edit`}
+          className="text-sm text-primary hover:underline"
+        >
+          {t('edit')}
+        </Link>
+        {onDelete && (
+          <button
+            onClick={() => onDelete(event.id)}
+            className="text-sm text-destructive hover:underline"
+          >
+            {t('delete')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { useTranslations } from 'next-intl';
+import PillSelector from '@/components/PillSelector';
+import { Button } from '@/components/ui/Button';
+import { formatFullName } from '@/lib/nameUtils';
+import type { NameOrder } from '@prisma/client';
+
+interface Person {
+  id: string;
+  name: string;
+  surname: string | null;
+  nickname: string | null;
+}
+
+interface EventFormProps {
+  mode: 'create' | 'edit';
+  availablePeople: Person[];
+  nameOrder?: NameOrder;
+  event?: {
+    id: string;
+    title: string;
+    date: string; // ISO string
+    people: Person[];
+  };
+}
+
+function toDatetimeLocal(isoString: string): string {
+  const d = new Date(isoString);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export default function EventForm({ mode, availablePeople, nameOrder, event }: EventFormProps) {
+  const t = useTranslations('events.form');
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const [title, setTitle] = useState(event?.title ?? '');
+  const [datetimeLocal, setDatetimeLocal] = useState(
+    event?.date ? toDatetimeLocal(event.date) : ''
+  );
+  const [selectedPeople, setSelectedPeople] = useState<{ id: string; label: string }[]>(
+    event?.people.map((p) => ({
+      id: p.id,
+      label: formatFullName(p, nameOrder),
+    })) ?? []
+  );
+
+  const pillItems = availablePeople.map((p) => ({
+    id: p.id,
+    label: formatFullName(p, nameOrder),
+  }));
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError('');
+
+    if (!title.trim()) {
+      setError(t('titleRequired'));
+      return;
+    }
+    if (!datetimeLocal) {
+      setError(t('dateRequired'));
+      return;
+    }
+    if (selectedPeople.length === 0) {
+      setError(t('peopleRequired'));
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const isoDate = new Date(datetimeLocal).toISOString();
+      const payload = {
+        title: title.trim(),
+        date: isoDate,
+        personIds: selectedPeople.map((p) => p.id),
+      };
+
+      const url = mode === 'create' ? '/api/events' : `/api/events/${event!.id}`;
+      const method = mode === 'create' ? 'POST' : 'PUT';
+
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || t('saveFailed'));
+      }
+
+      toast.success(mode === 'create' ? t('created') : t('updated'));
+      router.push('/events');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t('saveFailed'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      {error && (
+        <div className="p-3 bg-destructive/10 text-destructive text-sm rounded-lg">{error}</div>
+      )}
+
+      {/* Title */}
+      <div>
+        <label htmlFor="event-title" className="block text-sm font-medium text-foreground mb-1">
+          {t('title')}
+        </label>
+        <input
+          id="event-title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder={t('titlePlaceholder')}
+          className="w-full px-3 py-2 border border-border rounded-lg bg-surface text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary/50"
+          maxLength={200}
+        />
+      </div>
+
+      {/* Date & Time */}
+      <div>
+        <label htmlFor="event-date" className="block text-sm font-medium text-foreground mb-1">
+          {t('dateTime')}
+        </label>
+        <input
+          id="event-date"
+          type="datetime-local"
+          value={datetimeLocal}
+          onChange={(e) => setDatetimeLocal(e.target.value)}
+          className="w-full px-3 py-2 border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary/50"
+        />
+      </div>
+
+      {/* People */}
+      <div>
+        <PillSelector
+          label={t('people')}
+          selectedItems={selectedPeople}
+          availableItems={pillItems}
+          onAdd={(item) => setSelectedPeople((prev) => [...prev, item])}
+          onRemove={(id) => setSelectedPeople((prev) => prev.filter((p) => p.id !== id))}
+          placeholder={t('peoplePlaceholder')}
+          showAllOnFocus
+        />
+      </div>
+
+      <div className="flex gap-3">
+        <Button type="submit" disabled={isLoading}>
+          {isLoading ? t('saving') : mode === 'create' ? t('create') : t('update')}
+        </Button>
+        <button
+          type="button"
+          onClick={() => router.push('/events')}
+          className="px-4 py-2 text-sm border border-border rounded-lg text-foreground hover:bg-surface-elevated transition-colors"
+        >
+          {t('cancel')}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/events/EventList.tsx
+++ b/components/events/EventList.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
+import EventCard from './EventCard';
+import type { DateFormat } from '@/lib/date-format';
+import type { NameOrder } from '@prisma/client';
+
+interface EventPerson {
+  id: string;
+  name: string;
+  surname: string | null;
+  nickname: string | null;
+  photo: string | null;
+}
+
+interface Event {
+  id: string;
+  title: string;
+  date: string;
+  people: EventPerson[];
+}
+
+interface EventListProps {
+  events: Event[];
+  dateFormat: DateFormat;
+  nameOrder: NameOrder | undefined;
+}
+
+export default function EventList({ events, dateFormat, nameOrder }: EventListProps) {
+  const t = useTranslations('events');
+  const router = useRouter();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const now = new Date();
+  const upcoming = events.filter((e) => new Date(e.date) >= now);
+  const past = events.filter((e) => new Date(e.date) < now).reverse();
+
+  async function handleDelete(id: string) {
+    if (!confirm(t('confirmDelete'))) return;
+    setDeletingId(id);
+    try {
+      const res = await fetch(`/api/events/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete');
+      toast.success(t('deleted'));
+      router.refresh();
+    } catch {
+      toast.error(t('deleteFailed'));
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (events.length === 0) {
+    return (
+      <p className="text-muted text-center py-8">{t('noEvents')}</p>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {upcoming.length > 0 && (
+        <div>
+          <h2 className="text-sm font-semibold text-muted uppercase tracking-wide mb-3">
+            {t('upcoming')}
+          </h2>
+          <div className="space-y-3">
+            {upcoming.map((event) => (
+              <EventCard
+                key={event.id}
+                event={event}
+                dateFormat={dateFormat}
+                nameOrder={nameOrder}
+                onDelete={deletingId === null ? handleDelete : undefined}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+      {past.length > 0 && (
+        <div>
+          <h2 className="text-sm font-semibold text-muted uppercase tracking-wide mb-3">
+            {t('past')}
+          </h2>
+          <div className="space-y-3">
+            {past.map((event) => (
+              <EventCard
+                key={event.id}
+                event={event}
+                dateFormat={dateFormat}
+                nameOrder={nameOrder}
+                onDelete={deletingId === null ? handleDelete : undefined}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/events/PersonEventsSection.tsx
+++ b/components/events/PersonEventsSection.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+import { getTranslations } from 'next-intl/server';
+import { formatDate, type DateFormat } from '@/lib/date-format';
+import { formatFullName } from '@/lib/nameUtils';
+import type { NameOrder } from '@prisma/client';
+
+interface EventPerson {
+  id: string;
+  name: string;
+  surname: string | null;
+  nickname: string | null;
+  photo: string | null;
+}
+
+interface Event {
+  id: string;
+  title: string;
+  date: string;
+  people: EventPerson[];
+}
+
+interface PersonEventsSectionProps {
+  events: Event[];
+  dateFormat: DateFormat;
+  nameOrder: NameOrder | undefined;
+}
+
+export default async function PersonEventsSection({
+  events,
+  dateFormat,
+  nameOrder,
+}: PersonEventsSectionProps) {
+  const t = await getTranslations('events');
+
+  const now = new Date();
+  const upcoming = events.filter((e) => new Date(e.date) >= now);
+  const past = events.filter((e) => new Date(e.date) < now).reverse();
+
+  return (
+    <div className="border border-border rounded-lg p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-foreground">{t('title')}</h3>
+        <Link
+          href="/events/new"
+          className="text-sm text-primary hover:underline"
+        >
+          {t('addEvent')}
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <p className="text-muted text-sm">{t('noEventsForPerson')}</p>
+      ) : (
+        <div className="space-y-4">
+          {upcoming.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+                {t('upcoming')}
+              </p>
+              <div className="space-y-2">
+                {upcoming.map((event) => (
+                  <div key={event.id} className="flex items-center justify-between p-3 bg-primary/5 border border-primary/20 rounded-lg">
+                    <div>
+                      <p className="font-medium text-sm text-foreground">{event.title}</p>
+                      <p className="text-xs text-muted">
+                        {formatDate(new Date(event.date), dateFormat)}{' '}
+                        {new Date(event.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </p>
+                    </div>
+                    <Link href={`/events/${event.id}/edit`} className="text-xs text-primary hover:underline">
+                      {t('edit')}
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {past.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted uppercase tracking-wide mb-2">
+                {t('past')}
+              </p>
+              <div className="space-y-2">
+                {past.map((event) => (
+                  <div key={event.id} className="flex items-center justify-between p-3 bg-surface-elevated border border-border rounded-lg">
+                    <div>
+                      <p className="font-medium text-sm text-foreground">{event.title}</p>
+                      <p className="text-xs text-muted">
+                        {formatDate(new Date(event.date), dateFormat)}{' '}
+                        {new Date(event.date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                      </p>
+                    </div>
+                    <Link href={`/events/${event.id}/edit`} className="text-xs text-primary hover:underline">
+                      {t('edit')}
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       sh -c "
         echo '0 8 * * * wget -q -O - --header=\"Authorization: Bearer '\"$$CRON_SECRET\"'\" http://app:3000/api/cron/send-reminders > /proc/1/fd/1 2>&1' > /etc/crontabs/root &&
         echo '0 3 * * * wget -q -O - --header=\"Authorization: Bearer '\"$$CRON_SECRET\"'\" http://app:3000/api/cron/purge-deleted > /proc/1/fd/1 2>&1' >> /etc/crontabs/root &&
+        echo '*/15 * * * * wget -q -O - --header=\"Authorization: Bearer '\"$$CRON_SECRET\"'\" http://app:3000/api/cron/process-past-events > /proc/1/fd/1 2>&1' >> /etc/crontabs/root &&
         echo '0 2,10,18 * * * wget -q -O - --header=\"Authorization: Bearer '\"$$CRON_SECRET\"'\" http://app:3000/api/cron/carddav-sync > /proc/1/fd/1 2>&1' >> /etc/crontabs/root &&
         crond -f -l 2
       "

--- a/lib/services/event.ts
+++ b/lib/services/event.ts
@@ -1,0 +1,125 @@
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+import { createEventSchema, updateEventSchema } from '@/lib/validations';
+
+export type EventInput = z.infer<typeof createEventSchema>;
+export type EventUpdateInput = z.infer<typeof updateEventSchema>;
+
+export class InvalidEventPeopleError extends Error {
+  constructor() {
+    super('One or more selected people are invalid');
+    this.name = 'InvalidEventPeopleError';
+  }
+}
+
+const eventInclude = {
+  people: {
+    where: { deletedAt: null },
+    select: {
+      id: true,
+      name: true,
+      surname: true,
+      nickname: true,
+      photo: true,
+    },
+  },
+} as const;
+
+function getUniquePersonIds(personIds: string[]): string[] {
+  return [...new Set(personIds)];
+}
+
+async function assertOwnedPeople(userId: string, personIds: string[]) {
+  const uniquePersonIds = getUniquePersonIds(personIds);
+  const ownedPeople = await prisma.person.findMany({
+    where: {
+      userId,
+      id: { in: uniquePersonIds },
+      deletedAt: null,
+    },
+    select: { id: true },
+  });
+
+  if (ownedPeople.length !== uniquePersonIds.length) {
+    throw new InvalidEventPeopleError();
+  }
+
+  return uniquePersonIds;
+}
+
+export async function createEvent(userId: string, data: EventInput) {
+  const personIds = await assertOwnedPeople(userId, data.personIds);
+
+  return prisma.event.create({
+    data: {
+      userId,
+      title: data.title,
+      date: new Date(data.date),
+      people: {
+        connect: personIds.map((id) => ({ id })),
+      },
+    },
+    include: eventInclude,
+  });
+}
+
+export async function getEvents(userId: string) {
+  return prisma.event.findMany({
+    where: { userId },
+    include: eventInclude,
+    orderBy: { date: 'asc' },
+  });
+}
+
+export async function getEventsForPerson(userId: string, personId: string) {
+  return prisma.event.findMany({
+    where: {
+      userId,
+      people: { some: { id: personId } },
+    },
+    include: eventInclude,
+    orderBy: { date: 'asc' },
+  });
+}
+
+export async function getEvent(userId: string, id: string) {
+  return prisma.event.findFirst({
+    where: { id, userId },
+    include: eventInclude,
+  });
+}
+
+export async function updateEvent(userId: string, id: string, data: EventUpdateInput) {
+  // Verify ownership
+  const existing = await prisma.event.findFirst({ where: { id, userId } });
+  if (!existing) return null;
+
+  const personIds = data.personIds !== undefined
+    ? await assertOwnedPeople(userId, data.personIds)
+    : undefined;
+
+  const shouldReprocess =
+    data.date !== undefined ||
+    personIds !== undefined;
+
+  return prisma.event.update({
+    where: { id },
+    data: {
+      ...(data.title !== undefined && { title: data.title }),
+      ...(data.date !== undefined && { date: new Date(data.date) }),
+      ...(personIds !== undefined && {
+        people: {
+          set: personIds.map((pid) => ({ id: pid })),
+        },
+      }),
+      ...(shouldReprocess && { lastContactProcessed: false }),
+    },
+    include: eventInclude,
+  });
+}
+
+export async function deleteEvent(userId: string, id: string) {
+  const existing = await prisma.event.findFirst({ where: { id, userId } });
+  if (!existing) return null;
+  return prisma.event.delete({ where: { id } });
+}

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -419,6 +419,20 @@ export const createImportantDateSchema = z.object({
 export const updateImportantDateSchema = createImportantDateSchema;
 
 // ============================================
+// Event schemas
+// ============================================
+
+export const createEventSchema = z.object({
+  title: z.string().min(1, 'Title is required').max(200),
+  date: z.iso.datetime({ error: 'Invalid datetime' }),
+  personIds: z.array(z.string()).min(1, 'At least one person is required'),
+});
+
+export const updateEventSchema = createEventSchema.partial().extend({
+  personIds: z.array(z.string()).optional(),
+});
+
+// ============================================
 // Helper function for API validation
 // ============================================
 

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -47,6 +47,7 @@
     "dashboard": "Dashboard",
     "people": "Personen",
     "groups": "Gruppen",
+    "events": "Ereignisse",
     "relationshipTypes": "Beziehungsarten",
     "settings": "Einstellungen",
     "search": {
@@ -1636,5 +1637,38 @@
     "today": "Heute",
     "yearUnknown": "Jahr unbekannt",
     "yearUnknownTooltip": "Wenn aktiviert, werden nur der Monat und der Tag gespeichert. Das Jahr wird ignoriert."
+  },
+  "events": {
+    "title": "Ereignisse",
+    "addEvent": "Ereignis hinzufügen",
+    "newEvent": "Neues Ereignis",
+    "editEvent": "Ereignis bearbeiten",
+    "backToEvents": "Zurück zu Ereignissen",
+    "upcoming": "Bevorstehend",
+    "past": "Vergangen",
+    "noEvents": "Noch keine Ereignisse. Plane etwas mit deinen Kontakten!",
+    "noEventsForPerson": "Noch keine Ereignisse mit dieser Person geplant.",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "confirmDelete": "Möchtest du dieses Ereignis wirklich löschen?",
+    "deleted": "Ereignis gelöscht",
+    "deleteFailed": "Fehler beim Löschen des Ereignisses",
+    "form": {
+      "title": "Titel",
+      "titlePlaceholder": "z.B. Kaffee mit Freunden",
+      "dateTime": "Datum & Uhrzeit",
+      "people": "Personen",
+      "peoplePlaceholder": "Kontakte suchen...",
+      "titleRequired": "Titel ist erforderlich",
+      "dateRequired": "Datum und Uhrzeit sind erforderlich",
+      "peopleRequired": "Bitte wähle mindestens eine Person aus",
+      "saveFailed": "Fehler beim Speichern des Ereignisses",
+      "saving": "Speichern...",
+      "create": "Ereignis erstellen",
+      "update": "Ereignis aktualisieren",
+      "created": "Ereignis erstellt",
+      "updated": "Ereignis aktualisiert",
+      "cancel": "Abbrechen"
+    }
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -47,6 +47,7 @@
     "dashboard": "Dashboard",
     "people": "People",
     "groups": "Groups",
+    "events": "Events",
     "relationshipTypes": "Relationship Types",
     "settings": "Settings",
     "search": {
@@ -1632,5 +1633,38 @@
     "today": "Today",
     "yearUnknown": "Year unknown",
     "yearUnknownTooltip": "When checked, only the month and day will be saved. The year will be ignored."
+  },
+  "events": {
+    "title": "Events",
+    "addEvent": "Add Event",
+    "newEvent": "New Event",
+    "editEvent": "Edit Event",
+    "backToEvents": "Back to Events",
+    "upcoming": "Upcoming",
+    "past": "Past",
+    "noEvents": "No events yet. Plan something with your contacts!",
+    "noEventsForPerson": "No events planned with this person yet.",
+    "edit": "Edit",
+    "delete": "Delete",
+    "confirmDelete": "Are you sure you want to delete this event?",
+    "deleted": "Event deleted",
+    "deleteFailed": "Failed to delete event",
+    "form": {
+      "title": "Title",
+      "titlePlaceholder": "e.g. Coffee with friends",
+      "dateTime": "Date & Time",
+      "people": "People",
+      "peoplePlaceholder": "Search contacts...",
+      "titleRequired": "Title is required",
+      "dateRequired": "Date and time are required",
+      "peopleRequired": "Please select at least one person",
+      "saveFailed": "Failed to save event",
+      "saving": "Saving...",
+      "create": "Create Event",
+      "update": "Update Event",
+      "created": "Event created",
+      "updated": "Event updated",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -47,6 +47,7 @@
     "dashboard": "Inicio",
     "people": "Personas",
     "groups": "Grupos",
+    "events": "Eventos",
     "relationshipTypes": "Tipos de Relación",
     "settings": "Configuración",
     "search": {
@@ -1636,5 +1637,38 @@
     "today": "Hoy",
     "yearUnknown": "Año desconocido",
     "yearUnknownTooltip": "Cuando está marcado, solo se guardarán el mes y el día. El año será ignorado."
+  },
+  "events": {
+    "title": "Eventos",
+    "addEvent": "Agregar Evento",
+    "newEvent": "Nuevo Evento",
+    "editEvent": "Editar Evento",
+    "backToEvents": "Volver a Eventos",
+    "upcoming": "Próximos",
+    "past": "Pasados",
+    "noEvents": "Aún no hay eventos. ¡Planifica algo con tus contactos!",
+    "noEventsForPerson": "Aún no hay eventos planificados con esta persona.",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "confirmDelete": "¿Estás seguro de que quieres eliminar este evento?",
+    "deleted": "Evento eliminado",
+    "deleteFailed": "Error al eliminar el evento",
+    "form": {
+      "title": "Título",
+      "titlePlaceholder": "ej. Café con amigos",
+      "dateTime": "Fecha y Hora",
+      "people": "Personas",
+      "peoplePlaceholder": "Buscar contactos...",
+      "titleRequired": "El título es obligatorio",
+      "dateRequired": "La fecha y hora son obligatorias",
+      "peopleRequired": "Por favor selecciona al menos una persona",
+      "saveFailed": "Error al guardar el evento",
+      "saving": "Guardando...",
+      "create": "Crear Evento",
+      "update": "Actualizar Evento",
+      "created": "Evento creado",
+      "updated": "Evento actualizado",
+      "cancel": "Cancelar"
+    }
   }
 }

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -47,6 +47,7 @@
     "dashboard": "ダッシュボード",
     "people": "人",
     "groups": "グループ",
+    "events": "イベント",
     "relationshipTypes": "関係の種類",
     "settings": "設定",
     "search": {
@@ -1636,5 +1637,38 @@
     "today": "今日",
     "yearUnknown": "年不明",
     "yearUnknownTooltip": "チェックすると、月と日のみが保存されます。年は無視されます。"
+  },
+  "events": {
+    "title": "イベント",
+    "addEvent": "イベントを追加",
+    "newEvent": "新しいイベント",
+    "editEvent": "イベントを編集",
+    "backToEvents": "イベントに戻る",
+    "upcoming": "予定",
+    "past": "過去",
+    "noEvents": "まだイベントはありません。連絡先と何か計画しましょう！",
+    "noEventsForPerson": "この人との予定はまだありません。",
+    "edit": "編集",
+    "delete": "削除",
+    "confirmDelete": "このイベントを削除してもよろしいですか？",
+    "deleted": "イベントを削除しました",
+    "deleteFailed": "イベントの削除に失敗しました",
+    "form": {
+      "title": "タイトル",
+      "titlePlaceholder": "例：友達とコーヒー",
+      "dateTime": "日時",
+      "people": "人",
+      "peoplePlaceholder": "連絡先を検索...",
+      "titleRequired": "タイトルは必須です",
+      "dateRequired": "日時は必須です",
+      "peopleRequired": "少なくとも1人を選択してください",
+      "saveFailed": "イベントの保存に失敗しました",
+      "saving": "保存中...",
+      "create": "イベントを作成",
+      "update": "イベントを更新",
+      "created": "イベントを作成しました",
+      "updated": "イベントを更新しました",
+      "cancel": "キャンセル"
+    }
   }
 }

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -47,6 +47,7 @@
     "dashboard": "Dashbord",
     "people": "Personer",
     "groups": "Grupper",
+    "events": "Hendelser",
     "relationshipTypes": "Relasjonstyper",
     "settings": "Innstillinger",
     "search": {
@@ -1636,5 +1637,38 @@
     "today": "I dag",
     "yearUnknown": "År ukjent",
     "yearUnknownTooltip": "Når dette er avkrysset, lagres kun måneden og dagen. Året ignoreres."
+  },
+  "events": {
+    "title": "Hendelser",
+    "addEvent": "Legg til hendelse",
+    "newEvent": "Ny hendelse",
+    "editEvent": "Rediger hendelse",
+    "backToEvents": "Tilbake til hendelser",
+    "upcoming": "Kommende",
+    "past": "Tidligere",
+    "noEvents": "Ingen hendelser ennå. Planlegg noe med kontaktene dine!",
+    "noEventsForPerson": "Ingen planlagte hendelser med denne personen ennå.",
+    "edit": "Rediger",
+    "delete": "Slett",
+    "confirmDelete": "Er du sikker på at du vil slette denne hendelsen?",
+    "deleted": "Hendelse slettet",
+    "deleteFailed": "Kunne ikke slette hendelsen",
+    "form": {
+      "title": "Tittel",
+      "titlePlaceholder": "f.eks. Kaffe med venner",
+      "dateTime": "Dato og tid",
+      "people": "Personer",
+      "peoplePlaceholder": "Søk etter kontakter...",
+      "titleRequired": "Tittel er påkrevd",
+      "dateRequired": "Dato og tid er påkrevd",
+      "peopleRequired": "Velg minst én person",
+      "saveFailed": "Kunne ikke lagre hendelsen",
+      "saving": "Lagrer...",
+      "create": "Opprett hendelse",
+      "update": "Oppdater hendelse",
+      "created": "Hendelse opprettet",
+      "updated": "Hendelse oppdatert",
+      "cancel": "Avbryt"
+    }
   }
 }

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -47,6 +47,7 @@
     "dashboard": "仪表盘",
     "people": "联系人",
     "groups": "分组",
+    "events": "活动",
     "relationshipTypes": "关系类型",
     "settings": "设置",
     "search": {
@@ -1636,5 +1637,38 @@
     "today": "今天",
     "yearUnknown": "年份未知",
     "yearUnknownTooltip": "选中时，仅保存月份和日期。年份将被忽略。"
+  },
+  "events": {
+    "title": "活动",
+    "addEvent": "添加活动",
+    "newEvent": "新建活动",
+    "editEvent": "编辑活动",
+    "backToEvents": "返回活动",
+    "upcoming": "即将到来",
+    "past": "过去",
+    "noEvents": "还没有活动。和您的联系人计划一些事情吧！",
+    "noEventsForPerson": "还没有与此人计划的活动。",
+    "edit": "编辑",
+    "delete": "删除",
+    "confirmDelete": "确定要删除此活动吗？",
+    "deleted": "活动已删除",
+    "deleteFailed": "删除活动失败",
+    "form": {
+      "title": "标题",
+      "titlePlaceholder": "例：和朋友喝咖啡",
+      "dateTime": "日期和时间",
+      "people": "人员",
+      "peoplePlaceholder": "搜索联系人...",
+      "titleRequired": "标题为必填项",
+      "dateRequired": "日期和时间为必填项",
+      "peopleRequired": "请至少选择一个人",
+      "saveFailed": "保存活动失败",
+      "saving": "保存中...",
+      "create": "创建活动",
+      "update": "更新活动",
+      "created": "活动已创建",
+      "updated": "活动已更新",
+      "cancel": "取消"
+    }
   }
 }

--- a/prisma/migrations/20260321120000_add_events/migration.sql
+++ b/prisma/migrations/20260321120000_add_events/migration.sql
@@ -1,0 +1,35 @@
+-- CreateTable: events
+CREATE TABLE "events" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "lastContactProcessed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable: implicit many-to-many join between Event and Person
+CREATE TABLE "_EventPeople" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_EventPeople_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "events_userId_date_idx" ON "events"("userId", "date");
+
+-- CreateIndex
+CREATE INDEX "_EventPeople_B_index" ON "_EventPeople"("B");
+
+-- AddForeignKey
+ALTER TABLE "events" ADD CONSTRAINT "events_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_EventPeople" ADD CONSTRAINT "_EventPeople_A_fkey" FOREIGN KEY ("A") REFERENCES "events"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_EventPeople" ADD CONSTRAINT "_EventPeople_B_fkey" FOREIGN KEY ("B") REFERENCES "people"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,7 @@ model User {
   cardDavConnection      CardDavConnection?
   cardDavPendingImports  CardDavPendingImport[]
   duplicateDismissals    DuplicateDismissal[]
+  events            Event[]
 
   @@unique([provider, providerAccountId])
   @@map("users")
@@ -109,6 +110,7 @@ model Person {
   cardDavMapping     CardDavMapping?
   dismissalsAsA      DuplicateDismissal[]   @relation("DismissalPersonA")
   dismissalsAsB      DuplicateDismissal[]   @relation("DismissalPersonB")
+  events             Event[]                @relation("EventPeople")
 
   @@index([userId])
   @@index([relationshipToUserId])
@@ -122,6 +124,24 @@ model Person {
   @@index([userId, deletedAt]) // For soft delete filtering
   @@unique([userId, uid])
   @@map("people")
+}
+
+// Event Model - Planned events with linked contacts
+model Event {
+  id                   String   @id @default(cuid())
+  userId               String
+  title                String
+  date                 DateTime
+  lastContactProcessed Boolean  @default(false)
+  createdAt            DateTime @default(now())
+  updatedAt            DateTime @updatedAt
+
+  // Relations
+  user   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  people Person[] @relation("EventPeople")
+
+  @@index([userId, date])
+  @@map("events")
 }
 
 // Group Model - User-defined categories for organizing people

--- a/tests/api/process-past-events.test.ts
+++ b/tests/api/process-past-events.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  cronJobLogCreate: vi.fn(),
+  cronJobLogUpdate: vi.fn(),
+  eventFindMany: vi.fn(),
+  eventUpdate: vi.fn(),
+  personUpdateMany: vi.fn(),
+  transaction: vi.fn(),
+  authFailure: vi.fn(),
+}));
+
+const mockEnv = vi.hoisted(() => ({
+  CRON_SECRET: 'test-cron-secret-16-chars',
+}));
+
+vi.mock('../../lib/prisma', () => ({
+  prisma: {
+    cronJobLog: {
+      create: mocks.cronJobLogCreate,
+      update: mocks.cronJobLogUpdate,
+    },
+    event: {
+      findMany: mocks.eventFindMany,
+      update: mocks.eventUpdate,
+    },
+    person: {
+      updateMany: mocks.personUpdateMany,
+    },
+    $transaction: mocks.transaction,
+  },
+}));
+
+vi.mock('../../lib/env', () => ({
+  env: mockEnv,
+}));
+
+vi.mock('../../lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+  createModuleLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+  securityLogger: {
+    authFailure: mocks.authFailure,
+  },
+}));
+
+vi.mock('../../lib/api-utils', () => ({
+  withLogging: (fn: (...args: unknown[]) => unknown) => fn,
+  getClientIp: () => '127.0.0.1',
+  handleApiError: (error: unknown) =>
+    new Response(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    }),
+}));
+
+import { GET } from '../../app/api/cron/process-past-events/route';
+
+describe('GET /api/cron/process-past-events', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.cronJobLogCreate.mockResolvedValue({ id: 'cron-1' });
+    mocks.cronJobLogUpdate.mockResolvedValue({ id: 'cron-1' });
+    mocks.transaction.mockImplementation(async (operations: unknown[]) => Promise.all(operations));
+    mocks.personUpdateMany.mockResolvedValue({ count: 1 });
+    mocks.eventUpdate.mockResolvedValue({ id: 'event-1' });
+  });
+
+  it('returns 401 when the cron secret is invalid', async () => {
+    const request = new Request('http://localhost/api/cron/process-past-events', {
+      headers: { authorization: 'Bearer invalid-secret' },
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(mocks.authFailure).toHaveBeenCalled();
+    expect(mocks.cronJobLogCreate).not.toHaveBeenCalled();
+  });
+
+  it('updates lastContact only within the owning user scope and marks events processed', async () => {
+    const eventDate = new Date('2026-03-20T10:00:00.000Z');
+    mocks.eventFindMany.mockResolvedValue([
+      {
+        id: 'event-1',
+        userId: 'user-1',
+        date: eventDate,
+        people: [{ id: 'person-1' }],
+      },
+    ]);
+
+    const request = new Request('http://localhost/api/cron/process-past-events', {
+      headers: { authorization: `Bearer ${mockEnv.CRON_SECRET}` },
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ success: true, processed: 1 });
+    expect(mocks.personUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: 'person-1',
+        userId: 'user-1',
+        OR: [
+          { lastContact: null },
+          { lastContact: { lt: eventDate } },
+        ],
+      },
+      data: { lastContact: eventDate },
+    });
+    expect(mocks.eventUpdate).toHaveBeenCalledWith({
+      where: { id: 'event-1' },
+      data: { lastContactProcessed: true },
+    });
+  });
+
+  it('marks empty events as processed without updating people', async () => {
+    mocks.eventFindMany.mockResolvedValue([
+      {
+        id: 'event-1',
+        userId: 'user-1',
+        date: new Date('2026-03-20T10:00:00.000Z'),
+        people: [],
+      },
+    ]);
+
+    const request = new Request('http://localhost/api/cron/process-past-events', {
+      headers: { authorization: `Bearer ${mockEnv.CRON_SECRET}` },
+    });
+
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(mocks.personUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.eventUpdate).toHaveBeenCalledWith({
+      where: { id: 'event-1' },
+      data: { lastContactProcessed: true },
+    });
+  });
+});

--- a/tests/lib/services/event.test.ts
+++ b/tests/lib/services/event.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  personFindMany: vi.fn(),
+  eventCreate: vi.fn(),
+  eventFindMany: vi.fn(),
+  eventFindFirst: vi.fn(),
+  eventUpdate: vi.fn(),
+  eventDelete: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    person: {
+      findMany: mocks.personFindMany,
+    },
+    event: {
+      create: mocks.eventCreate,
+      findMany: mocks.eventFindMany,
+      findFirst: mocks.eventFindFirst,
+      update: mocks.eventUpdate,
+      delete: mocks.eventDelete,
+    },
+  },
+}));
+
+import {
+  createEvent,
+  deleteEvent,
+  getEvent,
+  InvalidEventPeopleError,
+  updateEvent,
+} from '@/lib/services/event';
+
+describe('event service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('rejects creating an event with people outside the user scope', async () => {
+    mocks.personFindMany.mockResolvedValue([{ id: 'person-1' }]);
+
+    await expect(
+      createEvent('user-1', {
+        title: 'Dinner',
+        date: '2026-03-22T10:00:00.000Z',
+        personIds: ['person-1', 'person-2'],
+      })
+    ).rejects.toBeInstanceOf(InvalidEventPeopleError);
+
+    expect(mocks.eventCreate).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates person ids before creating an event', async () => {
+    mocks.personFindMany.mockResolvedValue([{ id: 'person-1' }, { id: 'person-2' }]);
+    mocks.eventCreate.mockResolvedValue({ id: 'event-1' });
+
+    await createEvent('user-1', {
+      title: 'Dinner',
+      date: '2026-03-22T10:00:00.000Z',
+      personIds: ['person-1', 'person-1', 'person-2'],
+    });
+
+    expect(mocks.personFindMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        id: { in: ['person-1', 'person-2'] },
+        deletedAt: null,
+      },
+      select: { id: true },
+    });
+    expect(mocks.eventCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          people: {
+            connect: [{ id: 'person-1' }, { id: 'person-2' }],
+          },
+        }),
+      })
+    );
+  });
+
+  it('uses scoped lookup when fetching a single event', async () => {
+    mocks.eventFindFirst.mockResolvedValue({ id: 'event-1' });
+
+    await getEvent('user-1', 'event-1');
+
+    expect(mocks.eventFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'event-1', userId: 'user-1' },
+      })
+    );
+  });
+
+  it('resets processing state when date or people change', async () => {
+    mocks.eventFindFirst.mockResolvedValue({ id: 'event-1', userId: 'user-1' });
+    mocks.personFindMany.mockResolvedValue([{ id: 'person-1' }]);
+    mocks.eventUpdate.mockResolvedValue({ id: 'event-1' });
+
+    await updateEvent('user-1', 'event-1', {
+      date: '2026-03-25T10:00:00.000Z',
+      personIds: ['person-1'],
+    });
+
+    expect(mocks.eventUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'event-1' },
+        data: expect.objectContaining({
+          date: new Date('2026-03-25T10:00:00.000Z'),
+          lastContactProcessed: false,
+          people: {
+            set: [{ id: 'person-1' }],
+          },
+        }),
+      })
+    );
+  });
+
+  it('uses scoped lookup before deleting an event', async () => {
+    mocks.eventFindFirst.mockResolvedValue({ id: 'event-1', userId: 'user-1' });
+    mocks.eventDelete.mockResolvedValue({ id: 'event-1' });
+
+    await deleteEvent('user-1', 'event-1');
+
+    expect(mocks.eventFindFirst).toHaveBeenCalledWith({ where: { id: 'event-1', userId: 'user-1' } });
+    expect(mocks.eventDelete).toHaveBeenCalledWith({ where: { id: 'event-1' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add event planning pages, API routes, and schema changes
- link events to people and show them in the person details view
- process past events to update last contact automatically
- add ownership checks and tests for event processing

## Testing
- npx vitest run tests/lib/services/event.test.ts tests/api/process-past-events.test.ts
- manual local test of event creation and cron processing
- npm run verify currently fails on existing vCard date tests unrelated to this change