### PR TITLE
fix: clear lint warnings and edge-runtime instrumentation error

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { sendEmailBatch, emailTemplates } from '@/lib/email';
 import type { SendBatchEmailItem } from '@/lib/email';
-import { formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
+import { formatGraphName } from '@/lib/nameUtils';
 import { env, getAppUrl } from '@/lib/env';
 import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
 import { createModuleLogger, securityLogger } from '@/lib/logger';

--- a/components/PersonActionsMenu.tsx
+++ b/components/PersonActionsMenu.tsx
@@ -511,6 +511,7 @@ export default function PersonActionsMenu({
             onChange={(id) => handleMergeSelect(id)}
             placeholder={tMerge('searchPerson')}
             nameOrder={nameOrder}
+            nameDisplayFormat={nameDisplayFormat}
           />
         </div>
       </Modal>

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,20 +3,17 @@
  * This file is automatically loaded by Next.js to set up instrumentation
  */
 
-import { createModuleLogger } from './lib/logger';
-
-const log = createModuleLogger('init');
-
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    // Initialize Redis connection before handling requests
+    const { createModuleLogger } = await import('./lib/logger');
+    const log = createModuleLogger('init');
+
     const { initRedis } = await import('./lib/redis');
     try {
       await initRedis();
       log.info('Redis initialized successfully');
     } catch (error) {
       log.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Redis initialization failed');
-      // Don't fail the app startup, just log the error
     }
   }
 }

--- a/lib/upcoming-events.ts
+++ b/lib/upcoming-events.ts
@@ -1,5 +1,5 @@
 import { prisma } from '@/lib/prisma';
-import { formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
+import { formatGraphName } from '@/lib/nameUtils';
 import { parseAsLocalDate } from '@/lib/date-format';
 import { getTranslationsForLocale } from '@/lib/i18n-utils';
 import { getDateDisplayTitle } from '@/lib/important-date-types';


### PR DESCRIPTION
## Summary
- Drop unused `NameDisplayFormat` type imports in `lib/upcoming-events.ts` and `app/api/cron/send-reminders/route.ts`.
- Forward the `nameDisplayFormat` prop from `PersonActionsMenu` into `PersonAutocomplete` — it was destructured but never wired up, so the merge-person picker ignored the user's name display format.
- Lazy-import `lib/logger` inside `instrumentation.register` so `node:async_hooks` / `node:crypto` are no longer pulled into the Edge runtime bundle (the dev server was warning on every reload).

## Test plan
- [ ] `npm run lint` is clean
- [ ] `npm run dev` starts without the Edge runtime warnings about `node:async_hooks` / `node:crypto`
- [ ] Open a person, click the actions menu, choose "Merge with…" — autocomplete formats names per the user's display-format setting