### PR TITLE
fix: suppress already-mapped contacts from CardDAV import UI

### DIFF
--- a/app/api/carddav/pending-count/route.ts
+++ b/app/api/carddav/pending-count/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { getAlreadyMappedPersonUids } from '@/lib/carddav/mapped-uids';
 import { createModuleLogger } from '@/lib/logger';
 import { withLogging } from '@/lib/api-utils';
 
@@ -23,34 +24,17 @@ export const GET = withLogging(async function GET(_request: Request) {
       return NextResponse.json({ count: 0 });
     }
 
-    // Get UIDs of persons already mapped (under any UID) to exclude stale
-    // pending imports that would just be skipped during import.
-    const alreadyMappedPersonUids = new Set(
-      (await prisma.person.findMany({
-        where: {
-          userId: session.user.id,
-          deletedAt: null,
-          uid: { not: null },
-          cardDavMapping: { isNot: null },
-        },
-        select: { uid: true },
-      })).map((p) => p.uid!)
-    );
+    // Exclude pending imports whose person is already mapped (under any UID)
+    const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(session.user.id);
 
-    // Count pending imports, excluding already-mapped contacts
-    if (alreadyMappedPersonUids.size === 0) {
-      const count = await prisma.cardDavPendingImport.count({
-        where: { connectionId: connection.id },
-      });
-      return NextResponse.json({ count });
-    }
-
-    // When there are mapped UIDs to exclude, fetch and filter
-    const allPending = await prisma.cardDavPendingImport.findMany({
-      where: { connectionId: connection.id },
-      select: { uid: true },
+    const count = await prisma.cardDavPendingImport.count({
+      where: {
+        connectionId: connection.id,
+        ...(alreadyMappedPersonUids.size > 0
+          ? { uid: { notIn: [...alreadyMappedPersonUids] } }
+          : {}),
+      },
     });
-    const count = allPending.filter((p) => !alreadyMappedPersonUids.has(p.uid)).length;
 
     return NextResponse.json({ count });
   } catch (error) {

--- a/app/carddav/import/page.tsx
+++ b/app/carddav/import/page.tsx
@@ -2,6 +2,7 @@ import { auth } from '@/lib/auth';
 import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { getTranslations } from 'next-intl/server';
+import { getAlreadyMappedPersonUids } from '@/lib/carddav/mapped-uids';
 import ImportContactsList from '@/components/ImportContactsList';
 import Navigation from '@/components/Navigation';
 
@@ -64,17 +65,7 @@ export default async function ImportPage({
   // be created but old ones may still exist until cleaned up.
   let pendingImports = allPendingImports;
   if (!isFileImport && allPendingImports.length > 0) {
-    const alreadyMappedPersonUids = new Set(
-      (await prisma.person.findMany({
-        where: {
-          userId: session.user.id,
-          deletedAt: null,
-          uid: { not: null },
-          cardDavMapping: { isNot: null },
-        },
-        select: { uid: true },
-      })).map((p) => p.uid!)
-    );
+    const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(session.user.id);
     pendingImports = allPendingImports.filter(
       (p) => !alreadyMappedPersonUids.has(p.uid)
     );

--- a/lib/carddav/discover.ts
+++ b/lib/carddav/discover.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { createCardDavClient } from './client';
 import { getAddressBook } from './address-book';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
+import { getAlreadyMappedPersonUids } from './mapped-uids';
 import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('carddav');
@@ -61,17 +62,7 @@ export async function discoverNewContacts(userId: string): Promise<DiscoveryResu
     // This catches cases where a person was auto-exported with a server-
     // rewritten UID — their person.uid differs from mapping.uid, so the
     // existingUids check alone would miss them.
-    const alreadyMappedPersonUids = new Set(
-      (await prisma.person.findMany({
-        where: {
-          userId,
-          deletedAt: null,
-          uid: { not: null },
-          cardDavMapping: { isNot: null },
-        },
-        select: { uid: true },
-      })).map((p) => p.uid!)
-    );
+    const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(userId);
 
     // Get all existing pending imports
     const existingPending = await prisma.cardDavPendingImport.findMany({
@@ -135,18 +126,17 @@ export async function discoverNewContacts(userId: string): Promise<DiscoveryResu
       }
     }
 
-    // Clean up stale pending imports whose UIDs no longer exist on the server.
-    // Also include UIDs that are already mapped (imported) — those aren't stale
+    // Clean up stale pending imports: UIDs no longer on the server, or UIDs
+    // whose person is already mapped (these would just be skipped during import).
     const allValidUids = new Set([...serverUids, ...existingUids]);
 
-    // Find pending imports whose UIDs are no longer on the server
     const allPending = await prisma.cardDavPendingImport.findMany({
       where: { connectionId: connection.id },
       select: { id: true, uid: true },
     });
 
     const staleIds = allPending
-      .filter((p) => !allValidUids.has(p.uid))
+      .filter((p) => !allValidUids.has(p.uid) || alreadyMappedPersonUids.has(p.uid))
       .map((p) => p.id);
 
     if (staleIds.length > 0) {

--- a/lib/carddav/mapped-uids.ts
+++ b/lib/carddav/mapped-uids.ts
@@ -1,0 +1,21 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * Returns the set of person UIDs that already have a CardDavMapping.
+ *
+ * Used by discovery, sync, import page, and pending-count to suppress
+ * contacts whose person is already mapped under a different UID
+ * (e.g. auto-export with server UID rewrite).
+ */
+export async function getAlreadyMappedPersonUids(userId: string): Promise<Set<string>> {
+  const persons = await prisma.person.findMany({
+    where: {
+      userId,
+      deletedAt: null,
+      uid: { not: null },
+      cardDavMapping: { isNot: null },
+    },
+    select: { uid: true },
+  });
+  return new Set(persons.map((p) => p.uid!));
+}

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -11,6 +11,7 @@ import { updatePersonFromVCard } from './vcard-import';
 
 import { v4 as uuidv4 } from 'uuid';
 import { buildLocalHash } from './hash';
+import { getAlreadyMappedPersonUids } from './mapped-uids';
 import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('carddav');
@@ -181,17 +182,7 @@ export async function syncFromServer(
     // Get UIDs of persons that already have a mapping under any UID.
     // Prevents creating pending imports for contacts whose person is already
     // mapped (e.g. auto-export with server UID rewrite).
-    const alreadyMappedPersonUids = new Set(
-      (await prisma.person.findMany({
-        where: {
-          userId,
-          deletedAt: null,
-          uid: { not: null },
-          cardDavMapping: { isNot: null },
-        },
-        select: { uid: true },
-      })).map((p) => p.uid!)
-    );
+    const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(userId);
 
     // Collect all UIDs seen on the server during processing (for stale import cleanup)
     const serverUids = new Set<string>();
@@ -394,8 +385,8 @@ export async function syncFromServer(
       },
     });
 
-    // Clean up stale pending imports whose UIDs no longer exist on the server.
-    // UIDs that are already mapped (imported) are also valid — not stale
+    // Clean up stale pending imports: UIDs no longer on the server, or UIDs
+    // whose person is already mapped (these would just be skipped during import).
     const mappedUids = new Set(allMappings.map((m) => m.uid));
     const allValidUids = new Set([...serverUids, ...mappedUids]);
 
@@ -405,7 +396,7 @@ export async function syncFromServer(
     });
 
     const staleIds = stalePending
-      .filter((p) => !allValidUids.has(p.uid))
+      .filter((p) => !allValidUids.has(p.uid) || alreadyMappedPersonUids.has(p.uid))
       .map((p) => p.id);
 
     if (staleIds.length > 0) {

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -49,6 +49,9 @@ const mocks = vi.hoisted(() => ({
   vCardToPerson: vi.fn(),
   personToVCard: vi.fn(),
   updatePersonFromVCard: vi.fn(),
+
+  // mapped-uids helper
+  getAlreadyMappedPersonUids: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -117,6 +120,10 @@ vi.mock('@/lib/carddav/retry', () => ({
     category: 'UNKNOWN',
     userMessage: error instanceof Error ? error.message : 'Unknown error',
   })),
+}));
+
+vi.mock('@/lib/carddav/mapped-uids', () => ({
+  getAlreadyMappedPersonUids: mocks.getAlreadyMappedPersonUids,
 }));
 
 vi.mock('@/lib/photo-storage', () => ({
@@ -277,6 +284,8 @@ describe('CardDAV Sync Engine', () => {
     // Default: no existing mappings (for both syncFromServer pre-load and syncToServer)
     mocks.cardDavMappingFindMany.mockResolvedValue([]);
     mocks.personFindMany.mockResolvedValue([]);
+    // Default: no persons already mapped under a different UID
+    mocks.getAlreadyMappedPersonUids.mockResolvedValue(new Set());
 
     // Default: personToVCard returns a valid vCard string
     mocks.personToVCard.mockReturnValue('BEGIN:VCARD\nVERSION:3.0\nEND:VCARD');
@@ -446,6 +455,27 @@ describe('CardDAV Sync Engine', () => {
 
         expect(mocks.cardDavPendingImportUpsert).not.toHaveBeenCalled();
         expect(result.errors).toBe(1);
+      });
+
+      it('should not create pending import when person UID is already mapped under a different UID (issue #197)', async () => {
+        const serverUid = 'person-original-uid';
+
+        // No mapping for this UID (the mapping uses a different UID from auto-export)
+        mocks.cardDavMappingFindMany.mockResolvedValue([]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(serverUid, '/contacts/gerda.vcf', 'etag-1', 'Gerda'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(serverUid, 'Gerda'));
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        // Person with this UID already has a mapping (under a different UID)
+        mocks.getAlreadyMappedPersonUids.mockResolvedValue(new Set([serverUid]));
+
+        const result = await syncFromServer(USER_ID);
+
+        // Should NOT create a pending import
+        expect(mocks.cardDavPendingImportUpsert).not.toHaveBeenCalled();
+        expect(result.pendingImports).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
## Summary

Follow-up to #200 (which prevented the crash). This PR fixes the upstream discovery behavior so already-mapped contacts never appear in the import UI in the first place.

- **`lib/carddav/discover.ts`** — pre-fetches person UIDs that already have a mapping (under any UID) and skips them during discovery
- **`lib/carddav/sync.ts`** — same check before creating pending imports during sync
- **`app/carddav/import/page.tsx`** — filters out stale pending imports whose person is already mapped, so existing entries from before this fix don't linger in the UI
- **`app/api/carddav/pending-count/route.ts`** — matches the import page filtering so the notification badge count stays accurate

Relates to #197

## Test plan

- [x] All 284 CardDAV tests pass
- [x] TypeScript compiles cleanly
- [ ] Manual: connect a CardDAV server with auto-export enabled, verify duplicate server contacts don't appear in the import list
- [ ] Manual: verify pending-count badge matches the actual number of importable contacts