### PR TITLE
fix(graph): clone edges per recompose so forceLink sees fresh string ids

### DIFF
--- a/components/UnifiedNetworkGraph.tsx
+++ b/components/UnifiedNetworkGraph.tsx
@@ -381,13 +381,26 @@ export default function UnifiedNetworkGraph({
     });
 
     const rawEdges: SimulationEdge[] = raw.edges;
-    const incomingEdges = resolvedMode === 'bubbles'
+    const composedEdges = resolvedMode === 'bubbles'
       ? buildHubAndSpokeEdges({
           rawEdges,
           simNodes: incomingNodes,
           neutralEdgeColor: '#9ca3af',
         })
       : rawEdges;
+
+    // d3-force's forceLink mutates each edge's source/target from string ids
+    // to node-object references on the first sim build. If we reused those
+    // mutated edges on a later rebuild, forceLink would keep the stale refs
+    // (it skips resolution when source/target is already an object) — so the
+    // new simulation would move new node objects while edges still drew
+    // between the previous sim's node objects, leaving the visible
+    // disconnect from #240. Clone edges with string ids each time.
+    const incomingEdges: SimulationEdge[] = composedEdges.map((e) => ({
+      ...e,
+      source: typeof e.source === 'string' ? e.source : e.source.id,
+      target: typeof e.target === 'string' ? e.target : e.target.id,
+    }));
 
     const { nodes, edges } = diffSimulationData(nodesRef.current, incomingNodes, edgesRef.current, incomingEdges);
     nodesRef.current = nodes;


### PR DESCRIPTION
Closes #240.

## Summary

Toggling between **Show as groups** and **Show individuals** left nodes in the wrong positions, visibly disconnected from their edges, until the page was reloaded.

## Root cause

`d3-force`'s `forceLink` mutates each edge's `source` and `target` from string ids to node-object references when the simulation initializes. On subsequent rebuilds it skips that resolution — `if (typeof link.source !== "object") link.source = find(...)` — and keeps whatever object it already had.

The recompose pipeline cached raw edges from the API and reused them across sim rebuilds. After the *first* build, the cached edges held references to *those* node objects. After a mode toggle, `recomposeAndBuildSim` produced a brand new node set (via `diffSimulationData`'s spread) and a brand new simulation — but `forceLink` saw the existing object refs on the cached edges, kept them, and ran the new simulation's link force against the *previous* simulation's nodes.

Net effect: the new sim correctly nudged the new node objects, but the renderer painted edges between stale node references whose positions never updated. Hence "nodes try to move to the right positions but stop before they should be... disconnected from their edges."

## Fix

Right before passing edges into the new simulation, clone them with string-typed `source`/`target`. Every sim build now sees fresh string ids and resolves them against the current node set.

\`\`\`ts
const incomingEdges = composedEdges.map((e) => ({
  ...e,
  source: typeof e.source === 'string' ? e.source : e.source.id,
  target: typeof e.target === 'string' ? e.target : e.target.id,
}));
\`\`\`

Cheap one-pass clone. The original cached array is left alone.

## Checklist

- [x] Tests pass — `npx vitest run tests/unit/graph` (35/35)
- [x] `npx tsc --noEmit` clean
- [x] No new translations needed
- [x] No data model / migration changes

## Test plan

- [ ] Open dashboard with bubble mode active. Toggle to "Show individuals" — nodes settle into correct positions, edges connect them.
- [ ] Toggle back to "Show as groups" — bubbles render and edges connect them.
- [ ] Repeat toggle a few times — no visual drift.
- [ ] Filter pills work as before.

## Notes

> LLM-debugging physics is a huge pain in the ass, I've been there. My deepest condolences.

Honestly, in this case the physics was innocent — d3-force was holding object refs across rebuilds and we were handing it the same edge instances each time. Once you see it, it's obvious. Thanks for the clear repro steps.