### PR TITLE
feat(journal): optional time stamp on entries

### DIFF
--- a/app/api/journal/[id]/route.ts
+++ b/app/api/journal/[id]/route.ts
@@ -53,7 +53,7 @@ export const PUT = withAuth(async (request, session, context) => {
       return validation.response;
     }
 
-    const { title, date, body: entryBody, personIds, updateLastContact } = validation.data;
+    const { title, date, hasTime, body: entryBody, personIds, updateLastContact } = validation.data;
 
     const existingEntry = await prisma.journalEntry.findUnique({
       where: {
@@ -79,7 +79,9 @@ export const PUT = withAuth(async (request, session, context) => {
 
     const sanitizedTitle = sanitizeName(title) || title;
     const sanitizedBody = sanitizeNotes(entryBody) || entryBody;
-    const entryDate = new Date(date);
+    const entryDate = hasTime
+      ? new Date(date)
+      : new Date(`${date.slice(0, 10)}T00:00:00.000Z`);
 
     // Remove existing people associations and recreate atomically
     const entry = await prisma.$transaction(async (tx) => {
@@ -92,6 +94,7 @@ export const PUT = withAuth(async (request, session, context) => {
         data: {
           title: sanitizedTitle,
           date: entryDate,
+          hasTime,
           body: sanitizedBody,
           ...(personIds && personIds.length > 0 && {
             people: {

--- a/app/api/journal/route.ts
+++ b/app/api/journal/route.ts
@@ -77,7 +77,7 @@ export const POST = withAuth(async (request, session) => {
       return validation.response;
     }
 
-    const { title, date, body: entryBody, personIds, updateLastContact } = validation.data;
+    const { title, date, hasTime, body: entryBody, personIds, updateLastContact } = validation.data;
 
     // Validate personIds belong to the current user
     if (personIds && personIds.length > 0) {
@@ -91,13 +91,16 @@ export const POST = withAuth(async (request, session) => {
 
     const sanitizedTitle = sanitizeName(title) || title;
     const sanitizedBody = sanitizeNotes(entryBody) || entryBody;
-    const entryDate = new Date(date);
+    const entryDate = hasTime
+      ? new Date(date)
+      : new Date(`${date.slice(0, 10)}T00:00:00.000Z`);
 
     const entry = await prisma.journalEntry.create({
       data: {
         userId: session.user.id,
         title: sanitizedTitle,
         date: entryDate,
+        hasTime,
         body: sanitizedBody,
         ...(personIds && personIds.length > 0 && {
           people: {

--- a/app/journal/[id]/edit/page.tsx
+++ b/app/journal/[id]/edit/page.tsx
@@ -59,12 +59,10 @@ export default async function EditJournalEntryPage({
   const nameOrder = (user?.nameOrder ?? 'WESTERN') as 'WESTERN' | 'EASTERN';
   const dateFormat = (user?.dateFormat ?? 'MDY') as 'MDY' | 'DMY' | 'YMD';
 
-  // Serialize date to YYYY-MM-DD string for the form
-  const dateStr = entry.date.toISOString().slice(0, 10);
-
   const initialData = {
     title: entry.title,
-    date: dateStr,
+    dateIso: entry.date.toISOString(),
+    hasTime: entry.hasTime,
     body: entry.body,
     personIds: entry.people.map((p) => p.personId),
   };

--- a/app/journal/[id]/page.tsx
+++ b/app/journal/[id]/page.tsx
@@ -65,6 +65,12 @@ export default async function JournalEntryDetailPage({
     month: 'long',
     day: 'numeric',
   });
+  const formattedTime = entry.hasTime
+    ? entry.date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
+    : null;
+  const formattedDateLine = formattedTime
+    ? `${formattedDate} · ${formattedTime}`
+    : formattedDate;
 
   return (
     <div className="min-h-screen bg-background">
@@ -93,7 +99,7 @@ export default async function JournalEntryDetailPage({
                 <h1 className="text-3xl font-bold text-foreground mb-1">
                   {entry.title}
                 </h1>
-                <p className="text-sm text-muted">{formattedDate}</p>
+                <p className="text-sm text-muted">{formattedDateLine}</p>
               </div>
               <div className="flex gap-2">
                 <Button href={`/journal/${entry.id}/edit`} size="sm" variant="secondary">

--- a/app/journal/[id]/page.tsx
+++ b/app/journal/[id]/page.tsx
@@ -8,6 +8,7 @@ import MarkdownRenderer from '@/components/MarkdownRenderer';
 import { formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
 import { Button } from '@/components/ui/Button';
 import DeleteJournalEntryButton from '@/components/DeleteJournalEntryButton';
+import JournalEntryDateLine from '@/components/JournalEntryDateLine';
 
 export default async function JournalEntryDetailPage({
   params,
@@ -60,18 +61,6 @@ export default async function JournalEntryDetailPage({
   const nameDisplayFormat = (user?.nameDisplayFormat || 'FULL') as NameDisplayFormat;
   const locale = user?.language ?? 'en';
 
-  const formattedDate = entry.date.toLocaleDateString(locale, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-  const formattedTime = entry.hasTime
-    ? entry.date.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
-    : null;
-  const formattedDateLine = formattedTime
-    ? `${formattedDate} · ${formattedTime}`
-    : formattedDate;
-
   return (
     <div className="min-h-screen bg-background">
       <Navigation
@@ -99,7 +88,7 @@ export default async function JournalEntryDetailPage({
                 <h1 className="text-3xl font-bold text-foreground mb-1">
                   {entry.title}
                 </h1>
-                <p className="text-sm text-muted">{formattedDateLine}</p>
+                <JournalEntryDateLine dateIso={entry.date.toISOString()} hasTime={entry.hasTime} locale={locale} />
               </div>
               <div className="flex gap-2">
                 <Button href={`/journal/${entry.id}/edit`} size="sm" variant="secondary">

--- a/components/JournalEntryDateLine.tsx
+++ b/components/JournalEntryDateLine.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+interface JournalEntryDateLineProps {
+  dateIso: string;
+  hasTime: boolean;
+  locale: string;
+}
+
+export default function JournalEntryDateLine({ dateIso, hasTime, locale }: JournalEntryDateLineProps) {
+  let displayDate: string;
+  let displayTime: string | null = null;
+
+  if (hasTime) {
+    const dt = new Date(dateIso);
+    displayDate = dt.toLocaleDateString(locale, { year: 'numeric', month: 'long', day: 'numeric' });
+    displayTime = dt.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' });
+  } else {
+    // Date-only entries are stored as midnight UTC representing a calendar day.
+    // Parse via local components to avoid timezone-shift on the calendar day.
+    const dateOnly = dateIso.split('T')[0];
+    const [y, m, d] = dateOnly.split('-').map(Number);
+    const dt = new Date(y, m - 1, d);
+    displayDate = dt.toLocaleDateString(locale, { year: 'numeric', month: 'long', day: 'numeric' });
+  }
+
+  const text = displayTime ? `${displayDate} · ${displayTime}` : displayDate;
+  return <p className="text-sm text-muted">{text}</p>;
+}

--- a/components/JournalEntryForm.tsx
+++ b/components/JournalEntryForm.tsx
@@ -21,7 +21,8 @@ interface JournalEntryFormProps {
   entryId?: string;
   initialData?: {
     title: string;
-    date: string;
+    dateIso: string;       // entry.date.toISOString() from the server
+    hasTime: boolean;
     body: string;
     personIds: string[];
   };
@@ -41,6 +42,26 @@ function getTodayString(): string {
   const mm = String(now.getMonth() + 1).padStart(2, '0');
   const dd = String(now.getDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
+}
+
+function getCurrentTimeString(): string {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, '0');
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+function localDateString(d: Date): string {
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function localTimeString(d: Date): string {
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
 }
 
 export default function JournalEntryForm({
@@ -72,16 +93,32 @@ export default function JournalEntryForm({
       .filter((p): p is PillPerson => p !== undefined);
   };
 
+  const initialIso = initialData?.dateIso;
+  const initialHasTime = initialData?.hasTime ?? false;
+
+  const computeInitialDate = () => {
+    if (!initialIso) return getTodayString();
+    if (initialHasTime) return localDateString(new Date(initialIso));
+    return initialIso.slice(0, 10);
+  };
+  const computeInitialTime = () =>
+    initialIso && initialHasTime ? localTimeString(new Date(initialIso)) : '';
+
   const [title, setTitle] = useState(initialData?.title ?? '');
-  const [date, setDate] = useState(initialData?.date ?? getTodayString());
+  const [date, setDate] = useState(computeInitialDate);
+  const [time, setTime] = useState(computeInitialTime);
+  const [hasTime, setHasTime] = useState(initialHasTime);
   const [body, setBody] = useState(initialData?.body ?? '');
   const [selectedPeople, setSelectedPeople] = useState<PillPerson[]>(resolveInitialSelected);
   const [updateLastContact, setUpdateLastContact] = useState(mode === 'create');
 
   // Warn on unsaved changes
-  const isDirty = title !== (initialData?.title ?? '') ||
+  const isDirty =
+    title !== (initialData?.title ?? '') ||
     body !== (initialData?.body ?? '') ||
-    date !== (initialData?.date ?? getTodayString());
+    date !== computeInitialDate() ||
+    time !== computeInitialTime() ||
+    hasTime !== initialHasTime;
 
   useEffect(() => {
     if (!isDirty) return;
@@ -116,9 +153,14 @@ export default function JournalEntryForm({
       const url = mode === 'create' ? '/api/journal' : `/api/journal/${entryId}`;
       const method = mode === 'create' ? 'POST' : 'PUT';
 
+      const payloadDate = hasTime
+        ? new Date(`${date}T${time}`).toISOString()
+        : date;
+
       const payload = {
         title,
-        date,
+        date: payloadDate,
+        hasTime,
         body,
         personIds: selectedPeople.map((p) => p.id),
         updateLastContact: selectedPeople.length > 0 ? updateLastContact : false,

--- a/components/JournalEntryForm.tsx
+++ b/components/JournalEntryForm.tsx
@@ -226,14 +226,50 @@ export default function JournalEntryForm({
         <label htmlFor="journal-date" className="block text-sm font-medium text-muted mb-1">
           {t('dateLabel')}
         </label>
-        <input
-          type="date"
-          id="journal-date"
-          required
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          className="w-full px-3 py-2 border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-        />
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            type="date"
+            id="journal-date"
+            required
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className="px-3 py-2 border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+          {hasTime ? (
+            <>
+              <input
+                type="time"
+                id="journal-time"
+                aria-label={t('timeLabel')}
+                required
+                value={time}
+                onChange={(e) => setTime(e.target.value)}
+                className="px-3 py-2 border border-border rounded-lg bg-surface text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  setHasTime(false);
+                  setTime('');
+                }}
+                className="text-sm text-muted hover:text-foreground transition-colors"
+              >
+                {t('removeTime')}
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setHasTime(true);
+                if (!time) setTime(getCurrentTimeString());
+              }}
+              className="text-sm text-primary hover:underline"
+            >
+              + {t('addTime')}
+            </button>
+          )}
+        </div>
       </div>
 
       {/* People */}

--- a/components/JournalTimeline.tsx
+++ b/components/JournalTimeline.tsx
@@ -9,6 +9,7 @@ interface TimelineEntry {
   id: string;
   title: string;
   date: string;
+  hasTime: boolean;
   body: string;
   people: Array<{
     person: {
@@ -128,30 +129,42 @@ export default function JournalTimeline({ entries, nameOrder, nameDisplayFormat,
           <div className="space-y-0">
             {group.entries.map((entry, index) => {
               const isLast = index === group.entries.length - 1;
-              const dateOnly = entry.date.split('T')[0];
-              const [year, month, day] = dateOnly.split('-').map(Number);
-              const entryDate = new Date(year, month - 1, day);
+              const entryDate = entry.hasTime
+                ? new Date(entry.date)
+                : (() => {
+                    const dateOnly = entry.date.split('T')[0];
+                    const [y, m, d] = dateOnly.split('-').map(Number);
+                    return new Date(y, m - 1, d);
+                  })();
               const dayNumber = entryDate.getDate();
               const weekday = entryDate.toLocaleDateString(locale, { weekday: 'short' });
+              const timeLabel = entry.hasTime
+                ? entryDate.toLocaleTimeString(locale, { hour: 'numeric', minute: '2-digit' })
+                : null;
               const bodyPreview = truncateBody(entry.body);
 
               return (
                 <div key={entry.id} className="flex gap-0">
                   {/* Date column */}
-                  <div className="w-12 sm:w-16 flex-shrink-0 flex flex-col items-center pt-1 pr-2 sm:pr-3">
+                  <div className="w-14 sm:w-16 flex-shrink-0 flex flex-col items-center pt-1 pr-2 sm:pr-3">
                     <span
                       className="text-2xl font-bold text-foreground leading-none tabular-nums"
-                      aria-label={entryDate.toLocaleDateString(locale, {
-                        weekday: 'long',
-                        day: 'numeric',
-                        month: 'long',
-                      })}
+                      aria-label={
+                        timeLabel
+                          ? `${entryDate.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long' })}, ${timeLabel}`
+                          : entryDate.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long' })
+                      }
                     >
                       {dayNumber}
                     </span>
                     <span className="text-xs text-muted uppercase tracking-wide mt-0.5">
                       {weekday}
                     </span>
+                    {timeLabel && (
+                      <span className="text-xs text-muted tabular-nums mt-0.5 whitespace-nowrap">
+                        {timeLabel}
+                      </span>
+                    )}
                   </div>
 
                   {/* Timeline spine */}

--- a/lib/openapi/schemas.ts
+++ b/lib/openapi/schemas.ts
@@ -451,6 +451,7 @@ export function sharedSchemas(): Record<string, unknown> {
         userId: { type: 'string', description: 'User ID' },
         title: { type: 'string', description: 'Entry title' },
         date: { type: 'string', format: 'date-time', description: 'Date of the journal entry' },
+        hasTime: { type: 'boolean', description: 'Whether the date includes a meaningful time of day (true) or is a calendar-day-only entry (false).' },
         body: { type: 'string', description: 'Entry content (markdown supported)' },
         people: {
           type: 'array',
@@ -461,7 +462,7 @@ export function sharedSchemas(): Record<string, unknown> {
         updatedAt: { type: 'string', format: 'date-time' },
         deletedAt: { type: ['string', 'null'], format: 'date-time' },
       },
-      required: ['id', 'userId', 'title', 'date', 'body', 'people', 'createdAt', 'updatedAt'],
+      required: ['id', 'userId', 'title', 'date', 'hasTime', 'body', 'people', 'createdAt', 'updatedAt'],
     },
   };
 }

--- a/lib/validations.ts
+++ b/lib/validations.ts
@@ -336,6 +336,7 @@ export const addGroupMemberSchema = z.object({
 export const createJournalEntrySchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
   date: z.string().min(1, 'Date is required'),
+  hasTime: z.boolean().optional().default(false),
   body: z.string().min(1, 'Entry body is required').max(50000),
   personIds: z.array(z.string()).optional().default([]),
   updateLastContact: z.boolean().optional().default(true),
@@ -344,6 +345,7 @@ export const createJournalEntrySchema = z.object({
 export const updateJournalEntrySchema = z.object({
   title: z.string().min(1, 'Title is required').max(200),
   date: z.string().min(1, 'Date is required'),
+  hasTime: z.boolean().optional().default(false),
   body: z.string().min(1, 'Entry body is required').max(50000),
   personIds: z.array(z.string()).optional().default([]),
   updateLastContact: z.boolean().optional().default(false),

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -1795,6 +1795,9 @@
       "save": "Eintrag speichern",
       "cancel": "Abbrechen",
       "markdownSupport": "Unterstützt Markdown-Formatierung",
+      "timeLabel": "Uhrzeit",
+      "addTime": "Uhrzeit hinzufügen",
+      "removeTime": "Uhrzeit entfernen",
       "saved": "Eintrag gespeichert"
     },
     "detail": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -1791,6 +1791,9 @@
       "save": "Save entry",
       "cancel": "Cancel",
       "markdownSupport": "Supports Markdown formatting",
+      "timeLabel": "Time",
+      "addTime": "Add time",
+      "removeTime": "Remove time",
       "saved": "Entry saved"
     },
     "detail": {

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -1795,6 +1795,9 @@
       "save": "Guardar entrada",
       "cancel": "Cancelar",
       "markdownSupport": "Admite formato Markdown",
+      "timeLabel": "Hora",
+      "addTime": "Añadir hora",
+      "removeTime": "Quitar hora",
       "saved": "Entrada guardada"
     },
     "detail": {

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -1795,6 +1795,9 @@
       "save": "エントリーを保存",
       "cancel": "キャンセル",
       "markdownSupport": "Markdown形式をサポート",
+      "timeLabel": "時刻",
+      "addTime": "時刻を追加",
+      "removeTime": "時刻を削除",
       "saved": "エントリーを保存しました"
     },
     "detail": {

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -1795,6 +1795,9 @@
       "save": "Lagre oppføring",
       "cancel": "Avbryt",
       "markdownSupport": "Støtter Markdown-formatering",
+      "timeLabel": "Tid",
+      "addTime": "Legg til tid",
+      "removeTime": "Fjern tid",
       "saved": "Oppføring lagret"
     },
     "detail": {

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -1795,6 +1795,9 @@
       "save": "保存条目",
       "cancel": "取消",
       "markdownSupport": "支持 Markdown 格式",
+      "timeLabel": "时间",
+      "addTime": "添加时间",
+      "removeTime": "移除时间",
       "saved": "条目已保存"
     },
     "detail": {

--- a/prisma/migrations/20260507132900_add_has_time_to_journal_entries/migration.sql
+++ b/prisma/migrations/20260507132900_add_has_time_to_journal_entries/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "journal_entries" ADD COLUMN     "hasTime" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,6 +173,7 @@ model JournalEntry {
   userId    String
   title     String
   date      DateTime
+  hasTime   Boolean   @default(false)
   body      String    @db.Text
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt

--- a/tests/api/journal.test.ts
+++ b/tests/api/journal.test.ts
@@ -142,6 +142,65 @@ describe('Journal API', () => {
       expect(data.entry).toEqual(expect.objectContaining({ title: 'Dinner with friends' }));
     });
 
+    it('should persist hasTime=true and the supplied UTC instant', async () => {
+      mocks.journalEntryCreate.mockResolvedValue({
+        id: 'entry-2',
+        title: 'Quick call with Maria',
+        date: new Date('2026-05-07T22:30:00.000Z'),
+        hasTime: true,
+        body: 'Caught up briefly.',
+        people: [],
+      });
+
+      const request = new Request('http://localhost/api/journal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Quick call with Maria',
+          date: '2026-05-07T22:30:00.000Z',
+          hasTime: true,
+          body: 'Caught up briefly.',
+          personIds: [],
+          updateLastContact: false,
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+      const callArg = mocks.journalEntryCreate.mock.calls[0][0];
+      expect(callArg.data.hasTime).toBe(true);
+      expect(callArg.data.date).toEqual(new Date('2026-05-07T22:30:00.000Z'));
+    });
+
+    it('should persist hasTime=false and midnight UTC for date-only entries', async () => {
+      mocks.journalEntryCreate.mockResolvedValue({
+        id: 'entry-3',
+        title: 'Birthday',
+        date: new Date('2026-03-28T00:00:00.000Z'),
+        hasTime: false,
+        body: 'Family lunch.',
+        people: [],
+      });
+
+      const request = new Request('http://localhost/api/journal', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Birthday',
+          date: '2026-03-28',
+          body: 'Family lunch.',
+          personIds: [],
+          updateLastContact: false,
+        }),
+      });
+      const response = await POST(request);
+
+      expect(response.status).toBe(201);
+      const callArg = mocks.journalEntryCreate.mock.calls[0][0];
+      expect(callArg.data.hasTime).toBe(false);
+      expect(callArg.data.date).toEqual(new Date('2026-03-28T00:00:00.000Z'));
+    });
+
     it('should return 400 for missing title', async () => {
       const request = new Request('http://localhost/api/journal', {
         method: 'POST',

--- a/tests/api/journal.test.ts
+++ b/tests/api/journal.test.ts
@@ -310,6 +310,98 @@ describe('Journal Detail API', () => {
 
       expect(response.status).toBe(404);
     });
+
+    it('should persist hasTime=true and UTC instant when toggled on', async () => {
+      mocks.journalEntryFindUnique.mockResolvedValue({
+        id: 'entry-1',
+        userId: 'user-123',
+        title: 'Old title',
+        date: new Date('2026-05-07T00:00:00.000Z'),
+        hasTime: false,
+        body: 'Old body.',
+        deletedAt: null,
+      });
+      const updatedEntry = {
+        id: 'entry-1',
+        title: 'Coffee',
+        date: new Date('2026-05-07T22:30:00.000Z'),
+        hasTime: true,
+        body: 'New body.',
+        people: [],
+      };
+      mocks.$transaction.mockImplementation(async (cb: (tx: typeof mocks) => unknown) => {
+        mocks.journalEntryUpdate.mockResolvedValue(updatedEntry);
+        return cb({
+          journalEntryPerson: { deleteMany: mocks.journalEntryPersonDeleteMany },
+          journalEntry: { update: mocks.journalEntryUpdate },
+        } as unknown as typeof mocks);
+      });
+
+      const request = new Request('http://localhost/api/journal/entry-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Coffee',
+          date: '2026-05-07T22:30:00.000Z',
+          hasTime: true,
+          body: 'New body.',
+          personIds: [],
+          updateLastContact: false,
+        }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ id: 'entry-1' }) });
+
+      expect(response.status).toBe(200);
+      const callArg = mocks.journalEntryUpdate.mock.calls[0][0];
+      expect(callArg.data.hasTime).toBe(true);
+      expect(callArg.data.date).toEqual(new Date('2026-05-07T22:30:00.000Z'));
+    });
+
+    it('should persist hasTime=false and midnight UTC when toggled off', async () => {
+      mocks.journalEntryFindUnique.mockResolvedValue({
+        id: 'entry-1',
+        userId: 'user-123',
+        title: 'Old title',
+        date: new Date('2026-05-07T22:30:00.000Z'),
+        hasTime: true,
+        body: 'Old body.',
+        deletedAt: null,
+      });
+      const updatedEntry = {
+        id: 'entry-1',
+        title: 'Coffee',
+        date: new Date('2026-05-07T00:00:00.000Z'),
+        hasTime: false,
+        body: 'New body.',
+        people: [],
+      };
+      mocks.$transaction.mockImplementation(async (cb: (tx: typeof mocks) => unknown) => {
+        mocks.journalEntryUpdate.mockResolvedValue(updatedEntry);
+        return cb({
+          journalEntryPerson: { deleteMany: mocks.journalEntryPersonDeleteMany },
+          journalEntry: { update: mocks.journalEntryUpdate },
+        } as unknown as typeof mocks);
+      });
+
+      const request = new Request('http://localhost/api/journal/entry-1', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'Coffee',
+          date: '2026-05-07',
+          hasTime: false,
+          body: 'New body.',
+          personIds: [],
+          updateLastContact: false,
+        }),
+      });
+      const response = await PUT(request, { params: Promise.resolve({ id: 'entry-1' }) });
+
+      expect(response.status).toBe(200);
+      const callArg = mocks.journalEntryUpdate.mock.calls[0][0];
+      expect(callArg.data.hasTime).toBe(false);
+      expect(callArg.data.date).toEqual(new Date('2026-05-07T00:00:00.000Z'));
+    });
   });
 
   describe('DELETE /api/journal/[id]', () => {

--- a/tests/components/JournalTimeline.test.tsx
+++ b/tests/components/JournalTimeline.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { NextIntlClientProvider } from 'next-intl';
+import JournalTimeline from '../../components/JournalTimeline';
+import enMessages from '../../locales/en.json';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <NextIntlClientProvider locale="en" messages={enMessages}>
+      {children}
+    </NextIntlClientProvider>
+  );
+}
+
+const baseEntry = {
+  id: 'entry-1',
+  title: 'Coffee with Sara',
+  body: 'Caught up over espresso.',
+  people: [],
+};
+
+describe('JournalTimeline', () => {
+  it('omits the time line when hasTime is false', () => {
+    const entries = [{
+      ...baseEntry,
+      date: '2026-05-07T00:00:00.000Z',
+      hasTime: false,
+    }];
+    render(
+      <Wrapper>
+        <JournalTimeline entries={entries} nameOrder="WESTERN" locale="en" />
+      </Wrapper>
+    );
+    expect(screen.queryByText(/AM|PM|\d:\d{2}/)).toBeNull();
+  });
+
+  it('renders the locale-formatted time when hasTime is true', () => {
+    const entries = [{
+      ...baseEntry,
+      // 14:30 UTC. The test runner's timezone affects the displayed local
+      // time, but both 12h ("PM") and 24h (":30") forms include "30".
+      date: '2026-05-07T14:30:00.000Z',
+      hasTime: true,
+    }];
+    render(
+      <Wrapper>
+        <JournalTimeline entries={entries} nameOrder="WESTERN" locale="en" />
+      </Wrapper>
+    );
+    expect(screen.getByText(/:30/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #260.

- Adds an optional `hasTime` flag on journal entries. Existing entries default to `false` and render exactly as before.
- Form gains a small "Add time" / "Remove time" toggle next to the date. When time is added, the form converts the user's local datetime to a UTC instant before submitting; when omitted, the entry is stored as midnight UTC of the chosen day (existing convention).
- Timeline shows the time as a third line under the day-number/weekday when set. Date column widened from `w-12 sm:w-16` to `w-14 sm:w-16` so "2:30 PM" fits on mobile in en-US.
- Detail page appends the time after the date with a middle-dot separator. The date line is now a `'use client'` component so the timestamp renders in the viewer's local timezone (the prior server-side rendering would have shown UTC for users outside UTC).
- API request validation, OpenAPI response schema, and migration all updated.
- Three new translation keys (`timeLabel`, `addTime`, `removeTime`) added to all six locales.

## Test plan

- [ ] Create a new entry without time. Confirm it saves and the timeline shows day + weekday only.
- [ ] Create a new entry, click "Add time", pick a non-midnight time, save. Confirm:
  - [ ] Detail page shows date + middle dot + time, in your local timezone.
  - [ ] Timeline shows the day number, weekday, and the time on a third line.
- [ ] Edit an entry with time, click "Remove time", save. Confirm time disappears from both views.
- [ ] Edit a pre-existing (legacy) entry. Confirm it loads with the toggle off and renders the same as before.
- [ ] Switch language to Spanish (`es-ES`) or another locale and confirm the toggle button labels translate.