### PR TITLE
feat(carddav): log outgoing vCard on push failure

### DIFF
--- a/lib/carddav/client.ts
+++ b/lib/carddav/client.ts
@@ -7,6 +7,42 @@ import { readBodySafely } from '@/lib/logging/http-body';
 
 const log = createModuleLogger('carddav');
 
+/**
+ * Truncate embedded PHOTO base64 in a vCard so it can be safely logged.
+ * Preserves structure (headers, params, line folding) of everything else.
+ */
+function truncateVCardForLog(vcard: string, maxPhotoValueChars = 40): string {
+  const lines = vcard.split(/\r?\n/);
+  const out: string[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!/^PHOTO[;:]/i.test(line)) {
+      out.push(line);
+      continue;
+    }
+    let full = line;
+    let j = i + 1;
+    while (j < lines.length && /^[ \t]/.test(lines[j])) {
+      full += lines[j].substring(1);
+      j++;
+    }
+    i = j - 1;
+    const colonIdx = full.indexOf(':');
+    if (colonIdx < 0) {
+      out.push(full.slice(0, 80) + '…[truncated]');
+      continue;
+    }
+    const header = full.slice(0, colonIdx);
+    const value = full.slice(colonIdx + 1);
+    out.push(
+      value.length > maxPhotoValueChars
+        ? `${header}:${value.slice(0, maxPhotoValueChars)}…[+${value.length - maxPhotoValueChars} chars]`
+        : `${header}:${value}`,
+    );
+  }
+  return out.join('\r\n');
+}
+
 export interface AddressBook {
   url: string;
   displayName?: string;
@@ -136,6 +172,7 @@ export async function createCardDavClient(
           context: {
             serverHost: new URL(serverUrl).host,
             filename,
+            outgoingVCard: truncateVCardForLog(vCardData),
           },
         });
       }
@@ -190,6 +227,7 @@ export async function createCardDavClient(
           context: {
             serverHost: new URL(serverUrl).host,
             etag: vCard.etag,
+            outgoingVCard: truncateVCardForLog(newData),
           },
         });
       }


### PR DESCRIPTION
## Summary
- When a CardDAV `CREATE` or `UPDATE` returns 4xx/5xx, attach the outgoing vCard (PHOTO base64 truncated to 40 chars) to the `ExternalServiceError` context.
- The `err` serializer in `lib/logger.ts` flattens `context` onto the log event, so the exact payload the server rejected now shows up as `outgoingVCard` in the failure log.
- No behavior change beyond logging — no request/response semantics are altered.

## Why
A user hit a persistent `400 Bad Request` / `INVALID_ARGUMENT` from Google Contacts during sync:

```
CardDAV UPDATE failed: 400 Bad Request
body: { "error": { "code": 400, "message": "Request contains an invalid argument." } }
```

Google's response does not indicate which field is invalid, and the push-failure log previously captured only the response body, ETag, and endpoint — not the vCard we sent. Without the outgoing payload, every guess at the cause (photo size, preserved properties, custom fields) required a round-trip to the user.

With this change, one failing sync is enough to see the exact bytes Google rejected.

## Implementation
- New helper `truncateVCardForLog()` in `lib/carddav/client.ts`. It walks the vCard, finds any `PHOTO` line (including folded continuation lines), unfolds it, and truncates the value after the colon to 40 chars with a length suffix. All other properties are passed through untouched.
- `updateVCard` and `createVCard` each call the helper and add `outgoingVCard` to their error `context` when the HTTP response is not `ok`.

## Test plan
- [ ] Typecheck passes locally (verified — no new errors introduced in `lib/carddav/client.ts`)
- [ ] Existing CardDAV tests still pass
- [ ] Deploy; on next real `carddav.push.failed` log entry, confirm `outgoingVCard` field is present and PHOTO values are truncated