### PR TITLE
fix: resolve CSRF origin rejection and legacy date validation on self-hosted setups

### DIFF
--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -3,8 +3,39 @@ import { getAppUrl } from '@/lib/env';
 const SAFE_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
 
 /**
+ * Builds the set of origins that are considered valid for CSRF checks.
+ * Includes the configured app URL and the request's own Host header,
+ * so self-hosted users who access the app via a hostname/port that
+ * differs from NEXTAUTH_URL are not blocked on state-changing requests.
+ */
+function getAllowedOrigins(request: Request): Set<string> {
+  const allowed = new Set<string>();
+
+  // Always trust the configured app URL
+  const appUrl = getAppUrl();
+  allowed.add(new URL(appUrl).origin);
+
+  // Also trust the Host header the request was sent to.
+  // Browsers enforce that Origin and Host match for same-origin requests,
+  // so accepting Host covers cases where the user accesses the app via a
+  // different hostname/port than what NEXTAUTH_URL is set to (common in
+  // Docker and LAN setups).
+  const host = request.headers.get('host');
+  if (host) {
+    // Host header doesn't include a scheme; infer from the request URL
+    // or from the X-Forwarded-Proto header (set by reverse proxies).
+    const proto =
+      request.headers.get('x-forwarded-proto') ||
+      (new URL(request.url).protocol === 'https:' ? 'https' : 'http');
+    allowed.add(`${proto}://${host}`);
+  }
+
+  return allowed;
+}
+
+/**
  * Validates that the request originates from the same origin as the application.
- * Checks the Origin and Referer headers against the configured app URL to prevent
+ * Checks the Origin and Referer headers against allowed origins to prevent
  * cross-site request forgery on state-changing (non-GET/HEAD/OPTIONS) requests.
  */
 export function validateOrigin(request: Request): boolean {
@@ -25,15 +56,14 @@ export function validateOrigin(request: Request): boolean {
     return true;
   }
 
-  const appUrl = getAppUrl();
-  const expectedOrigin = new URL(appUrl).origin;
+  const allowed = getAllowedOrigins(request);
 
   if (origin) {
-    return origin === expectedOrigin;
+    return allowed.has(origin);
   }
 
   try {
-    return new URL(referer!).origin === expectedOrigin;
+    return allowed.has(new URL(referer!).origin);
   } catch {
     return false;
   }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -72,7 +72,12 @@ const importantDateSchema = z.object({
   reminderInterval: z.number().int().min(1).max(99).nullable().optional(),
   reminderIntervalUnit: reminderIntervalUnitSchema.nullable().optional(),
 }).refine(
-  (data) => data.type != null || (data.title && data.title.trim().length > 0),
+  (data) =>
+    // Existing dates (with id) are allowed through — they may predate the
+    // predefined-type migration and legitimately have neither type nor title.
+    data.id != null ||
+    data.type != null ||
+    (data.title && data.title.trim().length > 0),
   { message: 'Title is required when no predefined type is selected', path: ['title'] }
 );
 

--- a/tests/lib/csrf.test.ts
+++ b/tests/lib/csrf.test.ts
@@ -93,4 +93,50 @@ describe('CSRF Origin Validation', () => {
     });
     expect(validateOrigin(request)).toBe(true);
   });
+
+  it('should allow origin matching the Host header even if NEXTAUTH_URL differs', () => {
+    // User accesses via http://hades:3003 but NEXTAUTH_URL is https://nametag.one
+    const request = new Request('http://hades:3003/api/people', {
+      method: 'PUT',
+      headers: {
+        origin: 'http://hades:3003',
+        host: 'hades:3003',
+      },
+    });
+    expect(validateOrigin(request)).toBe(true);
+  });
+
+  it('should allow referer matching the Host header even if NEXTAUTH_URL differs', () => {
+    const request = new Request('http://hades:3003/api/people', {
+      method: 'PUT',
+      headers: {
+        referer: 'http://hades:3003/people/123/edit',
+        host: 'hades:3003',
+      },
+    });
+    expect(validateOrigin(request)).toBe(true);
+  });
+
+  it('should reject origin that matches neither NEXTAUTH_URL nor Host', () => {
+    const request = new Request('http://hades:3003/api/people', {
+      method: 'POST',
+      headers: {
+        origin: 'https://evil.com',
+        host: 'hades:3003',
+      },
+    });
+    expect(validateOrigin(request)).toBe(false);
+  });
+
+  it('should respect x-forwarded-proto when building Host origin', () => {
+    const request = new Request('http://hades:3003/api/people', {
+      method: 'PUT',
+      headers: {
+        origin: 'https://hades:3003',
+        host: 'hades:3003',
+        'x-forwarded-proto': 'https',
+      },
+    });
+    expect(validateOrigin(request)).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- **CSRF origin validation** now also accepts the request's `Host` header as a valid origin, so self-hosted users accessing the app via a hostname/port that differs from `NEXTAUTH_URL` are no longer blocked on state-changing requests (PUT/POST/DELETE). This is the same approach used by Django and Rails — browsers enforce that Origin and Host match for same-origin requests.
- **Important date validation** now allows existing dates (with an `id`) to bypass the type-or-title requirement, fixing edit failures for contacts with dates created before the predefined-type migration.

Closes #180

## Test plan

- [x] CSRF: Added tests for Host-header matching, cross-origin rejection, and `X-Forwarded-Proto` support
- [x] Validation: Verified legacy dates (with id, no type/title) pass; new dates without type or title still fail
- [x] All existing tests pass (133 validation/API tests, 14 CSRF tests)
- [ ] Manual: edit a person on a self-hosted instance where access URL differs from NEXTAUTH_URL