### PR TITLE
fix: deleted groups still shown on people list (#255)

### DIFF
--- a/app/api/carddav/export-bulk/route.ts
+++ b/app/api/carddav/export-bulk/route.ts
@@ -91,6 +91,7 @@ export const POST = withLogging(async function POST(request: Request) {
           },
         },
         groups: {
+          where: { group: { deletedAt: null } },
           include: {
             group: true,
           },

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -40,6 +40,7 @@ export const GET = withAuth(async (request, session) => {
       include: {
         relationshipToUser: true,
         groups: {
+          where: { group: { deletedAt: null } },
           include: {
             group: true,
           },

--- a/app/api/user/export/route.ts
+++ b/app/api/user/export/route.ts
@@ -44,6 +44,7 @@ export const GET = withAuth(async (request, session) => {
             },
           },
           groups: {
+            where: { group: { deletedAt: null } },
             include: {
               group: {
                 select: {

--- a/app/carddav/export/page.tsx
+++ b/app/carddav/export/page.tsx
@@ -62,6 +62,7 @@ export default async function ExportPage() {
     },
     include: {
       groups: {
+        where: { group: { deletedAt: null } },
         include: {
           group: true,
         },

--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -81,7 +81,10 @@ export default async function PeoplePage({
       where: peopleWhere,
       include: {
         relationshipToUser: { select: { label: true, color: true } },
-        groups: { include: { group: { select: { name: true, color: true } } } },
+        groups: {
+          where: { group: { deletedAt: null } },
+          include: { group: { select: { name: true, color: true } } },
+        },
         relationshipsFrom: { select: { id: true } },
         relationshipsTo: { select: { id: true } },
       },

--- a/lib/carddav/auto-export.ts
+++ b/lib/carddav/auto-export.ts
@@ -60,6 +60,7 @@ export async function autoExportPerson(personId: string): Promise<void> {
         },
       },
       groups: {
+        where: { group: { deletedAt: null } },
         include: {
           group: true,
         },
@@ -255,6 +256,7 @@ export async function autoUpdatePerson(personId: string): Promise<void> {
         },
       },
       groups: {
+        where: { group: { deletedAt: null } },
         include: {
           group: true,
         },

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -496,7 +496,10 @@ export async function syncToServer(
             locations: true,
             customFields: true,
             importantDates: true,
-            groups: { include: { group: true } },
+            groups: {
+              where: { group: { deletedAt: null } },
+              include: { group: true },
+            },
             relationshipsFrom: { include: { relatedPerson: true } },
           },
         },
@@ -716,6 +719,7 @@ export async function syncToServer(
           include: { relatedPerson: true },
         },
         groups: {
+          where: { group: { deletedAt: null } },
           include: { group: true },
         },
       },

--- a/tests/regression/soft-delete-filters.test.ts
+++ b/tests/regression/soft-delete-filters.test.ts
@@ -144,6 +144,18 @@ describe('Soft-delete filter regression tests', () => {
       const callArg = mocks.personFindMany.mock.calls[0][0];
       expect(callArg.where).toHaveProperty('deletedAt', null);
     });
+
+    it('should filter soft-deleted groups in nested groups include (issue #255)', async () => {
+      mocks.personFindMany.mockResolvedValue([]);
+
+      const request = new Request('http://localhost/api/people');
+      await getPeople(request);
+
+      expect(mocks.personFindMany).toHaveBeenCalledTimes(1);
+      const callArg = mocks.personFindMany.mock.calls[0][0];
+      expect(callArg.include.groups).toHaveProperty('where');
+      expect(callArg.include.groups.where).toEqual({ group: { deletedAt: null } });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -315,6 +327,20 @@ describe('Soft-delete filter regression tests', () => {
       const callArg = mocks.personFindMany.mock.calls[0][0];
       expect(callArg.include.importantDates).toHaveProperty('where');
       expect(callArg.include.importantDates.where).toHaveProperty('deletedAt', null);
+    });
+
+    it('should filter soft-deleted groups in nested groups include (issue #255)', async () => {
+      mocks.personFindMany.mockResolvedValue([]);
+      mocks.groupFindMany.mockResolvedValue([]);
+      mocks.relationshipTypeFindMany.mockResolvedValue([]);
+
+      const request = new Request('http://localhost/api/user/export');
+      await exportData(request);
+
+      expect(mocks.personFindMany).toHaveBeenCalledTimes(1);
+      const callArg = mocks.personFindMany.mock.calls[0][0];
+      expect(callArg.include.groups).toHaveProperty('where');
+      expect(callArg.include.groups.where).toEqual({ group: { deletedAt: null } });
     });
   });
 


### PR DESCRIPTION
Closes #255.

## Summary
- The People tab kept rendering a group in the Groups column after the group was deleted, and the edit form gave no way to remove it.
- Root cause: eight Prisma queries included `person.groups` without filtering `Group.deletedAt`. The `PersonGroup` join row stays in place when a group is soft-deleted (intentional, so trash/restore preserves membership), so the deleted group leaked through every nested include that didn't filter it.
- Aligns the list page, the JSON list endpoint, both export routes, the CardDAV export page, and the CardDAV auto-export/sync paths with the existing `groupsInclude()` pattern in `lib/prisma-queries.ts` that the single-person detail view already uses.
- The CardDAV/export sites had the same drift and would have re-exported deleted group names as vCard `CATEGORIES`; fixed in the same pass.

## Test plan
- [x] `npx vitest run tests/regression/soft-delete-filters.test.ts` — two new cases for `GET /api/people` and `GET /api/user/export` nested groups (red before fix, green after)
- [x] `npm run test:run` — 2005 passed, 0 failed
- [x] `npm run lint` — clean
- [ ] Manual: create a group, assign a person, delete the group, confirm the deleted group no longer appears in the People tab Groups column