### PR TITLE
fix(carddav): drop REV/PRODID round-trip and fix backslash unescape

### DIFF
--- a/lib/carddav/vcard-parser.ts
+++ b/lib/carddav/vcard-parser.ts
@@ -526,13 +526,19 @@ function processProperty(
       return true;
     }
 
+    // Server-authored metadata that has no user-facing meaning in Nametag.
+    // We consume it so it doesn't leak into unknownProperties, but we do NOT
+    // preserve it — round-tripping REV/PRODID accumulates duplicates and has
+    // caused CardDAV push failures when exported values carry odd escaping.
+    case 'REV':
+    case 'PRODID':
+      return true;
+
     // Properties to preserve as custom fields
     case 'ROLE':
     case 'LANG':
     case 'TZ':
     case 'KEY':
-    case 'REV':
-    case 'PRODID':
     case 'RELATED': {
       data.customFields.push({
         key: prop.property,
@@ -766,14 +772,35 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
 }
 
 /**
- * Unescape vCard text
+ * Unescape vCard text values.
+ *
+ * Scans left-to-right so escape sequences compose correctly. A regex chain
+ * like `.replace(/\\\\/g, '\\')` run after other replaces would turn the
+ * 3-char sequence `\\:` (which should decode to literal `\:`) into `:`.
+ *
+ * Handles: \\ \n \N \; \, and \: (the last is a 4.0 extension some tools
+ * emit; leaving it un-unescaped caused stray backslashes to survive a
+ * round-trip and break subsequent CardDAV PUTs).
  */
 function unescapeVCardText(text: string): string {
-  return text
-    .replace(/\\n/g, '\n')
-    .replace(/\\;/g, ';')
-    .replace(/\\,/g, ',')
-    .replace(/\\\\/g, '\\');
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch !== '\\' || i + 1 >= text.length) {
+      out += ch;
+      continue;
+    }
+    const next = text[i + 1];
+    if (next === 'n' || next === 'N') {
+      out += '\n';
+    } else if (next === '\\' || next === ';' || next === ',' || next === ':') {
+      out += next;
+    } else {
+      out += ch + next;
+    }
+    i++;
+  }
+  return out;
 }
 
 /**

--- a/prisma/migrations/20260423000000_drop_orphan_rev_prodid_custom_fields/migration.sql
+++ b/prisma/migrations/20260423000000_drop_orphan_rev_prodid_custom_fields/migration.sql
@@ -1,0 +1,8 @@
+-- Remove CardDAV REV / PRODID properties that were previously captured as custom
+-- fields. They are server-authored metadata (revision timestamps, tool IDs) with
+-- no user-facing value, and round-tripping them accumulated duplicates. One
+-- variant with stray backslash escaping ("...T06\:54\:04Z") caused the generated
+-- vCard to be rejected by Google Contacts CardDAV with 400 INVALID_ARGUMENT.
+-- The parser no longer captures these; this cleanup removes the stragglers.
+DELETE FROM "person_custom_fields"
+WHERE key IN ('REV', 'PRODID', 'X-REV', 'X-PRODID');

--- a/tests/lib/carddav/vcard-parser.test.ts
+++ b/tests/lib/carddav/vcard-parser.test.ts
@@ -83,6 +83,31 @@ describe('vCard Parser', () => {
 
       expect(props[0].params.TYPE).toEqual(['work', 'voice']);
     });
+
+    it('should unescape \\n, \\;, \\, and \\\\ in values', () => {
+      const vCard = 'BEGIN:VCARD\nVERSION:3.0\nNOTE:line1\\nline2 a\\;b c\\,d path\\\\here\nEND:VCARD';
+      const props = parseProperties(vCard, '3.0');
+
+      expect(props[0].value).toBe('line1\nline2 a;b c,d path\\here');
+    });
+
+    it('should unescape \\: (vCard 4.0 extension some tools emit)', () => {
+      const vCard = 'BEGIN:VCARD\nVERSION:3.0\nX-TS:2025-10-31T06\\:54\\:04Z\nEND:VCARD';
+      const props = parseProperties(vCard, '3.0');
+
+      expect(props[0].value).toBe('2025-10-31T06:54:04Z');
+    });
+
+    it('should decode \\\\: as literal backslash + colon, not strip the backslash', () => {
+      // `\\:` = escape-sequence \\ (literal backslash) then literal `:`.
+      // A naive regex chain that runs `/\\\\/g → \\` last would corrupt this
+      // by first consuming `\:` and turning it into `:`. Left-to-right scan
+      // must preserve the backslash.
+      const vCard = 'BEGIN:VCARD\nVERSION:3.0\nX-PATH:C\\\\:drive\nEND:VCARD';
+      const props = parseProperties(vCard, '3.0');
+
+      expect(props[0].value).toBe('C\\:drive');
+    });
   });
 
   describe('associateItemGroups', () => {
@@ -606,6 +631,24 @@ END:VCARD`;
       expect(parsed.customFields.find(f => f.key === 'ROLE')?.value).toBe('Tech Lead');
       expect(parsed.customFields.find(f => f.key === 'LANG')?.value).toBe('en');
       expect(parsed.customFields.find(f => f.key === 'TZ')?.value).toBe('-0500');
+    });
+
+    it('should NOT capture REV or PRODID (server-authored metadata)', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+REV:2025-10-31T06:54:04Z
+PRODID:-//Google Inc//Google Contacts//EN
+ROLE:Tech Lead
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.customFields.find(f => f.key === 'REV')).toBeUndefined();
+      expect(parsed.customFields.find(f => f.key === 'PRODID')).toBeUndefined();
+      expect(parsed.unknownProperties.find(p => p.key === 'REV')).toBeUndefined();
+      expect(parsed.unknownProperties.find(p => p.key === 'PRODID')).toBeUndefined();
+      expect(parsed.customFields.find(f => f.key === 'ROLE')?.value).toBe('Tech Lead');
     });
   });
 


### PR DESCRIPTION
## Summary
- Stop capturing `REV` and `PRODID` from inbound vCards as `PersonCustomField` rows.
- Rewrite `unescapeVCardText` as a left-to-right scanner so `\:`, `\\`, and edge cases like `\\:` decode correctly.
- Migration deletes stragglers (`REV`, `PRODID`, `X-REV`, `X-PRODID`) that accumulated before the parser fix.
- Adds parser tests covering both behaviors.

## Why

A sync was failing in production against Google Contacts CardDAV:
```
CardDAV UPDATE failed: 400 Bad Request
body: { "code": 400, "message": "Request contains an invalid argument.", "status": "INVALID_ARGUMENT" }
```

The outgoing vCard (captured via #229's diagnostic logging) contained three `X-REV` lines, one of which was malformed:
```
X-REV:2025-10-31T06:54:04Z
X-REV:2026-03-04T19:44:58Z
X-REV:2025-10-31T06\\:54\\:04Z     ← 400 trigger
```

Two bugs produced this:

1. **REV/PRODID round-trip.** `lib/carddav/vcard-parser.ts` captured `REV` and `PRODID` alongside truly useful fields like `ROLE`/`LANG`/`TZ`. Every pull sync then ran `deleteMany + create` on custom fields (`vcard-import.ts:95-97`), re-importing the same `REV` that Google had just written. Over time multiple distinct `REV` values accumulated. The export path rewrites any non-`X-` key to `X-*`, so these flowed back to the server as stale `X-REV` lines. `REV`/`PRODID` are server-authored metadata with no user-facing meaning — round-tripping them is just noise.

2. **`\:` was not unescaped.** `unescapeVCardText` handled `\\`, `\n`, `\;`, `\,`, but not `\:`. vCard 4.0 permits `\:` as a text-value escape, and some tools emit it. Because we didn't decode it, the backslash survived into the database, and on the next push `escapeVCardText` doubled it to `\\`, producing `X-REV:...T06\\:54\\:04Z` on the wire. Google's strict CardDAV parser rejects the whole vCard.

A naive fix — appending `.replace(/\\:/g, ':')` to the regex chain — is wrong. Regex doesn't know which backslash belongs to which escape sequence, so `\\:` (which should decode to literal `\:`) would have its backslash consumed. The fix is a proper left-to-right scanner that looks at each `\<char>` pair once.

## Test plan

- [x] `npx vitest run tests/lib/carddav/ tests/lib/vcard-v3-compliance.test.ts tests/lib/vcard-second-lastname.test.ts` — 304 tests pass including 4 new parser tests
- [x] `npx tsc --noEmit` — no new errors introduced
- [ ] Deploy to the affected instance, run the migration, sync the failing contact — expect 2xx instead of 400
- [ ] Verify `PersonCustomField` no longer accumulates `REV`/`PRODID` rows on subsequent syncs

## Data safety

Migration is idempotent and narrow: it only deletes rows where `key IN ('REV','PRODID','X-REV','X-PRODID')`. No schema changes. No user-authored data is affected — these keys are never entered by users; they arrived only via the parser bug.