### PR TITLE
fix(mobile): tactical bug bash for mobile experience

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -4,6 +4,7 @@ import { useState, FormEvent } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/Button';
 
 export default function ForgotPasswordPage() {
   const t = useTranslations('auth');
@@ -120,13 +121,9 @@ export default function ForgotPasswordPage() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button type="submit" disabled={isLoading} fullWidth>
               {isLoading ? t('sending') : t('sendResetLink')}
-            </button>
+            </Button>
           </div>
 
           <div className="text-center">

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,3 +85,18 @@ body {
   color: var(--foreground);
   font-family: var(--font-sans);
 }
+
+/* Mobile safety net: catch stray horizontal overflow at the page level.
+   Uses `clip` so it does not establish a containing block for fixed/sticky. */
+html {
+  overflow-x: clip;
+}
+
+/* Prevent iOS Safari from zooming on focus when an input renders text under 16px. */
+@media (max-width: 640px) {
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+}

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -70,7 +70,7 @@ export default async function GroupsPage({
 
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-6">
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -81,7 +81,7 @@ export default async function GroupsPage({
               </Button>
             ) : (
               <div className="relative group">
-                <span className="px-4 py-2 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-block">
+                <span className="px-4 py-2 min-h-11 sm:min-h-0 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-flex items-center justify-center">
                   {t('addGroup')}
                 </span>
                 <div className="invisible group-hover:visible absolute right-0 top-full mt-2 w-64 p-3 bg-surface-elevated text-white text-sm rounded-lg shadow-lg z-10">

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
 import Navigation from '@/components/Navigation';
+import { Button } from '@/components/ui/Button';
 import EmptyState from '@/components/EmptyState';
 import { canCreateResource } from '@/lib/billing/subscription';
 import { getTranslations } from 'next-intl/server';
@@ -75,12 +76,9 @@ export default async function GroupsPage({
               {t('title')}
             </h1>
             {canCreate.allowed ? (
-              <Link
-                href="/groups/new"
-                className="px-4 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors"
-              >
+              <Button href="/groups/new">
                 {t('addGroup')}
-              </Link>
+              </Button>
             ) : (
               <div className="relative group">
                 <span className="px-4 py-2 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-block">

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -105,7 +105,7 @@ export default async function JournalPage({
 
       <main className="max-w-3xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-6">
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>

--- a/app/journal/page.tsx
+++ b/app/journal/page.tsx
@@ -109,7 +109,7 @@ export default async function JournalPage({
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>
-            <Button href="/journal/new" size="sm">
+            <Button href="/journal/new">
               {t('addEntry')}
             </Button>
           </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import SessionProvider from "@/components/SessionProvider";
@@ -15,6 +15,12 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "Nametag - Personal Relationships Manager",
   description: "Manage your relationships, track important details, and visualize your network",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
 };
 
 export default async function RootLayout({

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -6,6 +6,7 @@ import { useState, FormEvent, useEffect } from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/Button';
 import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { fetchAvailableProviders } from '@/lib/client-features';
 
@@ -213,13 +214,9 @@ export default function LoginPage() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="group relative w-full flex justify-center py-2.5 px-6 border border-transparent text-sm font-semibold rounded-lg text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed transition-all shadow-sm hover:shadow-md active:translate-y-px active:shadow-sm"
-            >
+            <Button type="submit" disabled={isLoading} fullWidth>
               {isLoading ? t('signingIn') : t('login')}
-            </button>
+            </Button>
           </div>
 
           <div className="text-center space-y-2">

--- a/app/people/duplicates/page.tsx
+++ b/app/people/duplicates/page.tsx
@@ -39,7 +39,7 @@ export default function DuplicatesPage() {
       <Navigation currentPath="/people/duplicates" />
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>

--- a/app/people/duplicates/page.tsx
+++ b/app/people/duplicates/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import { Button } from '@/components/ui/Button';
 import Navigation from '@/components/Navigation';
 import DuplicatesList, { DuplicateGroupDisplay } from '@/components/DuplicatesList';
 
@@ -43,12 +43,9 @@ export default function DuplicatesPage() {
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>
-            <Link
-              href="/people"
-              className="px-4 py-2 border border-border text-foreground rounded-lg font-semibold hover:bg-surface transition-colors"
-            >
+            <Button href="/people" variant="secondary">
               {tCommon('back')}
-            </Link>
+            </Button>
           </div>
 
           {loading ? (

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -173,11 +173,11 @@ export default async function PeoplePage({
 
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-6">
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>
-            <div className="flex space-x-3">
+            <div className="flex flex-wrap gap-3">
               <Link
                 href="/people/duplicates"
                 className="px-4 py-2 border border-border text-foreground rounded-lg font-semibold hover:bg-surface transition-colors"

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -178,17 +178,17 @@ export default async function PeoplePage({
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>
-            <div className="flex flex-wrap gap-3">
-              <Button href="/people/duplicates" variant="secondary">
+            <div className="flex flex-wrap gap-3 w-full sm:w-auto">
+              <Button href="/people/duplicates" variant="secondary" className="flex-1 sm:flex-initial">
                 {t('duplicates.findDuplicates')}
               </Button>
               {canCreate.allowed ? (
-                <Button href="/people/new">
+                <Button href="/people/new" className="flex-1 sm:flex-initial">
                   {t('addPerson')}
                 </Button>
               ) : (
-                <div className="relative group">
-                  <span className="px-4 py-2 min-h-11 sm:min-h-0 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-flex items-center justify-center">
+                <div className="relative group flex-1 sm:flex-initial">
+                  <span className="px-4 py-2 min-h-11 sm:min-h-0 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-flex items-center justify-center w-full">
                     {t('addPerson')}
                   </span>
                   <div className="invisible group-hover:visible absolute right-0 top-full mt-2 w-64 p-3 bg-surface-elevated text-white text-sm rounded-lg shadow-lg z-10">

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -188,7 +188,7 @@ export default async function PeoplePage({
                 </Button>
               ) : (
                 <div className="relative group">
-                  <span className="px-4 py-2 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-block">
+                  <span className="px-4 py-2 min-h-11 sm:min-h-0 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-flex items-center justify-center">
                     {t('addPerson')}
                   </span>
                   <div className="invisible group-hover:visible absolute right-0 top-full mt-2 w-64 p-3 bg-surface-elevated text-white text-sm rounded-lg shadow-lg z-10">

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { Suspense } from 'react';
 import { prisma } from '@/lib/prisma';
 import Navigation from '@/components/Navigation';
+import { Button } from '@/components/ui/Button';
 import EmptyState from '@/components/EmptyState';
 import ImportSuccessToast from '@/components/ImportSuccessToast';
 import { canCreateResource } from '@/lib/billing/subscription';
@@ -178,19 +179,13 @@ export default async function PeoplePage({
               {t('title')}
             </h1>
             <div className="flex flex-wrap gap-3">
-              <Link
-                href="/people/duplicates"
-                className="px-4 py-2 border border-border text-foreground rounded-lg font-semibold hover:bg-surface transition-colors"
-              >
+              <Button href="/people/duplicates" variant="secondary">
                 {t('duplicates.findDuplicates')}
-              </Link>
+              </Button>
               {canCreate.allowed ? (
-                <Link
-                  href="/people/new"
-                  className="px-4 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors"
-                >
+                <Button href="/people/new">
                   {t('addPerson')}
-                </Link>
+                </Button>
               ) : (
                 <div className="relative group">
                   <span className="px-4 py-2 bg-muted/50 text-white rounded-lg font-semibold cursor-not-allowed inline-block">

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { PasswordStrengthIndicator } from '@/components/PasswordStrengthIndicator';
+import { Button } from '@/components/ui/Button';
 import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { fetchAvailableProviders } from '@/lib/client-features';
 
@@ -340,13 +341,9 @@ export default function RegisterPage() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-semibold rounded-lg text-white bg-primary hover:bg-primary-dark transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button type="submit" disabled={isLoading} fullWidth>
               {isLoading ? t('creatingAccount') : t('signUp')}
-            </button>
+            </Button>
           </div>
 
           <div className="text-center">

--- a/app/relationship-types/page.tsx
+++ b/app/relationship-types/page.tsx
@@ -63,7 +63,7 @@ export default async function RelationshipTypesPage() {
 
       <main className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center gap-3 mb-6">
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>

--- a/app/relationship-types/page.tsx
+++ b/app/relationship-types/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
 import Navigation from '@/components/Navigation';
+import { Button } from '@/components/ui/Button';
 import EmptyState from '@/components/EmptyState';
 import DeleteRelationshipTypeButton from '@/components/DeleteRelationshipTypeButton';
 import { getTranslations } from 'next-intl/server';
@@ -67,12 +68,9 @@ export default async function RelationshipTypesPage() {
             <h1 className="text-3xl font-bold text-foreground">
               {t('title')}
             </h1>
-            <Link
-              href="/relationship-types/new"
-              className="px-4 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors"
-            >
+            <Button href="/relationship-types/new">
               {t('createNewType')}
-            </Link>
+            </Button>
           </div>
 
           {relationshipTypesWithUsage.length > 0 ? (

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/Button';
 import { PasswordStrengthIndicator } from '@/components/PasswordStrengthIndicator';
 
 function ResetPasswordForm() {
@@ -201,13 +202,9 @@ function ResetPasswordForm() {
           </div>
 
           <div>
-            <button
-              type="submit"
-              disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-lg text-white bg-primary hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
-            >
+            <Button type="submit" disabled={isLoading} fullWidth>
               {isLoading ? t('resetting') : t('resetPassword')}
-            </button>
+            </Button>
           </div>
 
           <div className="text-center">

--- a/components/CompactContactRow.tsx
+++ b/components/CompactContactRow.tsx
@@ -225,7 +225,7 @@ export default function CompactContactRow({
               <select
                 value={selectedRelationshipTypeId}
                 onChange={(e) => onRelationshipChange(pendingImport.id, e.target.value)}
-                className="w-full max-w-xs px-3 py-2 border border-border rounded-lg bg-surface text-foreground text-sm focus:ring-2 focus:ring-primary focus:border-primary"
+                className="w-full max-w-xs px-3 py-2 border border-border rounded-lg bg-surface text-foreground text-base sm:text-sm focus:ring-2 focus:ring-primary focus:border-primary"
               >
                 <option value="">{t('useGlobalRelationship')}</option>
                 <option value="__none__">{t('noRelationship')}</option>

--- a/components/ConflictList.tsx
+++ b/components/ConflictList.tsx
@@ -234,7 +234,7 @@ export default function ConflictList({ conflicts }: ConflictListProps) {
               </p>
             </div>
 
-            <div className="overflow-x-auto">
+            <div className="overflow-x-auto max-w-full">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-border">

--- a/components/GraphFilterHelpModal.tsx
+++ b/components/GraphFilterHelpModal.tsx
@@ -15,7 +15,7 @@ export default function GraphFilterHelpModal() {
       <button
         type="button"
         onClick={() => setIsOpen(true)}
-        className="inline-flex w-6 h-6 items-center justify-center rounded-full border border-foreground/40 bg-surface-elevated text-base font-bold text-muted hover:text-foreground hover:border-foreground transition-colors shrink-0"
+        className="inline-flex w-6 h-6 sm:w-6 sm:h-6 min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 items-center justify-center rounded-full border border-foreground/40 bg-surface-elevated text-base font-bold text-muted hover:text-foreground hover:border-foreground transition-colors shrink-0"
         aria-label={t('graph.filterHelp.ariaLabel')}
         title={t('graph.filterHelp.ariaLabel')}
       >

--- a/components/JournalFilters.tsx
+++ b/components/JournalFilters.tsx
@@ -83,7 +83,7 @@ export default function JournalFilters({ people, currentPersonIds, currentSearch
           defaultValue={currentSearch ?? ''}
           placeholder={t('searchPlaceholder')}
           aria-label={t('searchPlaceholder')}
-          className="w-full px-3 py-2 bg-surface border border-border rounded-lg text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary text-sm"
+          className="w-full px-3 py-2 bg-surface border border-border rounded-lg text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary text-base sm:text-sm"
         />
       </form>
       <PillSelector

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -76,7 +76,7 @@ export default function Navigation({ userEmail, userName, userNickname, userPhot
   };
 
   return (
-    <nav className="bg-surface border-b border-border">
+    <nav className="bg-surface border-b border-border pt-[env(safe-area-inset-top)]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Top row: Logo, Search (centered), User menu */}
         <div className="relative z-30 flex items-center justify-between h-16">
@@ -168,7 +168,7 @@ export default function Navigation({ userEmail, userName, userNickname, userPhot
             role="dialog"
             aria-modal="true"
             aria-label="Navigation menu"
-            className="md:hidden fixed top-0 right-0 bottom-0 w-[90%] max-w-md bg-surface shadow-xl z-50 transform transition-transform duration-300 ease-in-out"
+            className="md:hidden fixed top-0 right-0 bottom-0 w-[90%] max-w-md bg-surface shadow-xl z-50 transform transition-transform duration-300 ease-in-out pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pr-[env(safe-area-inset-right)]"
           >
             <div className="h-full flex flex-col">
               {/* Menu header with close button */}

--- a/components/NavigationSearch.tsx
+++ b/components/NavigationSearch.tsx
@@ -182,7 +182,7 @@ export default function NavigationSearch() {
           onKeyDown={handleKeyDown}
           onFocus={handleFocus}
           placeholder={t('placeholder')}
-          className="w-full pl-9 pr-12 py-1.5 text-sm border border-border rounded-lg bg-surface-elevated text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
+          className="w-full pl-9 pr-12 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground placeholder-muted focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors"
           autoComplete="off"
         />
         <kbd className="absolute right-2 top-1/2 -translate-y-1/2 hidden lg:inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium text-muted bg-background border border-border rounded">

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -257,7 +257,7 @@ export default function PeopleListClient({
 
       {/* Table */}
       <div className="bg-surface shadow-sm rounded-lg overflow-hidden border border-border">
-        <div className="overflow-x-auto">
+        <div className="overflow-x-auto max-w-full">
           <table className="min-w-full divide-y divide-border">
             <thead className="bg-surface-elevated">
               <tr>

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -225,11 +225,11 @@ export default function PeopleListClient({
   return (
     <>
       {/* Showing count and filters */}
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
         <span className="text-sm text-muted">
           {tt.showing}
         </span>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <select
             value={groupFilter}
             onChange={(e) => handleFilterChange('group', e.target.value)}

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -273,37 +273,37 @@ export default function PeopleListClient({
                 </th>
                 <th className="w-[32px] py-3 px-2" />
                 <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('name')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('name')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tc.name}
                     {sortBy === 'name' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>
                 </th>
                 <th className="hidden md:table-cell px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('surname')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('surname')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tt.surname}
                     {sortBy === 'surname' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>
                 </th>
                 <th className="hidden lg:table-cell px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('nickname')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('nickname')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tt.nickname}
                     {sortBy === 'nickname' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('relationship')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('relationship')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tt.relationshipToUser}
                     {sortBy === 'relationship' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('group')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('group')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tt.groups}
                     {sortBy === 'group' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
-                  <Link href={buildSortUrl('lastContact')} className="flex items-center gap-1 hover:text-foreground">
+                  <Link href={buildSortUrl('lastContact')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tt.lastContact}
                     {sortBy === 'lastContact' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
                   </Link>

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -233,7 +233,7 @@ export default function PeopleListClient({
           <select
             value={groupFilter}
             onChange={(e) => handleFilterChange('group', e.target.value)}
-            className="px-3 py-1.5 text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allGroups')}</option>
             <option value="none">{tPeople('noGroup')}</option>
@@ -244,7 +244,7 @@ export default function PeopleListClient({
           <select
             value={relationshipFilter}
             onChange={(e) => handleFilterChange('relationship', e.target.value)}
-            className="px-3 py-1.5 text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allRelationships')}</option>
             <option value="none">{tPeople('noRelationship')}</option>

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -225,15 +225,15 @@ export default function PeopleListClient({
   return (
     <>
       {/* Showing count and filters */}
-      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+      <div className="mb-4 flex flex-col-reverse sm:flex-row sm:flex-wrap sm:items-center sm:justify-between gap-2">
         <span className="text-sm text-muted">
           {tt.showing}
         </span>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 w-full sm:w-auto">
           <select
             value={groupFilter}
             onChange={(e) => handleFilterChange('group', e.target.value)}
-            className="px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="flex-1 sm:flex-initial px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allGroups')}</option>
             <option value="none">{tPeople('noGroup')}</option>
@@ -244,7 +244,7 @@ export default function PeopleListClient({
           <select
             value={relationshipFilter}
             onChange={(e) => handleFilterChange('relationship', e.target.value)}
-            className="px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="flex-1 sm:flex-initial px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allRelationships')}</option>
             <option value="none">{tPeople('noRelationship')}</option>

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -233,7 +233,7 @@ export default function PeopleListClient({
           <select
             value={groupFilter}
             onChange={(e) => handleFilterChange('group', e.target.value)}
-            className="flex-1 sm:flex-initial px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="flex-1 sm:flex-initial min-w-0 px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allGroups')}</option>
             <option value="none">{tPeople('noGroup')}</option>
@@ -244,7 +244,7 @@ export default function PeopleListClient({
           <select
             value={relationshipFilter}
             onChange={(e) => handleFilterChange('relationship', e.target.value)}
-            className="flex-1 sm:flex-initial px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
+            className="flex-1 sm:flex-initial min-w-0 px-3 py-1.5 text-base sm:text-sm border border-border rounded-lg bg-surface-elevated text-foreground focus:ring-2 focus:ring-primary focus:border-primary"
           >
             <option value="">{tPeople('allRelationships')}</option>
             <option value="none">{tPeople('noRelationship')}</option>

--- a/components/PersonActionsMenu.tsx
+++ b/components/PersonActionsMenu.tsx
@@ -270,7 +270,7 @@ export default function PersonActionsMenu({
         <button
           onClick={() => setMenuOpen(!menuOpen)}
           disabled={isExporting}
-          className="h-[42px] px-2 py-2 border border-border text-foreground rounded-lg hover:bg-surface transition-colors disabled:opacity-50"
+          className="h-[42px] px-2 py-2 min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 border border-border text-foreground rounded-lg hover:bg-surface transition-colors disabled:opacity-50 flex items-center justify-center"
           aria-label={t('actions')}
           title={t('actions')}
 >

--- a/components/PersonCompare.tsx
+++ b/components/PersonCompare.tsx
@@ -403,7 +403,7 @@ export default function PersonCompare({
             </h3>
           </div>
 
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto max-w-full">
             <table className="w-full">
               <thead>
                 <tr className="border-b border-border">
@@ -619,7 +619,7 @@ export default function PersonCompare({
         (f) => !f.bothEmpty && !f.hasConflict
       ) && (
         <div className="bg-surface border border-border rounded-lg overflow-hidden">
-          <div className="overflow-x-auto">
+          <div className="overflow-x-auto max-w-full">
             <table className="w-full">
               <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
                 {scalarFieldStates

--- a/components/PersonVCardRawView.tsx
+++ b/components/PersonVCardRawView.tsx
@@ -89,7 +89,7 @@ export default function PersonVCardRawView({ person }: PersonVCardRawViewProps) 
             </button>
           </div>
 
-          <pre className="bg-background border border-border rounded-lg p-4 overflow-x-auto text-xs font-mono text-foreground whitespace-pre">
+          <pre className="bg-background border border-border rounded-lg p-4 overflow-x-auto max-w-full text-xs font-mono text-foreground whitespace-pre">
             {vcard}
           </pre>
         </div>

--- a/components/PhotoCropModal.tsx
+++ b/components/PhotoCropModal.tsx
@@ -98,7 +98,7 @@ export default function PhotoCropModal({ imageSrc, onConfirm, onCancel }: PhotoC
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-surface rounded-lg shadow-xl w-full max-w-md mx-4">
+      <div className="bg-surface rounded-lg shadow-xl w-full max-w-md mx-4 pb-[env(safe-area-inset-bottom)]">
         <div className="p-4 border-b border-border">
           <h2 className="text-lg font-semibold text-foreground">{t('cropTitle')}</h2>
         </div>

--- a/components/PhotoSourceModal.tsx
+++ b/components/PhotoSourceModal.tsx
@@ -101,7 +101,7 @@ export default function PhotoSourceModal({ onSelect, onClose }: PhotoSourceModal
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
       onClick={handleBackdropClick}
     >
-      <div className="bg-surface rounded-lg shadow-xl w-full max-w-md mx-4">
+      <div className="bg-surface rounded-lg shadow-xl w-full max-w-md mx-4 pb-[env(safe-area-inset-bottom)]">
         <div className="flex items-center justify-between p-4 border-b border-border">
           <h2 className="text-lg font-semibold text-foreground">{t('sourceTitle')}</h2>
           <button

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
+import { Button } from './ui/Button';
 import PersonAvatar from './PersonPhoto';
 import PhotoCropModal from './PhotoCropModal';
 import { getUserPhotoUrl } from '@/lib/photo-url';
@@ -348,13 +349,9 @@ export default function ProfileForm({ userId, currentName, currentSurname, curre
         </div>
 
         <div className="flex justify-end pt-4">
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="px-6 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
+          <Button type="submit" disabled={isLoading}>
             {isLoading ? t('saving') : t('saveChanges')}
-          </button>
+          </Button>
         </div>
       </form>
 
@@ -379,14 +376,9 @@ export default function ProfileForm({ userId, currentName, currentSurname, curre
               >
                 {t('emailChange.cancel')}
               </button>
-              <button
-                type="button"
-                onClick={saveProfile}
-                disabled={isLoading}
-                className="px-4 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
+              <Button type="button" onClick={saveProfile} disabled={isLoading}>
                 {isLoading ? t('saving') : t('emailChange.confirm')}
-              </button>
+              </Button>
             </div>
           </div>
         </div>

--- a/components/ProfileForm.tsx
+++ b/components/ProfileForm.tsx
@@ -369,13 +369,9 @@ export default function ProfileForm({ userId, currentName, currentSurname, curre
               {t('emailChange.warning')}
             </p>
             <div className="flex justify-end space-x-3">
-              <button
-                type="button"
-                onClick={() => setShowEmailConfirm(false)}
-                className="px-4 py-2 border border-border text-muted rounded-lg font-medium hover:bg-surface-elevated transition-colors"
-              >
+              <Button type="button" variant="secondary" onClick={() => setShowEmailConfirm(false)}>
                 {t('emailChange.cancel')}
-              </button>
+              </Button>
               <Button type="button" onClick={saveProfile} disabled={isLoading}>
                 {isLoading ? t('saving') : t('emailChange.confirm')}
               </Button>

--- a/components/billing/PaymentHistoryTable.tsx
+++ b/components/billing/PaymentHistoryTable.tsx
@@ -79,7 +79,7 @@ export default function PaymentHistoryTable({ payments }: PaymentHistoryTablePro
   };
 
   return (
-    <div className="overflow-x-auto">
+    <div className="overflow-x-auto max-w-full">
       <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
         <thead>
           <tr>

--- a/components/person-form/LastContactSection.tsx
+++ b/components/person-form/LastContactSection.tsx
@@ -98,7 +98,7 @@ export default function LastContactSection({
                 ),
               })
             }
-            className="w-16 px-2 py-1 text-sm border border-border rounded bg-surface text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-16 px-2 py-1 text-base sm:text-sm border border-border rounded bg-surface text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
           />
           <select
             disabled={!formData.contactReminderEnabled}
@@ -109,7 +109,7 @@ export default function LastContactSection({
                   .value as ReminderIntervalUnit,
               })
             }
-            className="px-2 py-1 text-sm border border-border rounded bg-surface text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-2 py-1 text-base sm:text-sm border border-border rounded bg-surface text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <option value="DAYS">{t('days')}</option>
             <option value="WEEKS">{t('weeks')}</option>

--- a/components/person-form/PersonForm.tsx
+++ b/components/person-form/PersonForm.tsx
@@ -20,6 +20,7 @@ import GroupsSection from './GroupsSection';
 import LastContactSection from './LastContactSection';
 import ImportantDatesManager from '../ImportantDatesManager';
 import MarkdownEditor from '../MarkdownEditor';
+import { Button } from '../ui/Button';
 import CardDavSyncSection from './CardDavSyncSection';
 
 type ReminderIntervalUnit = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
@@ -623,13 +624,9 @@ export default function PersonForm({
             )}
           </div>
         ) : (
-          <button
-            type="submit"
-            disabled={isLoading}
-            className="px-6 py-2 bg-primary text-white rounded-lg font-semibold hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-          >
+          <Button type="submit" disabled={isLoading}>
             {isLoading ? t('saving') : t('save')}
-          </button>
+          </Button>
         )}
       </div>
     </form>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -25,7 +25,7 @@ interface ButtonAsLinkProps extends BaseButtonProps {
 
 type ButtonProps = ButtonAsButtonProps | ButtonAsLinkProps;
 
-const baseStyles = 'inline-flex items-center justify-center font-semibold rounded-lg transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-primary';
+const baseStyles = 'inline-flex items-center justify-center font-semibold rounded-lg transition-all duration-150 focus:outline-none focus:ring-2 focus:ring-primary min-h-11 sm:min-h-0';
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary: 'bg-primary text-white hover:bg-primary-dark shadow-sm hover:shadow-md active:translate-y-px active:shadow-sm',

--- a/components/ui/ComboboxInput.tsx
+++ b/components/ui/ComboboxInput.tsx
@@ -171,7 +171,7 @@ export default function ComboboxInput({
               onKeyDown={handleKeyDown}
               placeholder={placeholder}
               disabled={disabled}
-              className="w-full px-3 py-2 pr-8 text-sm border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full px-3 py-2 pr-8 text-base sm:text-sm border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
               role="combobox"
               aria-expanded={isOpen}
               aria-controls={listboxId}

--- a/components/ui/ConfirmationModal.tsx
+++ b/components/ui/ConfirmationModal.tsx
@@ -41,7 +41,7 @@ export default function ConfirmationModal({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-surface rounded-lg max-w-md w-full p-6">
+      <div className="bg-surface rounded-lg max-w-md w-full p-6 pb-[calc(theme(spacing.6)+env(safe-area-inset-bottom))]">
         <h3 className="text-lg font-semibold text-foreground mb-4">
           {title}
         </h3>

--- a/components/ui/DatePicker.tsx
+++ b/components/ui/DatePicker.tsx
@@ -272,7 +272,7 @@ export default function DatePicker({
 
   return (
     <div id={id} className="flex flex-col gap-2">
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {orderedFields}
         {showTodayButton && (
           <button

--- a/components/ui/Modal.tsx
+++ b/components/ui/Modal.tsx
@@ -104,7 +104,7 @@ export default function Modal({
       <div
         ref={modalRef}
         tabIndex={-1}
-        className={`bg-surface rounded-lg w-full ${sizeClasses[size]} shadow-xl max-h-[90vh] overflow-y-auto`}
+        className={`bg-surface rounded-lg w-full ${sizeClasses[size]} shadow-xl max-h-[90vh] overflow-y-auto pb-[env(safe-area-inset-bottom)]`}
       >
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-border sticky top-0 bg-surface z-10">
@@ -116,7 +116,7 @@ export default function Modal({
           </h2>
           <button
             onClick={onClose}
-            className="text-muted hover:text-foreground transition-colors p-1 rounded-lg hover:bg-surface-elevated"
+            className="text-muted hover:text-foreground transition-colors p-1 rounded-lg hover:bg-surface-elevated min-h-11 min-w-11 flex items-center justify-center"
             aria-label={closeAriaLabel || 'Close modal'}
           >
             <svg


### PR DESCRIPTION
## Summary

Tactical sweep to bring the mobile experience to parity with desktop. No new patterns, no redesign — same UI, just sized and bounded correctly for phones.

**Phase 2 — systemic fixes** (one root-cause change resolving an entire category at once):

- `html { overflow-x: clip }` global page-level horizontal-scroll guard.
- iOS Safari focus-zoom fix: `input/select/textarea` get `font-size: 16px` under 640px viewport (CSS layer + a component-level `text-base sm:text-sm` sweep on the form controls that explicitly set `text-sm`).
- Bound 6 `overflow-x-auto` wrappers (`PeopleListClient`, `ConflictList`, `PersonCompare` ×2, `PersonVCardRawView`, `PaymentHistoryTable`) so their scroll context stays inside the parent card and doesn't push the whole page.
- 44×44 px touch targets on icon-only controls (modal close buttons, table sort arrows, the graph filter help `?`, the kebab menu trigger). Mobile-only via `min-h-11 sm:min-h-0` so desktop visuals are unchanged.
- Safe-area inset support: `viewport-fit=cover` opt-in via Next's `Viewport` export plus `pt-/pb-/pr-[env(safe-area-inset-*)]` on the top nav, mobile drawer, and modal panels (shared `Modal` + `ConfirmationModal` primitives, plus the bespoke `PhotoSourceModal` and `PhotoCropModal`).

**Phase 3 — audit-driven layout fixes**:

- Stack page headers (title + action buttons) on mobile, side-by-side on desktop. Applied to people, relationship-types, groups, journal, and people-duplicates.
- `DatePicker` field row gets `flex-wrap` so the "Today" button no longer overflows the form on the Last Contact section.
- People-list filter row: count text moves below filters on mobile; the two filter `<select>` elements share the row 50/50 (`flex-1 min-w-0`).
- Button consistency: upgraded `components/ui/Button.tsx` to enforce a 44 px mobile floor, then migrated the highest-traffic inline primary buttons (page headers across 5 listing pages, all 4 auth submit buttons, `ProfileForm` Save + email-confirm + Cancel, `PersonForm` edit-mode Save) to use it. Disabled-state spans on people/groups pages adjusted so they match the migrated `<Button>` heights in the same row.
- People page header: "Buscar duplicados" + "Añadir Persona" now share the row 50/50 on mobile and revert to natural width on desktop.

## Spec & plan

- Spec: `docs/superpowers/specs/2026-05-04-mobile-quirks-bug-bash-design.md`
- Plan: `docs/superpowers/plans/2026-05-04-mobile-quirks-bug-bash.md`

Out of scope (deliberately): people table → card layout, network-graph mobile redesign, bottom-tab nav, swipe gestures, PWA install, visual redesign, tablet-specific layouts.

## Test plan

- [x] `npm run lint` — 0 errors (3 pre-existing warnings unrelated)
- [x] `npm run typecheck` — clean
- [x] `npm run test:run` — 2003 passing, 16 skipped
- [x] DevTools sweep at 320 / 375 / 430 px viewports across listing pages, person detail, forms, auth, settings — issues found in audit walk are addressed by the commits in this PR
- [ ] **Real-device walk on iPhone:** dashboard, people list, person detail, person new, journal, settings → profile / carddav. Watch for notch overlap, on-screen keyboard hiding submit buttons, iOS URL-bar resize jitter, safe-area at the home indicator.