### PR TITLE
fix(i18n): language selection not persisting on self-hosted instances

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import SessionProvider from "@/components/SessionProvider";
 import ThemeProvider from "@/components/ThemeProvider";
+import LocaleSync from "@/components/LocaleSync";
 import { Toaster } from "sonner";
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
@@ -59,6 +60,7 @@ export default async function RootLayout({
               {children}
             </ThemeProvider>
           </SessionProvider>
+          <LocaleSync locale={locale} />
           <Toaster position="top-right" richColors />
         </NextIntlClientProvider>
       </body>

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -65,10 +65,9 @@ export default function LanguageSelector({
 
       // Set cookie for immediate effect
       const domain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
-      const secure = process.env.NODE_ENV === 'production' ? '; secure' : '';
       const domainAttr = domain ? `; domain=${domain}` : '';
 
-      document.cookie = `NEXT_LOCALE=${newLanguage}; path=/; max-age=${365 * 24 * 60 * 60}; samesite=lax${secure}${domainAttr}`;
+      document.cookie = `NEXT_LOCALE=${newLanguage}; path=/; max-age=${365 * 24 * 60 * 60}; samesite=lax${domainAttr}`;
 
       toast.success(tSuccess('languageChanged'));
 

--- a/components/LocaleSync.tsx
+++ b/components/LocaleSync.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface LocaleSyncProps {
+  locale: string;
+}
+
+export default function LocaleSync({ locale }: LocaleSyncProps) {
+  useEffect(() => {
+    const cookies = document.cookie.split(';').map(c => c.trim());
+    const localeCookie = cookies.find(c => c.startsWith('NEXT_LOCALE='));
+    const cookieValue = localeCookie?.split('=')[1];
+
+    if (cookieValue === locale) return;
+
+    const domain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
+    const domainAttr = domain ? `; domain=${domain}` : '';
+    document.cookie = `NEXT_LOCALE=${locale}; path=/; max-age=${365 * 24 * 60 * 60}; samesite=lax${domainAttr}`;
+
+    const updated = document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith('NEXT_LOCALE='));
+    if (updated?.split('=')[1] === locale) {
+      window.location.reload();
+    }
+  }, [locale]);
+
+  return null;
+}

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -109,7 +109,6 @@ export async function setLocaleCookie(locale: SupportedLocale): Promise<void> {
       httpOnly: boolean;
       sameSite: 'lax';
       domain?: string;
-      secure?: boolean;
     } = {
       path: '/',
       maxAge: 365 * 24 * 60 * 60, // 1 year
@@ -120,11 +119,6 @@ export async function setLocaleCookie(locale: SupportedLocale): Promise<void> {
     // Add domain for cross-subdomain sharing (production only)
     if (process.env.NEXT_PUBLIC_COOKIE_DOMAIN) {
       cookieOptions.domain = process.env.NEXT_PUBLIC_COOKIE_DOMAIN;
-    }
-
-    // Use secure cookies in production
-    if (process.env.NODE_ENV === 'production') {
-      cookieOptions.secure = true;
     }
 
     cookieStore.set(LOCALE_COOKIE_NAME, locale, cookieOptions);


### PR DESCRIPTION
## Summary

- Remove `secure` flag from the `NEXT_LOCALE` cookie. Self-hosted instances commonly run over plain HTTP, and browsers silently reject secure cookies on non-HTTPS pages, preventing the language preference from being saved. This is a non-sensitive UI preference cookie (stores locale codes like `en`, `es-ES`), so the flag is unnecessary.
- Add a `LocaleSync` client component that re-syncs the cookie from the user's DB preference on page load. This fixes the intermittent language reset when the cookie is lost (cleared cookies, new device, etc.).

Fixes #273

## Test plan

- [ ] Deploy on a self-hosted HTTP instance, change language, verify it persists across page reloads
- [ ] Clear cookies, reload the page, verify the language resets to the DB preference (not the browser default)
- [ ] Verify language switching still works on HTTPS (nametag.one)
- [ ] Run `npx vitest run tests/components/LanguageSelector.test.tsx tests/lib/locale.test.ts tests/api/user-language.test.ts` (all 61 tests pass)