### PR TITLE
fix: make orphan warning tooltip readable in light mode

### DIFF
--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -347,7 +347,7 @@ export default function PeopleListClient({
                         {isOrphan && (
                           <span className="relative group cursor-help">
                             <span className="text-yellow-500">{'\u26A0\uFE0F'}</span>
-                            <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-xs text-white bg-surface-elevated rounded-lg whitespace-normal max-w-xs z-50 shadow-lg">
+                            <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-xs text-foreground bg-surface-elevated rounded-lg whitespace-normal max-w-xs z-50 shadow-lg border border-border">
                               {tt.orphanWarning}
                               <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-px border-4 border-transparent border-t-surface-elevated"></span>
                             </span>


### PR DESCRIPTION
## Summary

- The orphan warning tooltip (⚠️ on contacts with no relationships) used `text-white` on `bg-surface-elevated`, which is near-white (`#F3F2EF`) in light mode — making the text invisible
- Switched to `text-foreground` so it adapts to the active theme
- Added `border border-border` for better tooltip definition in light mode

Closes #209