### PR TITLE
fix: add z-index for navbar to fix search stacking issue

### DIFF
--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -79,8 +79,8 @@ export default function Navigation({ userEmail, userName, userNickname, userPhot
     <nav className="bg-surface border-b border-border">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Top row: Logo, Search (centered), User menu */}
-        <div className="relative flex items-center justify-between h-16">
-          <Link href="/dashboard" className="flex items-center flex-shrink-0 z-10">
+        <div className="relative z-30 flex items-center justify-between h-16">
+          <Link href="/dashboard" className="flex items-center shrink-0 z-10">
             <Image
               src="/logo.svg"
               alt="Nametag Logo"


### PR DESCRIPTION
## Summary

Fix search bar stacking by adding z-30 to the navbar. 
This ensures the search dropdown appears above underlying elements.

## Checklist

- [x] Tested locally
- [x] Documentation updated if needed
- [x] Tests added/updated if applicable
- [x] Backwards compatibility considered
- [x] Translations updated if applicable

## Screenshots

Before: 
<img width="960" height="345" alt="Firefox_Screenshot_2026-04-06T15-32-26 764Z" src="https://github.com/user-attachments/assets/06f1f303-83ad-4329-b6c5-57df0aa91868" />

After: 
<img width="960" height="345" alt="Firefox_Screenshot_2026-04-06T15-31-38 693Z" src="https://github.com/user-attachments/assets/6787fc78-694b-44b3-ab8f-80a57dbf347d" />

## Related issues

No related issue.