### PR TITLE
fix(carddav): preserve local photos when remote vCard has no PHOTO field

### DIFF
--- a/app/api/people/[id]/photo/route.ts
+++ b/app/api/people/[id]/photo/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 import { savePhotoFromBuffer, deletePersonPhotos } from '@/lib/photo-storage';
+import { autoUpdatePerson } from '@/lib/carddav/auto-export';
 import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('people-photo');
@@ -65,6 +66,11 @@ export const POST = withAuth(async (request, session, context) => {
 
     log.info({ personId: id, filename }, 'Photo uploaded');
 
+    autoUpdatePerson(id).catch((error) => {
+      log.error({ err: error instanceof Error ? error : new Error(String(error)), personId: id },
+        'CardDAV auto-update after photo upload failed');
+    });
+
     return apiResponse.ok({ photo: filename });
   } catch (error) {
     return handleApiError(error, 'POST /api/people/[id]/photo');
@@ -100,6 +106,11 @@ export const DELETE = withAuth(async (_request, session, context) => {
     });
 
     log.info({ personId: id }, 'Photo deleted');
+
+    autoUpdatePerson(id).catch((error) => {
+      log.error({ err: error instanceof Error ? error : new Error(String(error)), personId: id },
+        'CardDAV auto-update after photo delete failed');
+    });
 
     return apiResponse.ok({ success: true });
   } catch (error) {

--- a/lib/carddav/vcard-import.ts
+++ b/lib/carddav/vcard-import.ts
@@ -134,7 +134,7 @@ export function buildScalarPersonData(parsedData: ParsedVCardData, skipNameField
     nickname: parsedData.nickname ?? null,
     organization: parsedData.organization ?? null,
     jobTitle: parsedData.jobTitle ?? null,
-    photo: parsedData.photo ?? null,
+    photo: parsedData.photo,
     gender: parsedData.gender ?? null,
     anniversary: parsedData.anniversary ?? null,
     lastContact: parsedData.lastContact ?? null,
@@ -228,14 +228,13 @@ export async function updatePersonFromVCard(
   userId: string,
   options?: { skipNameFields?: boolean },
 ): Promise<void> {
-  // Save photo as file if present (outside transaction since it's filesystem I/O)
-  let photoValue = parsedData.photo;
-  if (photoValue) {
-    const filename = await savePhoto(userId, personId, photoValue);
-    if (filename) {
-      photoValue = filename;
-    }
-    // If savePhoto fails, keep the original value as fallback
+  // Save photo as file if present (outside transaction since it's filesystem I/O).
+  // When the remote vCard has no PHOTO field (undefined), preserve the local photo
+  // rather than clearing it. Many CardDAV servers strip photos from vCards.
+  let photoDbValue: string | undefined;
+  if (parsedData.photo) {
+    const filename = await savePhoto(userId, personId, parsedData.photo);
+    photoDbValue = filename ?? parsedData.photo;
   }
 
   // Delete all multi-value fields and update person in a single atomic transaction
@@ -254,7 +253,7 @@ export async function updatePersonFromVCard(
       where: { id: personId },
       data: {
         ...buildScalarPersonData(parsedData, options?.skipNameFields),
-        photo: photoValue ?? null,
+        photo: photoDbValue,
         uid: parsedData.uid,
 
         // Create new multi-value fields

--- a/tests/lib/carddav/person-from-vcard.test.ts
+++ b/tests/lib/carddav/person-from-vcard.test.ts
@@ -152,13 +152,13 @@ describe('person-from-vcard', () => {
       expect(data.lastContact).toBeNull();
     });
 
-    it('passes null for photo when remote contact has no photo', async () => {
+    it('preserves local photo when remote vCard has no PHOTO field', async () => {
       const parsedData = makeMinimalParsedData();
 
       await updatePersonFromVCard(PERSON_ID, parsedData, USER_ID);
 
       const data = mocks.personUpdate.mock.calls[0][0].data;
-      expect(data.photo).toBeNull();
+      expect(data.photo).toBeUndefined();
     });
 
     it('preserves actual values when fields are present', async () => {
@@ -292,14 +292,14 @@ describe('person-from-vcard', () => {
       expect(calls.length).toBe(1); // Only the initial restore, not a second update
     });
 
-    it('sets photo to null when restored person has no photo', async () => {
+    it('preserves existing photo when restored vCard has no PHOTO field', async () => {
       const parsedData = makeMinimalParsedData();
       mocks.personUpdate.mockResolvedValue({ id: PERSON_ID });
 
       await restorePersonFromVCardData(USER_ID, PERSON_ID, parsedData);
 
       const data = mocks.personUpdate.mock.calls[0][0].data;
-      expect(data.photo).toBeNull();
+      expect(data.photo).toBeUndefined();
     });
   });
 

--- a/tests/lib/carddav/vcard-import-skip-names.test.ts
+++ b/tests/lib/carddav/vcard-import-skip-names.test.ts
@@ -32,6 +32,22 @@ function buildParsedData(overrides: Partial<ParsedVCardData> = {}): ParsedVCardD
   };
 }
 
+describe('buildScalarPersonData photo handling', () => {
+  it('should return undefined for photo when vCard has no PHOTO field', () => {
+    const data = buildParsedData({ photo: undefined });
+    const result = buildScalarPersonData(data);
+
+    expect(result.photo).toBeUndefined();
+  });
+
+  it('should return the photo data URI when vCard has a PHOTO field', () => {
+    const data = buildParsedData({ photo: 'data:image/jpeg;base64,abc123' });
+    const result = buildScalarPersonData(data);
+
+    expect(result.photo).toBe('data:image/jpeg;base64,abc123');
+  });
+});
+
 describe('buildScalarPersonData with skipNameFields', () => {
   it('should return all fields when skipNameFields is false', () => {
     const data = buildParsedData();


### PR DESCRIPTION
## Summary

- **Fixed photos disappearing after ~24h** when CardDAV sync is enabled. `updatePersonFromVCard` was setting `photo: null` when the remote vCard lacked a PHOTO field (common with servers that strip photos). Now the photo column is skipped entirely via Prisma `undefined`, preserving the locally-uploaded photo.
- **Fixed photos not syncing to CardDAV** on upload/delete. The `POST/DELETE /api/people/[id]/photo` endpoints were not triggering `autoUpdatePerson`, so photo changes were never pushed to CardDAV until the next full sync or person edit.

## Root Cause

`buildScalarPersonData()` used `parsedData.photo ?? null`, converting `undefined` (no PHOTO in vCard) to `null` (explicitly clear photo). Prisma treats `null` as "set this column to NULL" vs `undefined` as "skip this column". The same issue existed in the explicit `photo: photoValue ?? null` override in `updatePersonFromVCard()`.

## Test plan

- [x] New unit tests for `buildScalarPersonData` photo handling (undefined vs present)
- [x] Updated existing tests that asserted the old buggy behavior
- [x] All 2140 tests pass
- [x] Type check passes

Closes #278