### PR TITLE
fix(carddav): prevent duplicate vCard creation when enabling sync

### DIFF
--- a/app/api/people/[id]/route.ts
+++ b/app/api/people/[id]/route.ts
@@ -152,7 +152,7 @@ export const PUT = withAuth(async (request, session, context) => {
         });
     } else if (cardDavSyncEnabled === true && existingPerson.cardDavSyncEnabled !== true) {
       // Re-sync: do a full export to server instead of the normal update
-      autoExportPerson(id).catch((error) => {
+      autoExportPerson(id, { force: true }).catch((error) => {
         log.error({ err: error instanceof Error ? error : new Error(String(error)), personId: id }, 'Auto-export after sync enable failed');
       });
     }

--- a/lib/carddav/auto-export.ts
+++ b/lib/carddav/auto-export.ts
@@ -41,7 +41,10 @@ function formatExportFullName(person: {
 /**
  * Auto-export a person to CardDAV server
  */
-export async function autoExportPerson(personId: string): Promise<void> {
+export async function autoExportPerson(
+  personId: string,
+  options?: { force?: boolean },
+): Promise<void> {
   // Get person with all relations
   const person = await prisma.person.findUnique({
     where: { id: personId, deletedAt: null },
@@ -89,8 +92,11 @@ export async function autoExportPerson(personId: string): Promise<void> {
     where: { userId: person.userId },
   });
 
-  if (!connection || !connection.syncEnabled || !connection.autoExportNew) {
-    // Auto-export not enabled, skip
+  if (!connection || !connection.syncEnabled) {
+    return;
+  }
+
+  if (!connection.autoExportNew && !options?.force) {
     return;
   }
 

--- a/lib/services/person.ts
+++ b/lib/services/person.ts
@@ -413,9 +413,13 @@ export async function updatePerson(id: string, userId: string, data: PersonUpdat
     include: personUpdateInclude(),
   });
 
-  // CardDAV sync — use stored value as default when input doesn't specify
+  // CardDAV sync — use stored value as default when input doesn't specify.
+  // Skip when sync was just toggled ON: the route handler handles that
+  // transition with an explicit autoExportPerson call. Running both would
+  // race and create duplicate vCards / hit the unique constraint on personId.
   const shouldSync = cardDavSyncEnabled ?? existingPerson.cardDavSyncEnabled;
-  if (shouldSync !== false) {
+  const justEnabled = cardDavSyncEnabled === true && !existingPerson.cardDavSyncEnabled;
+  if (shouldSync !== false && !justEnabled) {
     autoUpdatePerson(person.id).catch((error: unknown) => {
       log.error(
         {


### PR DESCRIPTION
## Summary

- When toggling CardDAV sync on for a contact, `autoExportPerson` was called from two independent code paths in the same request: once by the person service (via `autoUpdatePerson`) and once by the route handler. Both raced to create the vCard and mapping, resulting in duplicate contacts on the server and a unique constraint violation on `personId`.
- Skip the service's `autoUpdatePerson` call when sync was just toggled on, since the route handler already handles that transition explicitly.
- Also fix `autoExportPerson` silently aborting when `autoExportNew` is `false`, even when the user explicitly enables sync for a specific person. The route handler now passes `{ force: true }` to bypass that guard.

Fixes #282

## Test plan

- [ ] Enable CardDAV sync for a contact - verify only one vCard is created on the server
- [ ] Edit a contact that already has sync enabled - verify `autoUpdatePerson` still fires and updates the server
- [ ] Toggle sync on with `autoExportNew` disabled - verify the contact is still exported
- [ ] Toggle sync off - verify the contact is deleted from the server as before
- [ ] Run existing test suite: `npx vitest run tests/lib/services/person.test.ts tests/lib/carddav/auto-export.test.ts`