### PR TITLE
fix(carddav): use item grouping for non-standard EMAIL/TEL/ADR labels

### DIFF
--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -29,6 +29,16 @@ const DEFAULT_OPTIONS: VCardOptions = {
   stripMarkdown: false,
 };
 
+// Standard TYPE parameter values that servers (Google, iCloud) accept on
+// EMAIL/TEL/ADR. Non-standard labels get emitted via Apple-style item grouping
+// with X-ABLabel so we don't send invalid TYPE values that servers reject
+// (Google returns 400 INVALID_ARGUMENT).
+const STANDARD_EMAIL_TYPES = new Set(['HOME', 'WORK', 'OTHER', 'INTERNET']);
+const STANDARD_TEL_TYPES = new Set([
+  'CELL', 'HOME', 'WORK', 'FAX', 'PAGER', 'VOICE', 'OTHER', 'MAIN',
+]);
+const STANDARD_ADR_TYPES = new Set(['HOME', 'WORK', 'OTHER']);
+
 /**
  * Convert Person model to vCard 3.0 string
  */
@@ -124,21 +134,37 @@ export function personToVCard(
 
   // TEL (Phone numbers)
   person.phoneNumbers.forEach((phone) => {
-    const type = phone.type.toUpperCase();
-    // Convert "MOBILE" to "CELL" for v3.0 compatibility
-    const v3Type = type === 'MOBILE' ? 'CELL' : type;
-    lines.push(buildV3Property('TEL', { TYPE: v3Type }, phone.number));
+    // MOBILE → CELL for v3.0 compatibility
+    const upper = phone.type.toUpperCase();
+    const v3Type = upper === 'MOBILE' ? 'CELL' : upper;
+
+    if (STANDARD_TEL_TYPES.has(v3Type)) {
+      lines.push(buildV3Property('TEL', { TYPE: v3Type }, phone.number));
+    } else {
+      const label = escapeVCardText(phone.type);
+      lines.push(`item${itemCounter}.TEL:${escapeVCardText(phone.number)}`);
+      lines.push(`item${itemCounter}.X-ABLabel:${label}`);
+      itemCounter++;
+    }
   });
 
   // EMAIL
   person.emails.forEach((email) => {
-    const type = email.type.toUpperCase();
-    lines.push(buildV3Property('EMAIL', { TYPE: type }, email.email));
+    const upper = email.type.toUpperCase();
+
+    if (STANDARD_EMAIL_TYPES.has(upper)) {
+      lines.push(buildV3Property('EMAIL', { TYPE: upper }, email.email));
+    } else {
+      const label = escapeVCardText(email.type);
+      lines.push(`item${itemCounter}.EMAIL:${escapeVCardText(email.email)}`);
+      lines.push(`item${itemCounter}.X-ABLabel:${label}`);
+      itemCounter++;
+    }
   });
 
   // ADR (Address) - ;;street;locality;region;postal;country
   person.addresses.forEach((addr) => {
-    const type = addr.type.toUpperCase();
+    const upper = addr.type.toUpperCase();
 
     // Combine streetLine1 and streetLine2 with newline separator
     const streetValue = [addr.streetLine1, addr.streetLine2]
@@ -156,8 +182,16 @@ export function personToVCard(
     ]
       .map(escapeVCardText)
       .join(';');
+
     // Build ADR line directly (don't use buildV3Property which would escape the semicolons)
-    lines.push(`ADR;TYPE=${type}:${adrValue}`);
+    if (STANDARD_ADR_TYPES.has(upper)) {
+      lines.push(`ADR;TYPE=${upper}:${adrValue}`);
+    } else {
+      const label = escapeVCardText(addr.type);
+      lines.push(`item${itemCounter}.ADR:${adrValue}`);
+      lines.push(`item${itemCounter}.X-ABLabel:${label}`);
+      itemCounter++;
+    }
   });
 
   // URL - use item grouping with X-ABLabel for better compatibility

--- a/lib/carddav/vcard-parser.ts
+++ b/lib/carddav/vcard-parser.ts
@@ -376,20 +376,26 @@ function processProperty(
     }
 
     case 'TEL': {
-      const typeParam = prop.params.TYPE || 'other';
-      const types = Array.isArray(typeParam) ? typeParam : [typeParam];
-      const type = types[0] || 'other';
+      const groupLabel = prop.group ? getItemGroupLabel(prop.group, itemGroups) : undefined;
+      const typeParam = prop.params.TYPE;
+      const types = typeParam
+        ? (Array.isArray(typeParam) ? typeParam : [typeParam])
+        : [];
+      const type = groupLabel || types[0] || 'other';
 
       data.phoneNumbers.push({ type, number: prop.value });
       return true;
     }
 
     case 'EMAIL': {
-      const typeParam = prop.params.TYPE || 'other';
-      const types = Array.isArray(typeParam) ? typeParam : [typeParam];
+      const groupLabel = prop.group ? getItemGroupLabel(prop.group, itemGroups) : undefined;
+      const typeParam = prop.params.TYPE;
+      const types = typeParam
+        ? (Array.isArray(typeParam) ? typeParam : [typeParam])
+        : [];
       // Filter out 'internet' which is redundant
       const filteredTypes = types.filter((t) => t.toLowerCase() !== 'internet');
-      const type = filteredTypes[0] || 'other';
+      const type = groupLabel || filteredTypes[0] || 'other';
 
       data.emails.push({ type, email: prop.value });
       return true;
@@ -398,9 +404,12 @@ function processProperty(
     case 'ADR': {
       // ADR = ;;street;locality;region;postal;country
       const parts = prop.value.split(';');
-      const typeParam = prop.params.TYPE || 'other';
-      const types = Array.isArray(typeParam) ? typeParam : [typeParam];
-      const type = types[0] || 'other';
+      const groupLabel = prop.group ? getItemGroupLabel(prop.group, itemGroups) : undefined;
+      const typeParam = prop.params.TYPE;
+      const types = typeParam
+        ? (Array.isArray(typeParam) ? typeParam : [typeParam])
+        : [];
+      const type = groupLabel || types[0] || 'other';
 
       // Split street component on newline
       const streetPart = parts[2] || '';

--- a/tests/lib/carddav/vcard-parser.test.ts
+++ b/tests/lib/carddav/vcard-parser.test.ts
@@ -597,6 +597,66 @@ END:VCARD`;
       expect(parsed.customFields[0].value).toBe('John Doe');
       expect(parsed.customFields[0].type).toBe('Father');
     });
+
+    it('uses X-ABLabel as EMAIL type when present', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.EMAIL:matt@example.com
+item1.X-ABLabel:Personal
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.emails).toHaveLength(1);
+      expect(parsed.emails[0].email).toBe('matt@example.com');
+      expect(parsed.emails[0].type).toBe('Personal');
+    });
+
+    it('uses X-ABLabel as TEL type when present', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.TEL:+15555551212
+item1.X-ABLabel:School
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.phoneNumbers).toHaveLength(1);
+      expect(parsed.phoneNumbers[0].number).toBe('+15555551212');
+      expect(parsed.phoneNumbers[0].type).toBe('School');
+    });
+
+    it('uses X-ABLabel as ADR type when present, preserving structured value', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.ADR:;;1 Beach Rd;Coast;ST;11111;US
+item1.X-ABLabel:Summer
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.addresses).toHaveLength(1);
+      expect(parsed.addresses[0].type).toBe('Summer');
+      expect(parsed.addresses[0].streetLine1).toBe('1 Beach Rd');
+      expect(parsed.addresses[0].locality).toBe('Coast');
+      expect(parsed.addresses[0].postalCode).toBe('11111');
+    });
+
+    it('prefers X-ABLabel over TYPE parameter for EMAIL', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.EMAIL;TYPE=INTERNET:matt@example.com
+item1.X-ABLabel:Personal
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.emails[0].type).toBe('Personal');
+    });
   });
 
   describe('parseVCard - Custom Fields', () => {

--- a/tests/lib/carddav/vcard.test.ts
+++ b/tests/lib/carddav/vcard.test.ts
@@ -671,6 +671,202 @@ END:VCARD`;
     });
   });
 
+  describe('custom TYPE labels - item grouping', () => {
+    function makePerson(overrides: Partial<PersonWithRelations>): PersonWithRelations {
+      return {
+        id: 'test-1',
+        userId: 'user-1',
+        name: 'John',
+        surname: 'Doe',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        prefix: null,
+        suffix: null,
+        uid: 'test-uid',
+        organization: null,
+        jobTitle: null,
+        photo: null,
+        gender: null,
+        anniversary: null,
+        lastContact: null,
+        notes: null,
+        relationshipToUserId: null,
+        contactReminderEnabled: false,
+        contactReminderInterval: null,
+        contactReminderIntervalUnit: null,
+        lastContactReminderSent: null,
+        cardDavSyncEnabled: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        deletedAt: null,
+        phoneNumbers: [],
+        emails: [],
+        addresses: [],
+        urls: [],
+        imHandles: [],
+        locations: [],
+        customFields: [],
+        importantDates: [],
+        relationshipsFrom: [],
+        groups: [],
+        ...overrides,
+      };
+    }
+
+    it('emits EMAIL with TYPE= for standard labels (home, work, other)', () => {
+      const person = makePerson({
+        emails: [
+          { id: 'e1', personId: 'test-1', type: 'home', email: 'a@x.com', createdAt: new Date() },
+          { id: 'e2', personId: 'test-1', type: 'work', email: 'b@x.com', createdAt: new Date() },
+          { id: 'e3', personId: 'test-1', type: 'other', email: 'c@x.com', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).toContain('EMAIL;TYPE=HOME:a@x.com');
+      expect(vcard).toContain('EMAIL;TYPE=WORK:b@x.com');
+      expect(vcard).toContain('EMAIL;TYPE=OTHER:c@x.com');
+      expect(vcard).not.toMatch(/item\d+\.EMAIL:/);
+    });
+
+    it('emits non-standard EMAIL labels via item grouping + X-ABLabel', () => {
+      const person = makePerson({
+        emails: [
+          { id: 'e1', personId: 'test-1', type: 'Personal', email: 'matt@example.com', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).not.toContain('EMAIL;TYPE=PERSONAL');
+      expect(vcard).toMatch(/item\d+\.EMAIL:matt@example\.com/);
+      expect(vcard).toMatch(/item\d+\.X-ABLabel:Personal/);
+    });
+
+    it('emits TEL with TYPE= for standard labels (cell, mobile→cell, home, work, fax)', () => {
+      const person = makePerson({
+        phoneNumbers: [
+          { id: 'p1', personId: 'test-1', type: 'cell', number: '+1', createdAt: new Date() },
+          { id: 'p2', personId: 'test-1', type: 'mobile', number: '+2', createdAt: new Date() },
+          { id: 'p3', personId: 'test-1', type: 'home', number: '+3', createdAt: new Date() },
+          { id: 'p4', personId: 'test-1', type: 'fax', number: '+4', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).toContain('TEL;TYPE=CELL:+1');
+      expect(vcard).toContain('TEL;TYPE=CELL:+2');
+      expect(vcard).toContain('TEL;TYPE=HOME:+3');
+      expect(vcard).toContain('TEL;TYPE=FAX:+4');
+      expect(vcard).not.toMatch(/item\d+\.TEL:/);
+    });
+
+    it('emits non-standard TEL labels via item grouping + X-ABLabel', () => {
+      const person = makePerson({
+        phoneNumbers: [
+          { id: 'p1', personId: 'test-1', type: 'school', number: '+15555551212', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).not.toContain('TEL;TYPE=SCHOOL');
+      expect(vcard).toMatch(/item\d+\.TEL:\+15555551212/);
+      expect(vcard).toMatch(/item\d+\.X-ABLabel:school/);
+    });
+
+    it('emits ADR with TYPE= for standard labels', () => {
+      const person = makePerson({
+        addresses: [
+          {
+            id: 'a1',
+            personId: 'test-1',
+            type: 'home',
+            streetLine1: '1 Main St',
+            streetLine2: null,
+            locality: 'Town',
+            region: 'ST',
+            postalCode: '00000',
+            country: 'US',
+            createdAt: new Date(),
+          },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).toContain('ADR;TYPE=HOME:;;1 Main St;Town;ST;00000;US');
+      expect(vcard).not.toMatch(/item\d+\.ADR:/);
+    });
+
+    it('emits non-standard ADR labels via item grouping + X-ABLabel, preserving structured value', () => {
+      const person = makePerson({
+        addresses: [
+          {
+            id: 'a1',
+            personId: 'test-1',
+            type: 'summer',
+            streetLine1: '1 Beach Rd',
+            streetLine2: null,
+            locality: 'Coast',
+            region: 'ST',
+            postalCode: '11111',
+            country: 'US',
+            createdAt: new Date(),
+          },
+        ],
+      });
+      const vcard = personToVCard(person);
+      expect(vcard).not.toContain('ADR;TYPE=SUMMER');
+      expect(vcard).toMatch(/item\d+\.ADR:;;1 Beach Rd;Coast;ST;11111;US/);
+      expect(vcard).toMatch(/item\d+\.X-ABLabel:summer/);
+    });
+
+    it('round-trips a custom EMAIL label through export and parse', () => {
+      const person = makePerson({
+        emails: [
+          { id: 'e1', personId: 'test-1', type: 'Personal', email: 'matt@example.com', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      const parsed = vCardToPerson(vcard);
+      expect(parsed.emails).toHaveLength(1);
+      expect(parsed.emails[0].email).toBe('matt@example.com');
+      expect(parsed.emails[0].type).toBe('Personal');
+    });
+
+    it('round-trips a custom TEL label through export and parse', () => {
+      const person = makePerson({
+        phoneNumbers: [
+          { id: 'p1', personId: 'test-1', type: 'School', number: '+15555551212', createdAt: new Date() },
+        ],
+      });
+      const vcard = personToVCard(person);
+      const parsed = vCardToPerson(vcard);
+      expect(parsed.phoneNumbers).toHaveLength(1);
+      expect(parsed.phoneNumbers[0].number).toBe('+15555551212');
+      expect(parsed.phoneNumbers[0].type).toBe('School');
+    });
+
+    it('round-trips a custom ADR label through export and parse', () => {
+      const person = makePerson({
+        addresses: [
+          {
+            id: 'a1',
+            personId: 'test-1',
+            type: 'Summer',
+            streetLine1: '1 Beach Rd',
+            streetLine2: null,
+            locality: 'Coast',
+            region: 'ST',
+            postalCode: '11111',
+            country: 'US',
+            createdAt: new Date(),
+          },
+        ],
+      });
+      const vcard = personToVCard(person);
+      const parsed = vCardToPerson(vcard);
+      expect(parsed.addresses).toHaveLength(1);
+      expect(parsed.addresses[0].type).toBe('Summer');
+      expect(parsed.addresses[0].streetLine1).toBe('1 Beach Rd');
+      expect(parsed.addresses[0].locality).toBe('Coast');
+    });
+  });
+
   describe('preserved properties round-trip', () => {
     it('should include preservedProperties in generated vCard', () => {
       const person: PersonWithRelations = {


### PR DESCRIPTION
## Summary
- Google CardDAV was returning `400 INVALID_ARGUMENT` on PUT for any contact whose EMAIL/TEL/ADR carried a non-standard TYPE label (e.g. `EMAIL;TYPE=PERSONAL`). The export path was uppercasing `PersonEmail.type` and emitting it verbatim — fine for `HOME`/`WORK`, broken for everything else.
- Switch to Apple-style item grouping + `X-ABLabel` for non-standard labels, matching what this file already does for `URL`, `IMPP`, and `GEO`. Standard values still emit as `TYPE=X` so existing synced contacts don't churn.
- Parser updated in tandem so round-trip stays intact: EMAIL/TEL/ADR now read `X-ABLabel` from the item group (URL already did).

## On-wire change
**Before** (non-standard labels):
```
EMAIL;TYPE=PERSONAL:matt@example.com
```
**After**:
```
item1.EMAIL:matt@example.com
item1.X-ABLabel:Personal
```

## Standard-type whitelists
- `EMAIL`: HOME, WORK, OTHER, INTERNET
- `TEL`: CELL, HOME, WORK, FAX, PAGER, VOICE, OTHER, MAIN (plus `MOBILE -> CELL` normalization preserved)
- `ADR`: HOME, WORK, OTHER

## Trade-off
On the next sync, every contact that has a non-standard email/phone/address label will re-export with the new `itemN.PROP` structure — one extra PUT per such contact, gated by the existing per-user rate limiter. Users keep their labels.

## Test plan
- [x] New unit tests for EMAIL/TEL/ADR export with standard + custom labels (`tests/lib/carddav/vcard.test.ts`)
- [x] New parser tests for EMAIL/TEL/ADR item-group `X-ABLabel` (`tests/lib/carddav/vcard-parser.test.ts`)
- [x] Round-trip tests (export -> parse) preserve custom labels for email/tel/adr
- [x] `npx vitest run tests/lib/carddav/` — 283/283 passing locally
- [x] Independent code review (correctness, regression risk, CLAUDE.md compliance) — no blockers
- [ ] Verify against the originally failing Google Contacts account after merge