### PR TITLE
fix(important-dates): show reminder limit message and rename Memorial to Date of Death

### DIFF
--- a/components/ImportantDatesManager.tsx
+++ b/components/ImportantDatesManager.tsx
@@ -247,13 +247,11 @@ export default function ImportantDatesManager({
     onChange,
     idPrefix,
     canEnable,
-    limitMessage,
   }: {
     date: ImportantDate;
     onChange: (updates: Partial<ImportantDate>) => void;
     idPrefix: string;
     canEnable: boolean;
-    limitMessage?: string;
   }) => {
     const isFuture = isDateInFuture(date.date);
     // Can toggle on if: already enabled (to disable) OR canEnable is true
@@ -290,9 +288,9 @@ export default function ImportantDatesManager({
             {t('remindMe')}
           </label>
         </div>
-        {!canToggle && limitMessage && (
+        {!canToggle && reminderLimit && !reminderLimit.isUnlimited && (
           <p className="text-xs text-amber-600 dark:text-amber-400 mb-3">
-            {t('reminderLimitReached', { limit: reminderLimit?.limit ?? 0 })}
+            {t('reminderLimitReached', { limit: reminderLimit.limit })}
           </p>
         )}
 

--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -106,7 +106,7 @@ export function personToVCard(
   // Map predefined types without vCard mapping to English display names for export
   const EXPORT_LABELS: Record<string, string> = {
     nameday: 'Name day',
-    memorial: 'Memorial',
+    memorial: 'Date of Death',
   };
 
   // Other dates - everything except birthday and anniversary

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -946,7 +946,7 @@
           "birthday": "Geburtstag",
           "anniversary": "Jahrestag",
           "nameday": "Namenstag",
-          "memorial": "Gedenktag",
+          "memorial": "Todestag",
           "other": "Andere"
         }
       },

--- a/locales/en.json
+++ b/locales/en.json
@@ -946,7 +946,7 @@
           "birthday": "Birthday",
           "anniversary": "Anniversary",
           "nameday": "Name day",
-          "memorial": "Memorial",
+          "memorial": "Date of Death",
           "other": "Other"
         }
       },

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -946,7 +946,7 @@
           "birthday": "Cumpleaños",
           "anniversary": "Aniversario",
           "nameday": "Día del santo",
-          "memorial": "Memorial",
+          "memorial": "Fecha de fallecimiento",
           "other": "Otro"
         }
       },

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -946,7 +946,7 @@
           "birthday": "誕生日",
           "anniversary": "記念日",
           "nameday": "名前の日",
-          "memorial": "追悼日",
+          "memorial": "命日",
           "other": "その他"
         }
       },

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -946,7 +946,7 @@
           "birthday": "Bursdag",
           "anniversary": "Jubileum",
           "nameday": "Navnedag",
-          "memorial": "Minnedag",
+          "memorial": "Dødsdato",
           "other": "Annet"
         }
       },

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -946,7 +946,7 @@
           "birthday": "生日",
           "anniversary": "周年纪念",
           "nameday": "命名日",
-          "memorial": "追悼纪念日",
+          "memorial": "忌日",
           "other": "其他"
         }
       },


### PR DESCRIPTION
## Summary

Addresses the concerns raised in #203:

- **Reminder limit message now renders.** In `ImportantDatesManager`, the "Reminder limit reached" warning was guarded by an unused `limitMessage` prop that was never passed in, so users on a tiered plan saw a disabled toggle with no explanation. Replaced the dead check with the same `reminderLimit && !reminderLimit.isUnlimited` pattern used by `LastContactSection`. This is likely the root of the reporter's confusion that "reminders only work for predefined types" — the toggle was being disabled by the quota, not by the type.
- **Renamed the `memorial` predefined date type label to "Date of Death"** across all six locales (en, es-ES, de-DE, ja-JP, nb-NO, zh-CN) and in the CardDAV X-ABLabel export. The internal type key stays as `memorial` so existing data and logic are unaffected.

The reporter also asked for a "Wedding Anniversary" predefined type, but the existing `anniversary` type already covers that — left out of this PR.

## Test plan

- [ ] Open a person edit page on a plan that limits reminders, max out the reminders, and confirm the "Reminder limit reached" warning shows under the disabled toggle in the important-dates section.
- [ ] Confirm "Date of Death" appears in the predefined-types dropdown on the important-dates form (and the localized equivalent in each language).
- [ ] Export a contact with a `memorial` date via CardDAV and verify the X-ABLabel reads "Date of Death".
- [ ] `npx vitest run` — all tests still pass.

Closes #203