### PR TITLE
fix: relink existing CardDAV mappings during import

### DIFF
--- a/app/api/carddav/import/route.ts
+++ b/app/api/carddav/import/route.ts
@@ -240,12 +240,25 @@ export const POST = withLogging(async function POST(request: Request) {
           const existingPerson = existingPersonsByUid.get(parsedData.uid);
 
           if (existingPerson) {
-            // Person already exists — create a CardDAV mapping (if applicable) and clean up
+            // Person already exists — relink their mapping to this connection
+            // instead of inserting a second row for the same person.
             const isFileImport = pendingImport.uploadedByUserId !== null;
             if (!isFileImport && connection) {
               const enhancedParsed = parseVCard(pendingImport.vCardData);
-              await prisma.cardDavMapping.create({
-                data: {
+              await prisma.cardDavMapping.upsert({
+                where: { personId: existingPerson.id },
+                update: {
+                  connectionId: connection.id,
+                  uid: parsedData.uid,
+                  href: pendingImport.href,
+                  etag: pendingImport.etag,
+                  syncStatus: 'synced',
+                  lastSyncedAt: new Date(),
+                  preservedProperties: enhancedParsed.unknownProperties.length > 0
+                    ? enhancedParsed.unknownProperties
+                    : undefined,
+                },
+                create: {
                   connectionId: connection.id,
                   personId: existingPerson.id,
                   uid: parsedData.uid,

--- a/tests/app/api/carddav/import-duplicate-uid.test.ts
+++ b/tests/app/api/carddav/import-duplicate-uid.test.ts
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   findManyPerson: vi.fn(),
   deletePending: vi.fn(),
   createMapping: vi.fn(),
+  upsertMapping: vi.fn(),
   findManyGroup: vi.fn(),
   findManyPersonGroup: vi.fn(),
   createManyPersonGroup: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock('@/lib/prisma', () => ({
     cardDavMapping: {
       findMany: mocks.findManyMapping,
       create: mocks.createMapping,
+      upsert: mocks.upsertMapping,
     },
     person: { findMany: mocks.findManyPerson },
     group: { findMany: mocks.findManyGroup },
@@ -234,6 +236,63 @@ describe('POST /api/carddav/import — duplicate UID handling', () => {
         personId: 'person-eve',
         uid: 'carddav-uid',
       }),
+    });
+  });
+
+  it('should relink an existing person to the current CardDAV connection instead of creating a duplicate mapping', async () => {
+    const pending = [
+      {
+        id: 'p-reconnect',
+        connectionId: 'conn-2',
+        uploadedByUserId: null,
+        uid: 'existing-uid',
+        href: '/addressbooks/reconnected.vcf',
+        etag: '"etag-2"',
+        vCardData: makeVCard('existing-uid', 'Grace'),
+        displayName: 'Grace',
+        discoveredAt: new Date(),
+        notifiedAt: null,
+      },
+    ];
+
+    mocks.findManyPending.mockResolvedValue(pending);
+    mocks.findUniqueConnection.mockResolvedValue({ id: 'conn-2' });
+    mocks.findManyPerson.mockResolvedValue([
+      { id: 'person-existing', uid: 'existing-uid' },
+    ]);
+    mocks.upsertMapping.mockResolvedValue({
+      id: 'mapping-1',
+      personId: 'person-existing',
+      connectionId: 'conn-2',
+      uid: 'existing-uid',
+    });
+
+    const res = await postImport(['p-reconnect']);
+    const data = await res.json();
+
+    expect(data.imported).toBe(0);
+    expect(data.skipped).toBe(1);
+    expect(mocks.createMapping).not.toHaveBeenCalled();
+    expect(mocks.upsertMapping).toHaveBeenCalledWith({
+      where: { personId: 'person-existing' },
+      update: expect.objectContaining({
+        connectionId: 'conn-2',
+        uid: 'existing-uid',
+        href: '/addressbooks/reconnected.vcf',
+        etag: '"etag-2"',
+        syncStatus: 'synced',
+      }),
+      create: expect.objectContaining({
+        connectionId: 'conn-2',
+        personId: 'person-existing',
+        uid: 'existing-uid',
+        href: '/addressbooks/reconnected.vcf',
+        etag: '"etag-2"',
+        syncStatus: 'synced',
+      }),
+    });
+    expect(mocks.deletePending).toHaveBeenCalledWith({
+      where: { id: 'p-reconnect' },
     });
   });
 


### PR DESCRIPTION
## Summary

This fixes CardDAV import reconnection for contacts that already exist locally.

When a pending CardDAV import matched an existing active person by UID, the import route tried to create a new `CardDavMapping` row. Because `CardDavMapping.personId` is unique, reconnecting an existing person to a different CardDAV connection could fail with `P2002` on `personId`.

This PR updates that path to upsert by `personId`, so the existing mapping is relinked to the current connection instead of inserting a duplicate row. It also adds a regression test covering the reported failure mode.

## Checklist

- [x] I've run tests locally (or explain why not)
- [ ] I've updated documentation where needed
- [x] I've added/updated tests for the change (if applicable)
- [x] I've considered backwards compatibility / migrations (if applicable)
- [x] **I've added/updated translations in ALL locale files** (`/locales/en.json` and `/locales/es-ES.json`) for any new or modified user-facing strings

Tests run:
- `npm run test:run -- tests/app/api/carddav/import-duplicate-uid.test.ts`
- `npm run test:run -- tests/app/api/carddav/import-relationship.test.ts tests/api/carddav-import-limits.test.ts`
- `npm run typecheck`

## Screenshots (if UI changes)

N/A

## Related issues

Closes #197
