### PR TITLE
fix(carddav): recover from server-deleted contacts instead of looping forever

### DIFF
--- a/lib/carddav/auto-export.ts
+++ b/lib/carddav/auto-export.ts
@@ -4,8 +4,10 @@ import { getAddressBook } from './address-book';
 import { personToVCard } from '@/lib/carddav/vcard-export';
 import { readPhotoForExport, isPhotoFilename } from '@/lib/photo-storage';
 import { withRetry } from './retry';
+import { classifyUpdateFailure } from './update-recovery';
 import { buildLocalHash } from './hash';
 import { createModuleLogger } from '@/lib/logger';
+import { ExternalServiceError } from '@/lib/errors';
 import { updateContext } from '@/lib/logging/context';
 
 const log = createModuleLogger('carddav');
@@ -321,13 +323,49 @@ export async function autoUpdatePerson(personId: string): Promise<void> {
     const vCardData = personToVCard(person, { photoDataUri: updatePhotoDataUri });
 
     // Update vCard on server
-    const vCard = {
+    let vCard = {
       url: mapping.href,
       etag: mapping.etag || '',
       data: '',
     };
 
-    const updated = await withRetry(() => client.updateVCard(vCard, vCardData));
+    let updated;
+    try {
+      updated = await withRetry(() => client.updateVCard(vCard, vCardData));
+    } catch (updateError) {
+      const isRecoverableStatus =
+        updateError instanceof ExternalServiceError &&
+        (updateError.status === 400 || updateError.status === 404 || updateError.status === 410);
+      if (!isRecoverableStatus) throw updateError;
+
+      // Disambiguate via GET. See update-recovery.ts for the rationale.
+      const addressBook = await getAddressBook(client, connection);
+      const recovery = await classifyUpdateFailure(client, addressBook, mapping.href, vCard.etag);
+
+      if (recovery.kind === 'gone') {
+        log.warn(
+          { event: 'carddav.contact.gone', personId: person.id, href: mapping.href },
+          'CardDAV resource gone server-side; resetting mapping so next push creates a fresh contact',
+        );
+        await prisma.cardDavMapping.delete({ where: { id: mapping.id } });
+        await prisma.person.update({
+          where: { id: person.id },
+          data: { uid: null },
+        });
+        return;
+      }
+
+      if (recovery.kind === 'stale-etag') {
+        log.warn(
+          { personId: person.id, href: mapping.href },
+          'Server returned a non-412 status with a moved ETag; refreshing and retrying',
+        );
+        vCard = { url: mapping.href, etag: recovery.freshEtag, data: '' };
+        updated = await client.updateVCard(vCard, vCardData);
+      } else {
+        throw updateError;
+      }
+    }
 
     // Update mapping
     const localHash = buildLocalHash(person);

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -5,6 +5,7 @@ import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { parseVCard } from '@/lib/carddav/vcard-parser';
 import type { UnknownProperty } from '@/lib/carddav/vcard-parser';
 import { withRetry, categorizeError } from './retry';
+import { classifyUpdateFailure } from './update-recovery';
 import { getAddressBook } from './address-book';
 import { readPhotoForExport, isPhotoFilename } from '@/lib/photo-storage';
 import { updatePersonFromVCard } from './vcard-import';
@@ -561,30 +562,77 @@ export async function syncToServer(
           };
 
           let updated: VCard;
+          let recoveredAsGone = false;
           try {
             updated = await withRetry(
               () => client.updateVCard(vCard, vCardData),
               { maxAttempts: 3 }
             );
           } catch (updateError) {
-            if (!(updateError instanceof ExternalServiceError && updateError.status === 412)) throw updateError;
+            if (!(updateError instanceof ExternalServiceError)) throw updateError;
 
-            // 412: fetch fresh ETag from server and retry once
-            log.warn({ personId: mapping.personId, href: mapping.href }, '412 Precondition Failed — refreshing ETag and retrying');
-            const freshVCard = await client.fetchVCard(addressBook, mapping.href);
-            if (!freshVCard) {
-              throw new Error(`412 recovery failed: could not fetch vCard at ${mapping.href}`);
+            if (updateError.status === 412) {
+              // 412: fetch fresh ETag from server and retry once
+              log.warn({ personId: mapping.personId, href: mapping.href }, '412 Precondition Failed — refreshing ETag and retrying');
+              const freshVCard = await client.fetchVCard(addressBook, mapping.href);
+              if (!freshVCard) {
+                throw new Error(`412 recovery failed: could not fetch vCard at ${mapping.href}`);
+              }
+
+              vCard = { url: mapping.href, etag: freshVCard.etag, data: '' };
+              updated = await client.updateVCard(vCard, vCardData);
+            } else if (
+              updateError.status === 400 ||
+              updateError.status === 404 ||
+              updateError.status === 410
+            ) {
+              // Disambiguate via GET. Google's `carddav/v1` returns 400
+              // INVALID_ARGUMENT both for genuinely-bad bodies AND for PUTs
+              // against server-deleted resources, so we can't trust the
+              // status code alone. 404/410 are the spec-correct "gone"
+              // signals from other servers.
+              const recovery = await classifyUpdateFailure(
+                client,
+                addressBook,
+                mapping.href,
+                vCard.etag,
+              );
+              if (recovery.kind === 'gone') {
+                log.warn(
+                  { event: 'carddav.contact.gone', personId: mapping.personId, href: mapping.href },
+                  'CardDAV resource gone server-side; resetting mapping so next push creates a fresh contact',
+                );
+                await prisma.cardDavMapping.delete({ where: { id: mapping.id } });
+                await prisma.person.update({
+                  where: { id: mapping.personId },
+                  data: { uid: null },
+                });
+                recoveredAsGone = true;
+              } else if (recovery.kind === 'stale-etag') {
+                log.warn(
+                  { personId: mapping.personId, href: mapping.href },
+                  'Server returned a non-412 status with a moved ETag; refreshing and retrying',
+                );
+                vCard = { url: mapping.href, etag: recovery.freshEtag, data: '' };
+                updated = await client.updateVCard(vCard, vCardData);
+              } else {
+                throw updateError;
+              }
+            } else {
+              throw updateError;
             }
+          }
 
-            vCard = { url: mapping.href, etag: freshVCard.etag, data: '' };
-            updated = await client.updateVCard(vCard, vCardData);
+          if (recoveredAsGone) {
+            // Mapping is gone; skip the post-update bookkeeping below.
+            continue;
           }
 
           // Store the new etag
           await prisma.cardDavMapping.update({
             where: { id: mapping.id },
             data: {
-              etag: updated.etag,
+              etag: updated!.etag,
             },
           });
 

--- a/lib/carddav/update-recovery.ts
+++ b/lib/carddav/update-recovery.ts
@@ -1,0 +1,46 @@
+import type { AddressBook, CardDavClientInterface } from './client';
+
+/**
+ * Classification of an updateVCard failure, derived by re-fetching the
+ * resource and comparing what the server returns to our stored state.
+ *
+ * - `gone`         : server says the resource doesn't exist (e.g., user
+ *                    deleted the contact in Google Contacts). Caller should
+ *                    drop the local mapping so the next push runs as CREATE.
+ * - `stale-etag`   : the resource exists but its etag has moved on. Some
+ *                    servers (notably Google's `carddav/v1`) return 400
+ *                    INVALID_ARGUMENT instead of the spec-correct 412 in
+ *                    this case. Caller can retry the update with the fresh
+ *                    etag.
+ * - `unrecoverable`: the resource is present with the same etag we sent
+ *                    (i.e. the body itself was rejected), or the recovery
+ *                    GET failed. Caller should surface the original error.
+ */
+export type UpdateRecoveryResult =
+  | { kind: 'gone' }
+  | { kind: 'stale-etag'; freshEtag: string }
+  | { kind: 'unrecoverable' };
+
+export async function classifyUpdateFailure(
+  client: CardDavClientInterface,
+  addressBook: AddressBook,
+  href: string,
+  staleEtag: string,
+): Promise<UpdateRecoveryResult> {
+  let fresh;
+  try {
+    fresh = await client.fetchVCard(addressBook, href);
+  } catch {
+    return { kind: 'unrecoverable' };
+  }
+
+  if (!fresh) {
+    return { kind: 'gone' };
+  }
+
+  if (fresh.etag !== staleEtag) {
+    return { kind: 'stale-etag', freshEtag: fresh.etag };
+  }
+
+  return { kind: 'unrecoverable' };
+}

--- a/tests/lib/carddav/auto-export.test.ts
+++ b/tests/lib/carddav/auto-export.test.ts
@@ -17,11 +17,15 @@ const mocks = vi.hoisted(() => ({
   cardDavConnectionFindUnique: vi.fn(),
   cardDavConnectionUpdate: vi.fn(),
   cardDavMappingFindUnique: vi.fn(),
+  cardDavMappingFindMany: vi.fn(),
   cardDavMappingCreate: vi.fn(),
   cardDavMappingUpdate: vi.fn(),
+  cardDavMappingDelete: vi.fn(),
 
   // CardDAV client
   fetchAddressBooks: vi.fn(),
+  fetchVCards: vi.fn(),
+  fetchVCard: vi.fn(),
   createVCard: vi.fn(),
   updateVCard: vi.fn(),
 
@@ -48,8 +52,10 @@ vi.mock('@/lib/prisma', () => ({
     },
     cardDavMapping: {
       findUnique: mocks.cardDavMappingFindUnique,
+      findMany: mocks.cardDavMappingFindMany,
       create: mocks.cardDavMappingCreate,
       update: mocks.cardDavMappingUpdate,
+      delete: mocks.cardDavMappingDelete,
     },
   },
 }));
@@ -58,6 +64,8 @@ vi.mock('@/lib/carddav/client', () => ({
   createCardDavClient: vi.fn(() =>
     Promise.resolve({
       fetchAddressBooks: mocks.fetchAddressBooks,
+      fetchVCards: mocks.fetchVCards,
+      fetchVCard: mocks.fetchVCard,
       createVCard: mocks.createVCard,
       updateVCard: mocks.updateVCard,
     })
@@ -536,6 +544,99 @@ describe('CardDAV Auto-Export', () => {
         }),
         expect.any(String),
       );
+    });
+
+    it('resets the mapping when GET says the resource is gone after a 400', async () => {
+      const { ExternalServiceError } = await import('@/lib/errors');
+      mocks.cardDavMappingFindUnique.mockResolvedValue(makeMapping());
+      mocks.fetchAddressBooks.mockResolvedValue([
+        { url: 'https://carddav.example.com/addressbooks/default/', displayName: 'Contacts', raw: {} },
+      ]);
+      mocks.updateVCard.mockRejectedValueOnce(
+        new ExternalServiceError({
+          message: 'CardDAV UPDATE failed: 400 Bad Request',
+          service: 'carddav',
+          status: 400,
+          body: '{"error":{"status":"INVALID_ARGUMENT"}}',
+        }),
+      );
+      mocks.fetchVCard.mockResolvedValue(null);
+
+      await autoUpdatePerson(PERSON_ID);
+
+      expect(mocks.cardDavMappingDelete).toHaveBeenCalledWith({ where: { id: MAPPING_ID } });
+      expect(mocks.personUpdate).toHaveBeenCalledWith({
+        where: { id: PERSON_ID },
+        data: { uid: null },
+      });
+      // Should NOT update the mapping with synced status — it's gone
+      expect(mocks.cardDavMappingUpdate).not.toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ syncStatus: 'synced' }) }),
+      );
+    });
+
+    it('retries with fresh ETag when GET reveals the etag has moved on after a 400', async () => {
+      const { ExternalServiceError } = await import('@/lib/errors');
+      mocks.cardDavMappingFindUnique.mockResolvedValue(makeMapping());
+      mocks.fetchAddressBooks.mockResolvedValue([
+        { url: 'https://carddav.example.com/addressbooks/default/', displayName: 'Contacts', raw: {} },
+      ]);
+      mocks.updateVCard
+        .mockRejectedValueOnce(
+          new ExternalServiceError({
+            message: 'CardDAV UPDATE failed: 400 Bad Request',
+            service: 'carddav',
+            status: 400,
+          }),
+        )
+        .mockResolvedValueOnce({
+          url: 'https://carddav.example.com/contacts/existing-uid-123.vcf',
+          etag: 'after-refresh',
+          data: '',
+        });
+      mocks.fetchVCard.mockResolvedValue({
+        url: 'https://carddav.example.com/contacts/existing-uid-123.vcf',
+        etag: 'fresh-server-etag',
+        data: '',
+      });
+
+      await autoUpdatePerson(PERSON_ID);
+
+      expect(mocks.updateVCard).toHaveBeenCalledTimes(2);
+      expect(mocks.cardDavMappingDelete).not.toHaveBeenCalled();
+      // Final update should use the fresh etag
+      expect(mocks.cardDavMappingUpdate).toHaveBeenCalledWith({
+        where: { id: MAPPING_ID },
+        data: expect.objectContaining({
+          etag: 'after-refresh',
+          syncStatus: 'synced',
+        }),
+      });
+    });
+
+    it('rethrows when GET shows the same etag (genuine body issue)', async () => {
+      const { ExternalServiceError } = await import('@/lib/errors');
+      mocks.cardDavMappingFindUnique.mockResolvedValue(makeMapping());
+      mocks.fetchAddressBooks.mockResolvedValue([
+        { url: 'https://carddav.example.com/addressbooks/default/', displayName: 'Contacts', raw: {} },
+      ]);
+      mocks.updateVCard.mockRejectedValueOnce(
+        new ExternalServiceError({
+          message: 'CardDAV UPDATE failed: 400 Bad Request',
+          service: 'carddav',
+          status: 400,
+        }),
+      );
+      mocks.fetchVCard.mockResolvedValue({
+        url: 'https://carddav.example.com/contacts/existing-uid-123.vcf',
+        etag: 'etag-1', // matches mapping.etag
+        data: '',
+      });
+
+      await expect(autoUpdatePerson(PERSON_ID)).rejects.toThrow(
+        'CardDAV UPDATE failed: 400 Bad Request',
+      );
+      expect(mocks.cardDavMappingDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/lib/carddav/sync-domain-events.test.ts
+++ b/tests/lib/carddav/sync-domain-events.test.ts
@@ -172,6 +172,13 @@ describe('CardDAV sync domain events', () => {
       message: 'CardDAV UPDATE failed: 400 Bad Request',
       service: 'carddav', status: 400, body: '<error>bad</error>',
     }));
+    // Recovery path: GET returns the same etag we sent, so the failure is
+    // genuine (body issue) rather than a stale-etag/resource-gone case.
+    // This keeps the original test intent: a real failure should emit
+    // carddav.push.failed.
+    mocks.fetchVCard.mockResolvedValue({
+      url: 'https://carddav.example/ab/x.vcf', etag: '"e"', data: '',
+    });
     mocks.findManyPerson.mockResolvedValue([]);
 
     await syncToServer('u-1');

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => ({
   cardDavMappingFindMany: vi.fn(),
   cardDavMappingCreate: vi.fn(),
   cardDavMappingUpdate: vi.fn(),
+  cardDavMappingDelete: vi.fn(),
   cardDavPendingImportUpsert: vi.fn(),
   cardDavPendingImportFindMany: vi.fn(),
   cardDavPendingImportDeleteMany: vi.fn(),
@@ -66,6 +67,7 @@ vi.mock('@/lib/prisma', () => ({
       findMany: mocks.cardDavMappingFindMany,
       create: mocks.cardDavMappingCreate,
       update: mocks.cardDavMappingUpdate,
+      delete: mocks.cardDavMappingDelete,
     },
     cardDavPendingImport: {
       upsert: mocks.cardDavPendingImportUpsert,
@@ -1105,6 +1107,111 @@ describe('CardDAV Sync Engine', () => {
 
       // Should NOT attempt fetchVCard recovery
       expect(mocks.fetchVCard).not.toHaveBeenCalled();
+      expect(result.errors).toBe(1);
+      expect(result.updatedRemotely).toBe(0);
+    });
+
+    it("recovers from a 400 INVALID_ARGUMENT when GET says the resource is gone", async () => {
+      const mapping = makePendingMapping();
+
+      mocks.cardDavMappingFindMany
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([{ personId: mapping.personId }]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      // Update fails with the Google-style 400
+      mocks.updateVCard.mockRejectedValueOnce(
+        new ExternalServiceError({
+          message: 'CardDAV UPDATE failed: 400 Bad Request',
+          service: 'carddav',
+          status: 400,
+          body: '{"error":{"status":"INVALID_ARGUMENT"}}',
+        }),
+      );
+
+      // GET disambiguates: resource is gone server-side
+      mocks.fetchVCard.mockResolvedValue(null);
+
+      const result = await syncToServer(USER_ID);
+
+      expect(mocks.fetchVCard).toHaveBeenCalledWith(expect.anything(), mapping.href);
+      expect(mocks.cardDavMappingDelete).toHaveBeenCalledWith({ where: { id: mapping.id } });
+      expect(mocks.personUpdate).toHaveBeenCalledWith({
+        where: { id: mapping.personId },
+        data: { uid: null },
+      });
+      // Not counted as an error: it's a self-heal, not a failure to surface
+      expect(result.errors).toBe(0);
+      expect(result.updatedRemotely).toBe(0);
+    });
+
+    it("recovers from a 400 with a moved ETag by retrying with the fresh ETag", async () => {
+      const mapping = makePendingMapping();
+
+      mocks.cardDavMappingFindMany
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([{ personId: mapping.personId }]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      // First update fails with 400
+      mocks.updateVCard
+        .mockRejectedValueOnce(
+          new ExternalServiceError({
+            message: 'CardDAV UPDATE failed: 400 Bad Request',
+            service: 'carddav',
+            status: 400,
+          }),
+        )
+        // Retry succeeds
+        .mockResolvedValueOnce({
+          url: mapping.href,
+          etag: 'after-refresh-etag',
+          data: 'updated',
+        });
+
+      // GET reveals the etag has moved on
+      mocks.fetchVCard.mockResolvedValue({
+        url: mapping.href,
+        etag: 'fresh-server-etag',
+        data: '',
+      });
+
+      const result = await syncToServer(USER_ID);
+
+      expect(mocks.fetchVCard).toHaveBeenCalledTimes(1);
+      expect(mocks.updateVCard).toHaveBeenCalledTimes(2);
+      // Mapping was NOT deleted — just retried with fresh etag
+      expect(mocks.cardDavMappingDelete).not.toHaveBeenCalled();
+      expect(result.updatedRemotely).toBe(1);
+      expect(result.errors).toBe(0);
+    });
+
+    it("treats 400 with same ETag and existing resource as a real error (genuine body issue)", async () => {
+      const mapping = makePendingMapping();
+
+      mocks.cardDavMappingFindMany
+        .mockResolvedValueOnce([mapping])
+        .mockResolvedValueOnce([{ personId: mapping.personId }]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      mocks.updateVCard.mockRejectedValueOnce(
+        new ExternalServiceError({
+          message: 'CardDAV UPDATE failed: 400 Bad Request',
+          service: 'carddav',
+          status: 400,
+        }),
+      );
+
+      // GET shows resource exists with the same etag we sent
+      mocks.fetchVCard.mockResolvedValue({
+        url: mapping.href,
+        etag: mapping.etag, // same as stored
+        data: '',
+      });
+
+      const result = await syncToServer(USER_ID);
+
+      expect(mocks.cardDavMappingDelete).not.toHaveBeenCalled();
       expect(result.errors).toBe(1);
       expect(result.updatedRemotely).toBe(0);
     });

--- a/tests/lib/carddav/update-recovery.test.ts
+++ b/tests/lib/carddav/update-recovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { classifyUpdateFailure } from '@/lib/carddav/update-recovery';
+import type { AddressBook, CardDavClientInterface } from '@/lib/carddav/client';
+
+function makeClient(fetchVCardImpl: CardDavClientInterface['fetchVCard']): CardDavClientInterface {
+  return {
+    fetchAddressBooks: vi.fn(),
+    fetchVCards: vi.fn(),
+    fetchVCard: fetchVCardImpl,
+    createVCard: vi.fn(),
+    updateVCard: vi.fn(),
+    deleteVCard: vi.fn(),
+  };
+}
+
+const ADDRESS_BOOK: AddressBook = {
+  url: 'https://carddav.example.com/addressbooks/default/',
+  displayName: 'Contacts',
+  raw: {},
+} as AddressBook;
+
+describe('classifyUpdateFailure', () => {
+  it("returns 'gone' when the resource fetch returns null (404 server-side)", async () => {
+    const client = makeClient(vi.fn().mockResolvedValue(null));
+
+    const result = await classifyUpdateFailure(
+      client,
+      ADDRESS_BOOK,
+      'https://carddav.example.com/contacts/dead.vcf',
+      'stale-etag',
+    );
+
+    expect(result).toEqual({ kind: 'gone' });
+  });
+
+  it("returns 'stale-etag' with the fresh etag when the resource exists but etag differs", async () => {
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        url: 'https://carddav.example.com/contacts/alive.vcf',
+        etag: 'fresh-etag',
+        data: 'irrelevant',
+      }),
+    );
+
+    const result = await classifyUpdateFailure(
+      client,
+      ADDRESS_BOOK,
+      'https://carddav.example.com/contacts/alive.vcf',
+      'stale-etag',
+    );
+
+    expect(result).toEqual({ kind: 'stale-etag', freshEtag: 'fresh-etag' });
+  });
+
+  it("returns 'unrecoverable' when the resource exists with the same etag (genuine body issue)", async () => {
+    const client = makeClient(
+      vi.fn().mockResolvedValue({
+        url: 'https://carddav.example.com/contacts/alive.vcf',
+        etag: 'same-etag',
+        data: 'irrelevant',
+      }),
+    );
+
+    const result = await classifyUpdateFailure(
+      client,
+      ADDRESS_BOOK,
+      'https://carddav.example.com/contacts/alive.vcf',
+      'same-etag',
+    );
+
+    expect(result).toEqual({ kind: 'unrecoverable' });
+  });
+
+  it("returns 'unrecoverable' when fetchVCard itself throws (network or auth failure during recovery)", async () => {
+    const client = makeClient(vi.fn().mockRejectedValue(new Error('network down')));
+
+    const result = await classifyUpdateFailure(
+      client,
+      ADDRESS_BOOK,
+      'https://carddav.example.com/contacts/x.vcf',
+      'any-etag',
+    );
+
+    expect(result).toEqual({ kind: 'unrecoverable' });
+  });
+});


### PR DESCRIPTION
## Summary
- Servers (notably Google's `carddav/v1`) sometimes return `400 INVALID_ARGUMENT` for an UPDATE against a *deleted* resource instead of the spec-correct 412/404. Our sync treated this as permanent — the same dead URL got re-pushed indefinitely (one user accumulated ~50 hours of failed retries on a single contact).
- On 4xx statuses that plausibly signal a missing or stale resource (400/404/410), do a single GET to disambiguate. Three outcomes:
  - `gone` → drop the mapping + clear `person.uid` so the next push runs the CREATE flow with a fresh UUID
  - `stale-etag` → retry the UPDATE with the fresh etag (parallels the existing 412 path; covers Google's habit of returning 400 in place of 412)
  - `unrecoverable` → surface the original error as before
- Wired into both `syncToServer` and `autoUpdatePerson` via a small pure helper (`classifyUpdateFailure`) so the policy is testable in isolation. The existing 412 path is unchanged.
- New domain event `carddav.contact.gone` makes the self-heal observable without polluting the existing `carddav.push.failed` counter.

## Why narrow to 400/404/410
5xx and other 4xx (401/403/etc.) intentionally fall through to the existing error handler. Recovery only triggers for statuses that actually correspond to "the resource may not exist as we believe", so we don't risk deleting a mapping over a transient server hiccup.

## Test plan
- [x] New unit tests for `classifyUpdateFailure` (4 cases including the network-failure-during-recovery branch)
- [x] New integration tests in `sync.test.ts` and `auto-export.test.ts` (3 each: gone, stale-etag retry, unrecoverable rethrow)
- [x] Existing `carddav.push.failed` domain-event test updated to set up the unrecoverable path explicitly so its intent is preserved
- [x] `npx vitest run tests/lib/carddav/` — 280/280 passing
- [x] Lint clean on touched files
- [ ] Verify in prod against the originally-stuck contact after merge — expect to see one `carddav.contact.gone` log line, then a successful CREATE with a fresh UUID