### PR TITLE
fix: prevent UniqueConstraintViolation on personId during CardDAV import

### DIFF
--- a/app/api/carddav/import/route.ts
+++ b/app/api/carddav/import/route.ts
@@ -122,6 +122,19 @@ export const POST = withLogging(async function POST(request: Request) {
       existingActivePersons.map((p) => [p.uid, p])
     );
 
+    // Pre-fetch existing mappings by personId to detect persons that already have
+    // a mapping under a different UID (e.g. auto-export with server UID rewrite).
+    // The personId column is globally unique, so we must check this before creating.
+    const existingPersonIds = existingActivePersons.map((p) => p.id);
+    const mappingsByPersonId = new Set(
+      existingPersonIds.length > 0
+        ? (await prisma.cardDavMapping.findMany({
+            where: { personId: { in: existingPersonIds } },
+            select: { personId: true },
+          })).map((m) => m.personId)
+        : []
+    );
+
     // Use withDeleted() to bypass soft-delete filtering and find soft-deleted records
     const rawClient = withDeleted();
     let softDeletedPersons: Awaited<ReturnType<typeof rawClient.person.findMany>> = [];
@@ -242,7 +255,7 @@ export const POST = withLogging(async function POST(request: Request) {
           if (existingPerson) {
             // Person already exists — create a CardDAV mapping (if applicable) and clean up
             const isFileImport = pendingImport.uploadedByUserId !== null;
-            if (!isFileImport && connection) {
+            if (!isFileImport && connection && !mappingsByPersonId.has(existingPerson.id)) {
               const enhancedParsed = parseVCard(pendingImport.vCardData);
               await prisma.cardDavMapping.create({
                 data: {
@@ -258,6 +271,7 @@ export const POST = withLogging(async function POST(request: Request) {
                     : undefined,
                 },
               });
+              mappingsByPersonId.add(existingPerson.id);
             }
 
             await prisma.cardDavPendingImport.delete({
@@ -295,8 +309,9 @@ export const POST = withLogging(async function POST(request: Request) {
         }
 
         // Create CardDAV mapping only for CardDAV imports (not file imports)
+        // Skip if person already has a mapping (e.g. restored person with stale mapping)
         const isFileImport = pendingImport.uploadedByUserId !== null;
-        if (!isFileImport && connection) {
+        if (!isFileImport && connection && !mappingsByPersonId.has(person.id)) {
           const enhancedParsed = parseVCard(pendingImport.vCardData);
           await prisma.cardDavMapping.create({
             data: {
@@ -312,6 +327,7 @@ export const POST = withLogging(async function POST(request: Request) {
                 : undefined,
             },
           });
+          mappingsByPersonId.add(person.id);
         }
 
         // Assign to groups - merge global groups + per-contact groups

--- a/tests/app/api/carddav/import-duplicate-uid.test.ts
+++ b/tests/app/api/carddav/import-duplicate-uid.test.ts
@@ -302,6 +302,54 @@ describe('POST /api/carddav/import — duplicate UID handling', () => {
     });
   });
 
+  it('should skip mapping creation when person already has a mapping under a different UID (issue #197)', async () => {
+    // Scenario: Person "Gerda" has a mapping from auto-export (uid="auto-uid"),
+    // but a Baikal contact with a matching person UID "baikal-uid" is being imported.
+    // The existing mapping check by UID misses it, but the personId check catches it.
+    const cardDavPending = {
+      id: 'p-gerda',
+      connectionId: 'conn-1',
+      uploadedByUserId: null, // CardDAV import
+      uid: 'baikal-uid',
+      href: '/addressbooks/gerda.vcf',
+      etag: '"etag-1"',
+      vCardData: makeVCard('baikal-uid', 'Gerda'),
+      displayName: 'Gerda',
+      discoveredAt: new Date(),
+      notifiedAt: null,
+    };
+
+    mocks.findManyPending.mockResolvedValue([cardDavPending]);
+
+    // User has a CardDAV connection
+    mocks.findUniqueConnection.mockResolvedValue({ id: 'conn-1' });
+
+    // Person exists with uid matching the import
+    mocks.findManyPerson.mockResolvedValue([
+      { id: 'person-gerda', uid: 'baikal-uid' },
+    ]);
+
+    // The person already has a mapping under a DIFFERENT UID (from auto-export)
+    // First call: mapping by UID for connection → no match (different UID)
+    // Second call: mapping by personId → match found!
+    mocks.findManyMapping
+      .mockResolvedValueOnce([]) // no mapping with uid="baikal-uid"
+      .mockResolvedValueOnce([{ personId: 'person-gerda' }]); // person already mapped
+
+    const res = await postImport(['p-gerda']);
+    const data = await res.json();
+
+    // Should skip (not crash with UniqueConstraintViolation)
+    expect(data.skipped).toBe(1);
+    expect(data.errors).toBe(0);
+    // Should NOT attempt to create a mapping
+    expect(mocks.createMapping).not.toHaveBeenCalled();
+    // Pending import should be cleaned up
+    expect(mocks.deletePending).toHaveBeenCalledWith({
+      where: { id: 'p-gerda' },
+    });
+  });
+
   it('should return 404 when no pending imports match', async () => {
     mocks.findManyPending.mockResolvedValue([]);
 


### PR DESCRIPTION
## Summary

- Fixes #197 — CardDAV import crashed with `UniqueConstraintViolation` on `personId` when importing contacts whose matching person already had a mapping under a different UID (e.g. from auto-export when the server rewrites the vCard UID)
- Adds a pre-fetch of existing mappings by `personId` (O(1) Set lookup) so both the reconnection path and the new/restore path skip mapping creation when one already exists
- Adds regression test covering the exact reported scenario

## Test plan

- [x] All 30 existing CardDAV tests pass
- [x] New test: "should skip mapping creation when person already has a mapping under a different UID (issue #197)"
- [ ] Manual test with a Baikal/CardDAV server: connect, export contacts, then import older contacts with matching UIDs — should skip gracefully instead of crashing