### PR TITLE
fix(dates): preserve calendar date across timezones (closes #218)

### DIFF
--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -396,21 +396,25 @@ export default async function PersonDetailsPage({
                     </div>
                   )}
 
-                  {person.anniversary && (
-                    <div>
-                      <h4 className="text-sm font-medium text-muted mb-1">
-                        {t('anniversary')}
-                      </h4>
-                      <p className="text-foreground">
-                        {formatDate(new Date(person.anniversary), dateFormat)}
-                        {getYearsAgo(new Date(person.anniversary), t) && (
-                          <span className="text-sm text-muted ml-1">
-                            ({getYearsAgo(new Date(person.anniversary), t)})
-                          </span>
-                        )}
-                      </p>
-                    </div>
-                  )}
+                  {person.anniversary && (() => {
+                    const anniversaryDate = parseAsLocalDate(person.anniversary.toISOString());
+                    const yearsAgo = getYearsAgo(anniversaryDate, t);
+                    return (
+                      <div>
+                        <h4 className="text-sm font-medium text-muted mb-1">
+                          {t('anniversary')}
+                        </h4>
+                        <p className="text-foreground">
+                          {formatDate(anniversaryDate, dateFormat)}
+                          {yearsAgo && (
+                            <span className="text-sm text-muted ml-1">
+                              ({yearsAgo})
+                            </span>
+                          )}
+                        </p>
+                      </div>
+                    );
+                  })()}
 
                   <LastContactQuickUpdate
                     personId={person.id}

--- a/components/LastContactQuickUpdate.tsx
+++ b/components/LastContactQuickUpdate.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
-import { formatDate, type DateFormat } from '@/lib/date-format';
+import { formatDate, getLocalDateString, parseAsLocalDate, type DateFormat } from '@/lib/date-format';
 
 function getRelativeTime(
   date: Date,
@@ -49,11 +49,10 @@ export default function LastContactQuickUpdate({
   const [isLoading, setIsLoading] = useState(false);
 
   async function handleContactedToday() {
-    const today = new Date().toISOString().split('T')[0];
+    const today = getLocalDateString();
     const previousValue = lastContact;
 
-    // Optimistic update
-    setLastContact(new Date().toISOString());
+    setLastContact(today);
     setIsLoading(true);
 
     try {
@@ -78,7 +77,7 @@ export default function LastContactQuickUpdate({
     }
   }
 
-  const parsedDate = lastContact ? new Date(lastContact) : null;
+  const parsedDate = lastContact ? parseAsLocalDate(lastContact) : null;
   const isToday = !isLoading && parsedDate && Math.floor(Math.abs(new Date().getTime() - parsedDate.getTime()) / (1000 * 60 * 60 * 24)) === 0;
 
   return (

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -396,7 +396,7 @@ export default function PeopleListClient({
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-                      {person.lastContact ? formatDate(new Date(person.lastContact), dateFormat) : '\u2014'}
+                      {person.lastContact ? formatDate(person.lastContact, dateFormat) : '\u2014'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
                       <div className="flex justify-end gap-3">

--- a/components/person-form/LastContactSection.tsx
+++ b/components/person-form/LastContactSection.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from 'next-intl';
 import DatePicker from '../ui/DatePicker';
+import { getLocalDateString } from '@/lib/date-format';
 import type { FormData } from '../../hooks/usePersonForm';
 
 type ReminderIntervalUnit = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
@@ -41,7 +42,7 @@ export default function LastContactSection({
         onChange={(val) => onFormDataChange({ lastContact: val })}
         dateFormat={dateFormat}
         showTodayButton
-        maxDate={new Date().toISOString().split('T')[0]}
+        maxDate={getLocalDateString()}
       />
       {formData.lastContact && (
         <button

--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -366,13 +366,17 @@ function formatFullName(person: PersonWithRelations): string {
 }
 
 /**
- * Format date for vCard 3.0 (YYYYMMDD or --MMDD for year-omitted)
+ * Format date for vCard 3.0 (YYYYMMDD or --MMDD for year-omitted).
+ *
+ * Uses UTC accessors because Nametag stores calendar dates as UTC-midnight
+ * DateTime values. Reading them with local-time `getDate()` would shift the
+ * day west of UTC.
  */
 export function formatVCardV3Date(date: Date): string {
   const d = new Date(date);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
+  const year = d.getUTCFullYear();
+  const month = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
 
   // If year is 1604 or earlier, omit it (year unknown - Apple uses 1604 as marker)
   if (year <= 1604) {

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -1,20 +1,42 @@
 export type DateFormat = 'MDY' | 'DMY' | 'YMD';
 
 /**
- * Parse a date string or Date object as a local date, avoiding timezone issues.
- * Date-only strings (YYYY-MM-DD) are parsed as local dates instead of UTC.
+ * Parse a date-only value as a Date anchored at local midnight on the encoded
+ * calendar day. Accepts `YYYY-MM-DD` and ISO datetime strings (where only the
+ * date prefix is meaningful — Nametag stores calendar dates as UTC-midnight
+ * DateTime values, which would otherwise shift west of UTC under `getDate()`).
+ * Date objects pass through unchanged; for real timestamps use `formatDateTime`.
  */
 export function parseAsLocalDate(date: Date | string): Date {
   if (typeof date === 'string') {
-    // Parse date-only strings (YYYY-MM-DD) as local dates to avoid timezone issues
     const dateOnlyPattern = /^\d{4}-\d{2}-\d{2}$/;
     if (dateOnlyPattern.test(date)) {
       const [year, month, day] = date.split('-').map(Number);
       return new Date(year, month - 1, day);
     }
+    // ISO datetime: take the date part and anchor it locally so the calendar
+    // day is preserved across timezones.
+    const isoDatePrefixPattern = /^(\d{4})-(\d{2})-(\d{2})T/;
+    const match = isoDatePrefixPattern.exec(date);
+    if (match) {
+      const [, year, month, day] = match;
+      return new Date(Number(year), Number(month) - 1, Number(day));
+    }
     return new Date(date);
   }
   return date;
+}
+
+/**
+ * Today's calendar date in the viewer's local timezone, as `YYYY-MM-DD`.
+ * Use instead of `new Date().toISOString().split('T')[0]`, which is UTC and
+ * rolls forward after UTC midnight for users west of UTC.
+ */
+export function getLocalDateString(date: Date = new Date()): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 export function formatDate(date: Date | string, format: DateFormat): string {

--- a/tests/components/LastContactQuickUpdate.test.tsx
+++ b/tests/components/LastContactQuickUpdate.test.tsx
@@ -163,7 +163,8 @@ describe('LastContactQuickUpdate', () => {
     const callBody = JSON.parse(
       (calls[0][1] as RequestInit).body as string
     );
-    const today = new Date().toISOString().split('T')[0];
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
     expect(callBody.lastContact).toBe(today);
 
     // Should show success toast

--- a/tests/lib/carddav/vcard-parser.test.ts
+++ b/tests/lib/carddav/vcard-parser.test.ts
@@ -362,9 +362,11 @@ END:VCARD`;
       expect(parsed.importantDates).toHaveLength(1);
       expect(parsed.importantDates[0].type).toBe('birthday');
       expect(parsed.importantDates[0].title).toBe('');
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(1990);
-      expect(parsed.importantDates[0].date.getMonth()).toBe(4); // May (0-indexed)
-      expect(parsed.importantDates[0].date.getDate()).toBe(15);
+      // Parsed dates are UTC-midnight (matching the API storage convention),
+      // so assertions must use UTC accessors to be timezone-independent.
+      expect(parsed.importantDates[0].date.getUTCFullYear()).toBe(1990);
+      expect(parsed.importantDates[0].date.getUTCMonth()).toBe(4); // May (0-indexed)
+      expect(parsed.importantDates[0].date.getUTCDate()).toBe(15);
     });
 
     it('should parse BDAY with year-omitted (v4 format)', () => {

--- a/tests/lib/date-format.test.ts
+++ b/tests/lib/date-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatDateWithoutYear, getDateFormatLabel, getDateFormatExample, parseAsLocalDate } from '@/lib/date-format';
+import { formatDate, formatDateWithoutYear, getDateFormatLabel, getDateFormatExample, getLocalDateString, parseAsLocalDate } from '@/lib/date-format';
 
 describe('date-format', () => {
   describe('parseAsLocalDate', () => {
@@ -49,11 +49,32 @@ describe('date-format', () => {
     });
 
     describe('with ISO datetime strings', () => {
-      it('should parse full ISO datetime string normally', () => {
-        const isoString = '2024-12-25T10:30:00.000Z';
-        const result = parseAsLocalDate(isoString);
-        // Should parse as UTC datetime
-        expect(result.toISOString()).toBe(isoString);
+      it('extracts the date prefix and anchors it locally (issue #218)', () => {
+        // Date-only fields are stored as UTC midnight; when round-tripped
+        // through the API as full ISO they must still display as the original
+        // calendar date in any timezone. Asserting via local components: in a
+        // pre-fix world a Phoenix viewer would see Dec 24 here.
+        const result = parseAsLocalDate('2024-12-25T00:00:00.000Z');
+        expect(result.getFullYear()).toBe(2024);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(25);
+      });
+
+      it('uses the date prefix even when the ISO carries a non-zero time', () => {
+        const result = parseAsLocalDate('2024-12-25T10:30:00.000Z');
+        expect(result.getFullYear()).toBe(2024);
+        expect(result.getMonth()).toBe(11);
+        expect(result.getDate()).toBe(25);
+      });
+    });
+
+    describe('issue #218 regression — lastContact display', () => {
+      it('formats a UTC-midnight ISO consistently with formatDate', () => {
+        // The server returns lastContact as UTC midnight ISO; formatting it
+        // must yield the calendar date encoded in the prefix.
+        expect(formatDate('2026-04-30T00:00:00.000Z', 'YMD')).toBe('2026-04-30');
+        expect(formatDate('2026-04-30T00:00:00.000Z', 'MDY')).toBe('04/30/2026');
+        expect(formatDate('2026-04-30T00:00:00.000Z', 'DMY')).toBe('30/04/2026');
       });
     });
 
@@ -196,6 +217,26 @@ describe('date-format', () => {
     it('should return default label for unknown format', () => {
       // TypeScript would prevent this, but testing runtime behavior
       expect(getDateFormatLabel('UNKNOWN' as 'MDY')).toBe('MM/DD/YYYY');
+    });
+  });
+
+  describe('getLocalDateString', () => {
+    it('returns the supplied date as YYYY-MM-DD using local components', () => {
+      // Constructed with local components so the result is independent of the
+      // host timezone — pre-fix code used UTC and would shift after midnight.
+      expect(getLocalDateString(new Date(2026, 3, 30))).toBe('2026-04-30');
+    });
+
+    it('zero-pads single-digit months and days', () => {
+      expect(getLocalDateString(new Date(2026, 0, 5))).toBe('2026-01-05');
+    });
+
+    it('defaults to today', () => {
+      const result = getLocalDateString();
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+      const now = new Date();
+      const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+      expect(result).toBe(expected);
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes #218: in timezones west of UTC (e.g. America/Phoenix), the profile's "last contact" was rendering one day back, and the profile's "Update to today" button was saving tomorrow's date in the evening — both effects compounded so the edit form appeared a day ahead of the profile display.
- Same root cause turned out to also affect anniversary display on the person detail page and vCard export (`BDAY:YYYYMMDD` was emitted with a day-shifted value west of UTC).

## What changed

**Display (root cause for #218).** Nametag stores calendar dates (`lastContact`, `anniversary`, `ImportantDate.date`) as DateTime values at UTC midnight; the API serialises them as full ISO strings. Several display sites read them as `formatDate(new Date(person.lastContact), …)`, which uses local `getDate()` and shifts the day for users west of UTC.

- `lib/date-format.ts` — `parseAsLocalDate` now also extracts the `YYYY-MM-DD` prefix from ISO datetime strings and anchors it locally, so a UTC-midnight ISO renders as the encoded calendar day in any zone. Added `getLocalDateString()` helper for computing today in the viewer's timezone.
- `components/LastContactQuickUpdate.tsx` — local "today" instead of UTC; display via `parseAsLocalDate`.
- `components/PeopleListClient.tsx`, `components/person-form/LastContactSection.tsx`, `app/people/[id]/page.tsx` — display sites updated to flow through `parseAsLocalDate`/`getLocalDateString`.

**Storage (#218 evening case).** `LastContactQuickUpdate` and `LastContactSection` previously computed today as `new Date().toISOString().split('T')[0]`. After UTC midnight (≈5pm Phoenix), this resolved to tomorrow. Replaced with the new `getLocalDateString()`.

**vCard export (latent timezone bug found while reviewing).** `formatVCardV3Date` extracted day/month/year via local accessors on UTC-midnight Dates, drifting the BDAY value. Switched to UTC accessors so the stored calendar date round-trips correctly through CardDAV in any server timezone. Updated one parser test that asserted via local accessors to use UTC accessors (the parser already produces UTC-midnight Dates, matching storage convention — the test was just zone-dependent).

## Test plan

- [x] `npx vitest run` — 2000 passed, 0 failed.
- [x] `TZ=America/Phoenix npx vitest run` — 2000 passed, 0 failed (was 5 failing on `master` due to the latent vCard bug).
- [x] Added regression tests in `tests/lib/date-format.test.ts` covering `formatDate('2026-04-30T00:00:00.000Z', …)` and `getLocalDateString`, plus a parseAsLocalDate test referencing issue #218.
- [x] Replaced `tests/components/LastContactQuickUpdate.test.tsx` assertion that computed expected "today" via `toISOString` (the same antipattern as the bug) with a local-component computation.
- [x] Typecheck and ESLint clean for all changed files.
- [ ] Manual smoke-test in a browser with the system timezone set to America/Phoenix:
  - [ ] Create a person, set Last contact to today via the edit form → profile shows the same day.
  - [ ] Click "Update to today" in the profile after 5pm local → both the profile and the edit form show today.
  - [ ] Set an anniversary on a stored person → renders the same calendar day on profile.