### PR TITLE
Install tzdata so TZ env var resolves non-UTC zones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,9 @@ RUN npx esbuild prisma/seed.production.ts --platform=node --format=cjs --outfile
 FROM node:20-alpine AS runner
 WORKDIR /app
 
+# Install tzdata so the TZ env var can resolve non-UTC zones
+RUN apk add --no-cache tzdata
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 


### PR DESCRIPTION
## Summary

`node:20-alpine` ships without `tzdata`, so setting `TZ=Europe/Madrid` (or any non-UTC zone) on the app container silently falls back to UTC because the zone file isn't available at `/usr/share/zoneinfo/`. Adding `apk add --no-cache tzdata` to the `runner` stage of the Dockerfile makes `TZ` resolve correctly.

## Why not leave it to operators?

The pre-built image is published to `ghcr.io/mattogodoy/nametag:latest` and consumed by self-hosted deployments. Operators adding `TZ=...` to their `docker-compose.yml` currently get silent UTC — without a clear error signalling what's missing. Shipping `tzdata` in the base image removes the footgun.

## Test plan

- [ ] CI: Build job passes (verifies the Dockerfile still builds cleanly)
- [ ] After release: pull the new image, set `TZ=Europe/Madrid`, run `docker exec <container> date` and confirm CEST/CET
- [ ] `ls /usr/share/zoneinfo/Europe/Madrid` inside the container returns a file

## Note on cron container

`docker-compose.yml`'s `cron` service uses plain `alpine:3.19` which *also* lacks tzdata. That one is configured by operators directly in their compose file, so not changed here — but worth documenting for a follow-up.