### PR TITLE
fix(graph): photos render at default zoom, no more black-circle stub

### DIFF
--- a/components/UnifiedNetworkGraph.tsx
+++ b/components/UnifiedNetworkGraph.tsx
@@ -170,7 +170,7 @@ export default function UnifiedNetworkGraph({
     const isDark = document.documentElement.classList.contains('dark');
 
     // Request photos for nodes that will render at full LOD and are in viewport.
-    if (lod === 'full') {
+    if (lod !== 'dots') {
       const padPx = 64;
       for (const node of nodesRef.current) {
         if (node.kind !== 'person') continue;

--- a/components/graph/canvas-renderer.ts
+++ b/components/graph/canvas-renderer.ts
@@ -49,7 +49,6 @@ function nodeFontSize(node: SimulationNode, isMobile: boolean): number {
 
 function getNodeFill(node: SimulationNode, isDark: boolean): string {
   if (node.kind === 'bubble') return node.color ?? (isDark ? '#4b5563' : '#d1d5db');
-  if (node.photo) return isDark ? '#000000' : '#ffffff';
   if (node.isCenter) return '#3B82F6';
   if (node.colors.length > 0) return node.colors[0];
   return '#9CA3AF';
@@ -116,9 +115,20 @@ function drawNode(rc: RenderContext, node: SimulationNode): void {
   if (node.x === undefined || node.y === undefined) return;
   const r = nodeRadius(node, rc.isMobile);
 
+  // Resolve a loaded photo (if any) before painting the fill, so we can use
+  // a contrast background only when an image will actually be drawn over it.
+  const photoImage = rc.lod !== 'dots' && node.kind === 'person' && node.photo
+    ? rc.getPhoto(node.id)
+    : undefined;
+  const willDrawPhoto = photoImage !== undefined
+    && photoImage !== 'loading'
+    && photoImage !== 'error';
+
   rc.ctx.beginPath();
   rc.ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
-  rc.ctx.fillStyle = getNodeFill(node, rc.isDark);
+  rc.ctx.fillStyle = willDrawPhoto
+    ? (rc.isDark ? '#000000' : '#ffffff')
+    : getNodeFill(node, rc.isDark);
   rc.ctx.fill();
 
   if (rc.lod !== 'dots') {
@@ -127,16 +137,13 @@ function drawNode(rc: RenderContext, node: SimulationNode): void {
     rc.ctx.stroke();
   }
 
-  if (rc.lod === 'full' && node.kind === 'person' && node.photo) {
-    const entry = rc.getPhoto(node.id);
-    if (entry && entry !== 'loading' && entry !== 'error') {
-      rc.ctx.save();
-      rc.ctx.beginPath();
-      rc.ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
-      rc.ctx.clip();
-      rc.ctx.drawImage(entry, node.x - r, node.y - r, r * 2, r * 2);
-      rc.ctx.restore();
-    }
+  if (willDrawPhoto && photoImage instanceof HTMLImageElement) {
+    rc.ctx.save();
+    rc.ctx.beginPath();
+    rc.ctx.arc(node.x, node.y, r, 0, Math.PI * 2);
+    rc.ctx.clip();
+    rc.ctx.drawImage(photoImage, node.x - r, node.y - r, r * 2, r * 2);
+    rc.ctx.restore();
   }
 }
 


### PR DESCRIPTION
## Summary

Two issues from the bubble graph PR (#236) that combined to make photo nodes render as opaque black circles at default zoom:

1. **`getNodeFill` returned a dark/light "photo background" color whenever `node.photo` was set, regardless of whether the photo was actually being drawn over it.** Below full LOD the photo render path was skipped, so the dark fill stayed visible without anything on top — the user just saw black circles where their contacts' avatars should have been.

2. **The full-LOD threshold (`k >= 1.2`) was too eager.** Photos didn't load or render until the user zoomed in past ~120%. At default zoom (`k = 1`, LOD = `'labels'`) the dashboard was photo-less by design. That's not what users expect.

## Fix

- `drawNode` now resolves the photo cache entry first, then picks the fill — contrast background **only when** an image is about to be drawn over it. `getNodeFill` no longer special-cases `node.photo`.
- Photo loading and rendering now happen at any non-`'dots'` LOD (`k >= 0.6`). The very-zoomed-out tier still skips photos for performance.

## Why

Default-zoom photos are part of what makes the network feel like *people* and not data points. The black-circle regression was the kind of thing that immediately reads as "broken."

## Checklist

- [x] I've run tests locally — graph unit tests pass (35/35)
- [x] `npx tsc --noEmit` clean
- [x] No new translations needed (no user-facing strings touched)
- [x] No data model / migration changes

## Test plan

- [ ] Open `/dashboard` at default zoom — person nodes with photos should render their avatars (not black circles)
- [ ] Zoom out far (k < 0.6) — photos disappear; nodes render as dot-only (intended)
- [ ] Zoom in further — photos remain visible
- [ ] Lazy loading still works — DevTools Network panel shows `/api/photos/*` requests fired only for nodes in the viewport, only once each per session

## Notes

Touches `components/graph/canvas-renderer.ts` and `components/UnifiedNetworkGraph.tsx` only. Targeted fix; no other behavioral changes.