### PR TITLE
fix: use blob URL instead of data URL for photo crop to prevent browser freeze

### DIFF
--- a/components/person-form/PersonForm.tsx
+++ b/components/person-form/PersonForm.tsx
@@ -245,14 +245,13 @@ export default function PersonForm({
 
   const handlePhotoSourceSelect = (file: File) => {
     setShowPhotoSourceModal(false);
-    const reader = new FileReader();
-    reader.onload = () => {
-      setCropImageSrc(reader.result as string);
-    };
-    reader.readAsDataURL(file);
+    setCropImageSrc(URL.createObjectURL(file));
   };
 
   const handleCropConfirm = (blob: Blob) => {
+    if (cropImageSrc) {
+      URL.revokeObjectURL(cropImageSrc);
+    }
     setCropImageSrc(null);
     if (photoPreview) {
       URL.revokeObjectURL(photoPreview);
@@ -422,7 +421,12 @@ export default function PersonForm({
         onShowPhotoSourceModal={setShowPhotoSourceModal}
         onPhotoSourceSelect={handlePhotoSourceSelect}
         onCropConfirm={handleCropConfirm}
-        onCropCancel={() => setCropImageSrc(null)}
+        onCropCancel={() => {
+          if (cropImageSrc) {
+            URL.revokeObjectURL(cropImageSrc);
+          }
+          setCropImageSrc(null);
+        }}
         onPhotoRemove={handlePhotoRemove}
       />
 


### PR DESCRIPTION
## Summary
- Replaced `FileReader.readAsDataURL()` with `URL.createObjectURL()` in the photo selection flow. The data URL approach converts the entire file to a base64 string (~33% larger), which freezes the browser when decoding large images for the crop modal.
- Added `URL.revokeObjectURL()` cleanup on both the confirm and cancel paths to prevent memory leaks.

Fixes #275

## Test plan
- [ ] Select a large photo (10MB+) on the person edit page and verify the crop modal opens without freezing
- [ ] Crop and confirm: photo preview appears, no console errors
- [ ] Open crop modal then cancel: no memory leak (blob URL revoked)
- [ ] Verify photo uploads correctly after saving the form