### PR TITLE
fix(people-merge): preserve journal entry references when merging contacts

### DIFF
--- a/lib/services/person.ts
+++ b/lib/services/person.ts
@@ -732,6 +732,31 @@ export async function mergePeople(
       });
     }
 
+    // (d2) Re-parent journal entry references; remove any that would collide
+    // with an existing target reference (the join has @@unique on
+    // [journalEntryId, personId]). Without this step, the source's join rows
+    // remain pointing at a soft-deleted person and disappear from the journal
+    // UI, which filters out people with deletedAt set.
+    const targetJournalRefs = await tx.journalEntryPerson.findMany({
+      where: { personId: targetId },
+      select: { journalEntryId: true },
+    });
+    const targetJournalEntryIds = targetJournalRefs.map((r) => r.journalEntryId);
+
+    if (targetJournalEntryIds.length > 0) {
+      await tx.journalEntryPerson.deleteMany({
+        where: {
+          personId: sourceId,
+          journalEntryId: { in: targetJournalEntryIds },
+        },
+      });
+    }
+
+    await tx.journalEntryPerson.updateMany({
+      where: { personId: sourceId },
+      data: { personId: targetId },
+    });
+
     // (e) Delete source's CardDAV mapping
     await tx.cardDavMapping.deleteMany({ where: { personId: sourceId } });
 

--- a/tests/lib/services/person.test.ts
+++ b/tests/lib/services/person.test.ts
@@ -775,6 +775,9 @@ describe('mergePeople', () => {
     mocks.mockTxClient.personCustomField.deleteMany.mockResolvedValue({ count: 0 });
     mocks.mockTxClient.importantDate.updateMany.mockResolvedValue({ count: 0 });
     mocks.mockTxClient.importantDate.deleteMany.mockResolvedValue({ count: 0 });
+    // Default: target has no existing journal references → updateMany still
+    // runs unconditionally, but deleteMany is skipped. Tests that exercise
+    // the collision path override findMany per-test.
     mocks.mockTxClient.journalEntryPerson.findMany.mockResolvedValue([]);
     mocks.mockTxClient.journalEntryPerson.updateMany.mockResolvedValue({ count: 0 });
     mocks.mockTxClient.journalEntryPerson.deleteMany.mockResolvedValue({ count: 0 });
@@ -970,6 +973,7 @@ describe('mergePeople', () => {
   it('re-parents source journal entry references to target', async () => {
     await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
 
+    expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledTimes(1);
     expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledWith({
       where: { personId: SOURCE_ID },
       data: { personId: PERSON_ID },
@@ -984,16 +988,24 @@ describe('mergePeople', () => {
 
     await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
 
+    expect(mocks.mockTxClient.journalEntryPerson.deleteMany).toHaveBeenCalledTimes(1);
     expect(mocks.mockTxClient.journalEntryPerson.deleteMany).toHaveBeenCalledWith({
       where: {
         personId: SOURCE_ID,
         journalEntryId: { in: ['je-1', 'je-2'] },
       },
     });
+    expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledTimes(1);
     expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledWith({
       where: { personId: SOURCE_ID },
       data: { personId: PERSON_ID },
     });
+
+    // Order matters: the bare updateMany would throw P2002 on the
+    // (journalEntryId, personId) unique constraint if it ran before delete.
+    const deleteOrder = mocks.mockTxClient.journalEntryPerson.deleteMany.mock.invocationCallOrder[0];
+    const updateOrder = mocks.mockTxClient.journalEntryPerson.updateMany.mock.invocationCallOrder[0];
+    expect(deleteOrder).toBeLessThan(updateOrder);
   });
 
   it('does not delete journal references when target has none', async () => {

--- a/tests/lib/services/person.test.ts
+++ b/tests/lib/services/person.test.ts
@@ -30,6 +30,9 @@ const mocks = vi.hoisted(() => {
   const personCustomFieldDeleteMany = vi.fn();
   const importantDateUpdateMany = vi.fn();
   const importantDateDeleteMany = vi.fn();
+  const journalEntryPersonFindMany = vi.fn();
+  const journalEntryPersonUpdateMany = vi.fn();
+  const journalEntryPersonDeleteMany = vi.fn();
   const withDeletedPersonFindUnique = vi.fn();
   const withDeletedPersonUpdate = vi.fn();
   const withDeletedDisconnect = vi.fn();
@@ -49,6 +52,11 @@ const mocks = vi.hoisted(() => {
     personLocation: { updateMany: personLocationUpdateMany, deleteMany: personLocationDeleteMany },
     personCustomField: { updateMany: personCustomFieldUpdateMany, deleteMany: personCustomFieldDeleteMany },
     importantDate: { updateMany: importantDateUpdateMany, deleteMany: importantDateDeleteMany },
+    journalEntryPerson: {
+      findMany: journalEntryPersonFindMany,
+      updateMany: journalEntryPersonUpdateMany,
+      deleteMany: journalEntryPersonDeleteMany,
+    },
   };
 
   return {
@@ -76,6 +84,9 @@ const mocks = vi.hoisted(() => {
     personCustomFieldDeleteMany,
     importantDateUpdateMany,
     importantDateDeleteMany,
+    journalEntryPersonFindMany,
+    journalEntryPersonUpdateMany,
+    journalEntryPersonDeleteMany,
     withDeletedPersonFindUnique,
     withDeletedPersonUpdate,
     withDeletedDisconnect,
@@ -107,6 +118,11 @@ vi.mock('../../../lib/prisma', () => ({
     personLocation: { updateMany: mocks.personLocationUpdateMany, deleteMany: mocks.personLocationDeleteMany },
     personCustomField: { updateMany: mocks.personCustomFieldUpdateMany, deleteMany: mocks.personCustomFieldDeleteMany },
     importantDate: { updateMany: mocks.importantDateUpdateMany, deleteMany: mocks.importantDateDeleteMany },
+    journalEntryPerson: {
+      findMany: mocks.journalEntryPersonFindMany,
+      updateMany: mocks.journalEntryPersonUpdateMany,
+      deleteMany: mocks.journalEntryPersonDeleteMany,
+    },
   },
   withDeleted: vi.fn(() => ({
     person: {
@@ -759,6 +775,9 @@ describe('mergePeople', () => {
     mocks.mockTxClient.personCustomField.deleteMany.mockResolvedValue({ count: 0 });
     mocks.mockTxClient.importantDate.updateMany.mockResolvedValue({ count: 0 });
     mocks.mockTxClient.importantDate.deleteMany.mockResolvedValue({ count: 0 });
+    mocks.mockTxClient.journalEntryPerson.findMany.mockResolvedValue([]);
+    mocks.mockTxClient.journalEntryPerson.updateMany.mockResolvedValue({ count: 0 });
+    mocks.mockTxClient.journalEntryPerson.deleteMany.mockResolvedValue({ count: 0 });
   });
 
   it('returns null when target not found', async () => {
@@ -946,5 +965,40 @@ describe('mergePeople', () => {
   it('does not call personGroup.createMany when no new groups', async () => {
     await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
     expect(mocks.mockTxClient.personGroup.createMany).not.toHaveBeenCalled();
+  });
+
+  it('re-parents source journal entry references to target', async () => {
+    await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
+
+    expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledWith({
+      where: { personId: SOURCE_ID },
+      data: { personId: PERSON_ID },
+    });
+  });
+
+  it('removes source journal references that would collide with target', async () => {
+    mocks.mockTxClient.journalEntryPerson.findMany.mockResolvedValueOnce([
+      { journalEntryId: 'je-1' },
+      { journalEntryId: 'je-2' },
+    ]);
+
+    await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
+
+    expect(mocks.mockTxClient.journalEntryPerson.deleteMany).toHaveBeenCalledWith({
+      where: {
+        personId: SOURCE_ID,
+        journalEntryId: { in: ['je-1', 'je-2'] },
+      },
+    });
+    expect(mocks.mockTxClient.journalEntryPerson.updateMany).toHaveBeenCalledWith({
+      where: { personId: SOURCE_ID },
+      data: { personId: PERSON_ID },
+    });
+  });
+
+  it('does not delete journal references when target has none', async () => {
+    await mergePeople(PERSON_ID, SOURCE_ID, USER_ID);
+
+    expect(mocks.mockTxClient.journalEntryPerson.deleteMany).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- When merging two people, the merged-away person silently disappeared from any journal entry that referenced them.
- Root cause: `mergePeople` in `lib/services/person.ts` re-parented most source relations (phones, emails, groups, relationships, important dates, etc.) but never touched `JournalEntryPerson`. The source person is soft-deleted at the end of the merge, and journal queries filter included people on `deletedAt: null` — so the references became invisible.
- Fix: re-parent source's `JournalEntryPerson` rows to the target inside the merge transaction, deleting rows that would collide with the target's existing references on the `(journalEntryId, personId)` unique constraint.

## Known limitation: no backfill
This fix is forward-only. People merged before this PR shipped have orphaned `JournalEntryPerson` rows pointing at soft-deleted Persons that will continue to be hidden by the journal UI. There is no automatic recovery — the merge target isn't recorded anywhere so we can't programmatically figure out where those references should now point. Affected users would need to either re-add the surviving person to each affected journal entry by hand, or accept the historical data loss.

## Test plan
- [x] `npx vitest run tests/lib/services/person.test.ts` — added 3 cases covering re-parent, dedup of colliding entries (with strict count + invocation-order assertions), and the no-collision path
- [x] `npx vitest run tests/api/people-merge.test.ts tests/api/journal.test.ts` — existing route + journal tests still pass
- [ ] Manually merge two people in the app where both are tagged on the same and different journal entries; confirm the target person stays visible on every entry the source was on