### PR TITLE
fix(photos): downsize crops client-side and lift 10MB upload ceiling

### DIFF
--- a/app/api/people/[id]/photo/route.ts
+++ b/app/api/people/[id]/photo/route.ts
@@ -5,7 +5,7 @@ import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('people-photo');
 
-const MAX_UPLOAD_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50MB
 
 // POST /api/people/[id]/photo - Upload a person's photo
 export const POST = withAuth(async (request, session, context) => {
@@ -27,7 +27,7 @@ export const POST = withAuth(async (request, session, context) => {
 
     // Check file size before reading full buffer
     if (file.size > MAX_UPLOAD_SIZE) {
-      return apiResponse.error('Photo exceeds maximum size of 10MB');
+      return apiResponse.error(`Photo exceeds maximum size of ${MAX_UPLOAD_SIZE / (1024 * 1024)}MB`);
     }
 
     // Verify person exists and is owned by user

--- a/app/api/user/photo/route.ts
+++ b/app/api/user/photo/route.ts
@@ -5,7 +5,7 @@ import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('user-photo');
 
-const MAX_UPLOAD_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_UPLOAD_SIZE = 50 * 1024 * 1024; // 50MB
 const USER_PHOTO_ID = '_avatar';
 
 // POST /api/user/photo - Upload the logged-in user's photo
@@ -25,7 +25,7 @@ export const POST = withAuth(async (request, session) => {
     }
 
     if (file.size > MAX_UPLOAD_SIZE) {
-      return apiResponse.error('Photo exceeds maximum size of 10MB');
+      return apiResponse.error(`Photo exceeds maximum size of ${MAX_UPLOAD_SIZE / (1024 * 1024)}MB`);
     }
 
     const arrayBuffer = await file.arrayBuffer();

--- a/components/PhotoCropModal.tsx
+++ b/components/PhotoCropModal.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback } from 'react';
 import Cropper from 'react-easy-crop';
 import type { Area } from 'react-easy-crop';
 import { useTranslations } from 'next-intl';
+import { toast } from 'sonner';
 
 interface PhotoCropModalProps {
   imageSrc: string;
@@ -11,18 +12,34 @@ interface PhotoCropModalProps {
   onCancel: () => void;
 }
 
+// Server stores the photo at 256x256; 512 gives 2x headroom for retina displays
+// while keeping the upload payload small regardless of source resolution.
+const OUTPUT_SIZE = 512;
+const JPEG_QUALITY = 0.92;
+
+function canvasHasAlpha(ctx: CanvasRenderingContext2D, width: number, height: number): boolean {
+  const { data } = ctx.getImageData(0, 0, width, height);
+  for (let i = 3; i < data.length; i += 4) {
+    if (data[i] < 255) return true;
+  }
+  return false;
+}
+
+// imageSrc must be a same-origin data URL or blob URL — the alpha scan below
+// uses getImageData(), which throws SecurityError on cross-origin tainted canvases.
 async function getCroppedBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> {
   return new Promise((resolve, reject) => {
     const image = new Image();
     image.onload = () => {
       const canvas = document.createElement('canvas');
-      canvas.width = pixelCrop.width;
-      canvas.height = pixelCrop.height;
+      canvas.width = OUTPUT_SIZE;
+      canvas.height = OUTPUT_SIZE;
       const ctx = canvas.getContext('2d');
       if (!ctx) {
         reject(new Error('Could not get canvas context'));
         return;
       }
+      ctx.imageSmoothingQuality = 'high';
       ctx.drawImage(
         image,
         pixelCrop.x,
@@ -31,10 +48,14 @@ async function getCroppedBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> 
         pixelCrop.height,
         0,
         0,
-        pixelCrop.width,
-        pixelCrop.height
+        OUTPUT_SIZE,
+        OUTPUT_SIZE
       );
-      // Use PNG to preserve transparency; server will convert to JPEG if opaque
+      // Output JPEG by default for compact uploads; only fall back to PNG when
+      // the source actually has transparency (server does not need to convert).
+      const hasAlpha = canvasHasAlpha(ctx, OUTPUT_SIZE, OUTPUT_SIZE);
+      const mimeType = hasAlpha ? 'image/png' : 'image/jpeg';
+      const quality = hasAlpha ? undefined : JPEG_QUALITY;
       canvas.toBlob(
         (blob) => {
           if (blob) {
@@ -43,7 +64,8 @@ async function getCroppedBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> 
             reject(new Error('Failed to create blob from canvas'));
           }
         },
-        'image/png'
+        mimeType,
+        quality
       );
     };
     image.onerror = () => reject(new Error('Failed to load image'));
@@ -69,6 +91,7 @@ export default function PhotoCropModal({ imageSrc, onConfirm, onCancel }: PhotoC
       const blob = await getCroppedBlob(imageSrc, croppedAreaPixels);
       onConfirm(blob);
     } catch {
+      toast.error(t('uploadError'));
       setIsProcessing(false);
     }
   };

--- a/components/PhotoSourceModal.tsx
+++ b/components/PhotoSourceModal.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 
 const ALLOWED_PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-const MAX_PHOTO_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_PHOTO_SIZE = 50 * 1024 * 1024; // 50MB
 
 interface PhotoSourceModalProps {
   onSelect: (file: File) => void;

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -43,7 +43,7 @@ export default function ProfileForm({ userId, currentName, currentSurname, curre
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const ALLOWED_PHOTO_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
-  const MAX_PHOTO_SIZE = 10 * 1024 * 1024; // 10MB
+  const MAX_PHOTO_SIZE = 50 * 1024 * 1024; // 50MB
 
   const emailChanged = formData.email !== currentEmail;
 

--- a/lib/photo-storage.ts
+++ b/lib/photo-storage.ts
@@ -7,10 +7,15 @@ import { validateServerUrl } from '@/lib/carddav/url-validation';
 
 const log = createModuleLogger('photos');
 
-const MAX_PHOTO_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_PHOTO_SIZE = 50 * 1024 * 1024; // 50MB
 const PHOTO_SIZE = 256;
 const JPEG_QUALITY = 80;
 const FETCH_TIMEOUT_MS = 15000;
+// Bound decoded-pixel memory independently of byte size. Sharp's default
+// (268MP) is too generous: an attacker can craft a small file that decodes
+// into hundreds of MB of RGBA pixels. 100MP covers any realistic phone or
+// DSLR sensor (Hasselblad H6D-100c is ~100MP at the high end).
+const SHARP_MAX_INPUT_PIXELS = 100 * 1024 * 1024;
 
 /**
  * Atomically write data to filePath: write to a temp file in the same
@@ -192,12 +197,12 @@ export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasA
     throw new Error(`Photo exceeds maximum size of ${MAX_PHOTO_SIZE / (1024 * 1024)}MB`);
   }
 
-  const image = sharp(buffer)
+  const image = sharp(buffer, { limitInputPixels: SHARP_MAX_INPUT_PIXELS })
     .resize(PHOTO_SIZE, PHOTO_SIZE, { fit: 'cover' })
     .rotate(); // auto-rotate based on EXIF before stripping
 
   // Check if the source format has an alpha channel
-  const metadata = await sharp(buffer).metadata();
+  const metadata = await sharp(buffer, { limitInputPixels: SHARP_MAX_INPUT_PIXELS }).metadata();
   const hasAlpha = metadata.hasAlpha === true;
 
   if (hasAlpha) {

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1195,7 +1195,7 @@
       "uploadError": "Foto konnte nicht hochgeladen werden",
       "removeError": "Foto konnte nicht entfernt werden",
       "formatError": "Format nicht unterstützt. Verwende JPEG, PNG, GIF oder WebP.",
-      "sizeError": "Das Foto darf maximal 10 MB groß sein",
+      "sizeError": "Das Foto darf maximal 50 MB groß sein",
       "sourceTitle": "Foto hinzufügen",
       "dropzoneText": "Ziehen und ablegen, einfügen oder klicken zum Durchsuchen",
       "dropzoneActive": "Bild hier ablegen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1191,7 +1191,7 @@
       "uploadError": "Failed to upload photo",
       "removeError": "Failed to remove photo",
       "formatError": "Unsupported format. Use JPEG, PNG, GIF, or WebP.",
-      "sizeError": "Photo must be smaller than 10MB",
+      "sizeError": "Photo must be smaller than 50MB",
       "sourceTitle": "Add Photo",
       "dropzoneText": "Drag and drop, paste, or click to browse",
       "dropzoneActive": "Drop image here",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1195,7 +1195,7 @@
       "uploadError": "Error al subir la foto",
       "removeError": "Error al eliminar la foto",
       "formatError": "Formato no soportado. Usa JPEG, PNG, GIF o WebP.",
-      "sizeError": "La foto debe ser menor de 10MB",
+      "sizeError": "La foto debe ser menor de 50MB",
       "sourceTitle": "Agregar foto",
       "dropzoneText": "Arrastra y suelta, pega o haz clic para buscar",
       "dropzoneActive": "Suelta la imagen aquí",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -1195,7 +1195,7 @@
       "uploadError": "写真のアップロードに失敗しました",
       "removeError": "写真の削除に失敗しました",
       "formatError": "サポートされていない形式です。JPEG、PNG、GIF、またはWebPを使用してください。",
-      "sizeError": "写真は10MB以下にしてください",
+      "sizeError": "写真は50MB以下にしてください",
       "sourceTitle": "写真を追加",
       "dropzoneText": "ドラッグ＆ドロップ、貼り付け、またはクリックして参照",
       "dropzoneActive": "ここに画像をドロップ",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -1195,7 +1195,7 @@
       "uploadError": "Kunne ikke laste opp bilde",
       "removeError": "Kunne ikke fjerne bilde",
       "formatError": "Format ikke støttet. Bruk JPEG, PNG, GIF eller WebP.",
-      "sizeError": "Bildet må være mindre enn 10 MB",
+      "sizeError": "Bildet må være mindre enn 50 MB",
       "sourceTitle": "Legg til bilde",
       "dropzoneText": "Dra og slipp, lim inn eller klikk for å bla",
       "dropzoneActive": "Slipp bildet her",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1195,7 +1195,7 @@
       "uploadError": "上传照片失败",
       "removeError": "移除照片失败",
       "formatError": "不支持的格式。使用 JPEG、PNG、GIF 或 WebP。",
-      "sizeError": "照片必须小于 10MB",
+      "sizeError": "照片必须小于 50MB",
       "sourceTitle": "添加照片",
       "dropzoneText": "拖放、粘贴或单击以浏览",
       "dropzoneActive": "在此处放置图像",

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,13 @@ const nextConfig: NextConfig = {
   // Production optimization
   output: process.env.NODE_ENV === 'production' ? 'standalone' : undefined,
 
+  // Next 16's default proxyClientMaxBodySize is 10MB. Bodies larger than the
+  // limit are silently truncated, which breaks multipart parsing for photo
+  // uploads from high-resolution sources. Raise to match our 50MB upload cap.
+  experimental: {
+    proxyClientMaxBodySize: '50mb',
+  },
+
   // Logging configuration
   logging: {
     fetches: {

--- a/tests/api/people-photo.test.ts
+++ b/tests/api/people-photo.test.ts
@@ -118,18 +118,18 @@ describe('People Photo API', () => {
       expect(body.error).toContain('No photo file provided');
     });
 
-    it('should return 400 when photo exceeds 10MB', async () => {
+    it('should return 400 when photo exceeds 50MB', async () => {
       mocks.personFindUnique.mockResolvedValue({ id: 'person-1' });
 
-      // Create a blob that reports a size > 10MB
-      const largeBuffer = new ArrayBuffer(10 * 1024 * 1024 + 1);
+      // Create a blob that reports a size > 50MB
+      const largeBuffer = new ArrayBuffer(50 * 1024 * 1024 + 1);
       const file = new Blob([largeBuffer], { type: 'image/jpeg' });
       const { request, context } = createFormDataRequest('person-1', file);
       const response = await POST(request, context);
       const body = await response.json();
 
       expect(response.status).toBe(400);
-      expect(body.error).toContain('10MB');
+      expect(body.error).toContain('50MB');
     });
 
     it('should return 404 for non-existent person', async () => {

--- a/tests/components/PhotoSourceModal.test.tsx
+++ b/tests/components/PhotoSourceModal.test.tsx
@@ -97,14 +97,14 @@ describe('PhotoSourceModal', () => {
     expect(toast.error).toHaveBeenCalled();
   });
 
-  it('rejects files exceeding 10MB', () => {
+  it('rejects files exceeding 50MB', () => {
     render(
       <Wrapper>
         <PhotoSourceModal onSelect={mockOnSelect} onClose={mockOnClose} />
       </Wrapper>
     );
 
-    const file = createFile('big.png', 'image/png', 11 * 1024 * 1024);
+    const file = createFile('big.png', 'image/png', 51 * 1024 * 1024);
     const input = document.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(input, { target: { files: [file] } });
 

--- a/tests/lib/photo-storage.test.ts
+++ b/tests/lib/photo-storage.test.ts
@@ -119,9 +119,9 @@ describe('processPhoto', () => {
     await expect(processPhoto(textBuf)).rejects.toThrow('Unsupported image format');
   });
 
-  it('should reject buffers exceeding 10MB', async () => {
-    // Create a buffer with JPEG magic bytes but over 10MB
-    const oversized = Buffer.alloc(10 * 1024 * 1024 + 1);
+  it('should reject buffers exceeding 50MB', async () => {
+    // Create a buffer with JPEG magic bytes but over 50MB
+    const oversized = Buffer.alloc(50 * 1024 * 1024 + 1);
     oversized[0] = 0xFF;
     oversized[1] = 0xD8;
     oversized[2] = 0xFF;


### PR DESCRIPTION
## Summary

Closes #198 and #204. Two symptoms, one root cause:

- **#198** — DSLR JPEGs (12–24 MB) rejected at the file picker by a hard 10 MB client check.
- **#204** — A 5.9 MB JPEG fails after cropping with `Request body exceeded 10MB for /api/people/.../photo`. The crop modal rendered the full cropped region (e.g. ~12MP) to a canvas and exported it as PNG, which inflates dramatically. The resulting body exceeded Next 16's default `proxyClientMaxBodySize` (10 MB), which **silently truncates** the multipart body — the server then sees malformed form-data and returns 400.

## Fix

- **`PhotoCropModal`** — always emit a 512×512 canvas (server stores 256×256; 2× headroom for retina). Default to JPEG q=0.92, fall back to PNG only when the canvas pixels actually have alpha. Surface a toast on failure instead of swallowing it.
- Raise the source-file cap from **10 MB → 50 MB** across `PhotoSourceModal`, `ProfileForm`, `lib/photo-storage`, and both photo route handlers. Error strings derive the limit from the constant.
- **`next.config.ts`** — add `experimental.proxyClientMaxBodySize: '50mb'` so the runtime stops truncating bodies at 10 MB.
- **Defense-in-depth on the vCard import path** — bound sharp's decoded-pixel memory with `limitInputPixels = 100MP`. Byte size is a poor proxy for decoded RGBA memory; this caps even small-file/huge-decode attacks.
- Update `sizeError` translations in all six locales (en, es-ES, de-DE, ja-JP, nb-NO, zh-CN).
- Update three test files that hard-coded the old 10 MB limit.

## Test plan

- [x] All 1995 vitest tests pass (16 skipped — Redis/DB integration only)
- [x] `tsc --noEmit` clean for all touched files
- [x] Manual browser test: upload large JPEG, crop, save — round-trip works end-to-end

## Notes

- The client now downsizes aggressively before upload, so the server's 50 MB cap is essentially defensive (only matters for direct API callers).
- The `limitInputPixels = 100MP` cap covers Hasselblad H6D-100c on the high end — should not affect any realistic phone or DSLR sensor.