### PR TITLE
fix: harden API routes for bearer token compatibility

### DIFF
--- a/app/api/billing/apply-promotion/route.ts
+++ b/app/api/billing/apply-promotion/route.ts
@@ -46,4 +46,4 @@ export const POST = withAuth(async (request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-apply-promotion');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/cancel/route.ts
+++ b/app/api/billing/cancel/route.ts
@@ -78,4 +78,4 @@ export const POST = withAuth(async (request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-cancel');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/checkout/route.ts
+++ b/app/api/billing/checkout/route.ts
@@ -66,4 +66,4 @@ export const POST = withAuth(async (request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-checkout');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/history/route.ts
+++ b/app/api/billing/history/route.ts
@@ -41,4 +41,4 @@ export const GET = withAuth(async (_request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-history');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/portal/route.ts
+++ b/app/api/billing/portal/route.ts
@@ -25,4 +25,4 @@ export const POST = withAuth(async (_request, session) => {
     }
     return handleApiError(error, 'billing-portal');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/subscription/route.ts
+++ b/app/api/billing/subscription/route.ts
@@ -45,4 +45,4 @@ export const GET = withAuth(async (_request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-subscription-get');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/billing/usage/route.ts
+++ b/app/api/billing/usage/route.ts
@@ -20,4 +20,4 @@ export const GET = withAuth(async (_request, session) => {
   } catch (error) {
     return handleApiError(error, 'billing-usage');
   }
-});
+}, { allowApiToken: false });

--- a/app/api/groups/[id]/route.ts
+++ b/app/api/groups/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateGroupSchema, validateRequest } from '@/lib/validations';
 import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { getRandomColor } from '@/lib/colors';
 
 // GET /api/groups/[id] - Get a single group
 export const GET = withAuth(async (_request, session, context) => {
@@ -85,7 +86,7 @@ export const PUT = withAuth(async (request, session, context) => {
       data: {
         name,
         description: description || null,
-        color: color || null,
+        color: color ?? existingGroup.color ?? getRandomColor(),
       },
     });
 

--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { createGroupSchema, validateRequest } from '@/lib/validations';
 import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
+import { getRandomColor } from '@/lib/colors';
 import { canCreateResource } from '@/lib/billing';
 
 // GET /api/groups - List all groups for the current user
@@ -77,7 +78,7 @@ export const POST = withAuth(async (request, session) => {
         userId: session.user.id,
         name: sanitizedName,
         description: sanitizedDescription,
-        color: color || null,
+        color: color || getRandomColor(),
         // If peopleIds are provided, create PersonGroup associations
         ...(peopleIds && peopleIds.length > 0 && {
           people: {

--- a/app/api/relationship-types/[id]/route.ts
+++ b/app/api/relationship-types/[id]/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { updateRelationshipTypeSchema, validateRequest } from '@/lib/validations';
 import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { getRandomColor } from '@/lib/colors';
 
 export const GET = withAuth(async (_request, session, context) => {
   const { id } = await context.params;
@@ -78,7 +79,7 @@ export const PUT = withAuth(async (request, session, context) => {
         data: {
           name: normalizedName,
           label,
-          color: color || null,
+          color: color ?? existing.color ?? getRandomColor(),
           inverseId: id, // Points to itself
         },
         include: {
@@ -124,7 +125,7 @@ export const PUT = withAuth(async (request, session, context) => {
           userId: session.user.id,
           name: inverseName,
           label: inverseLabel,
-          color: color || null,
+          color: color || getRandomColor(),
           inverseId: id, // Link back to the type being edited
         },
       });
@@ -137,7 +138,7 @@ export const PUT = withAuth(async (request, session, context) => {
       data: {
         name: normalizedName,
         label,
-        color: color || null,
+        color: color ?? existing.color ?? getRandomColor(),
         inverseId: finalInverseId,
       },
       include: {
@@ -155,7 +156,7 @@ export const PUT = withAuth(async (request, session, context) => {
     if (finalInverseId && finalInverseId !== id) {
       await prisma.relationshipType.update({
         where: { id: finalInverseId },
-        data: { color: color || null },
+        data: { color: color ?? existing.color ?? getRandomColor() },
       });
     }
 

--- a/app/api/relationship-types/route.ts
+++ b/app/api/relationship-types/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { createRelationshipTypeSchema, validateRequest } from '@/lib/validations';
 import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
+import { getRandomColor } from '@/lib/colors';
 
 export const GET = withAuth(async (_request, session) => {
   // Get all relationship types for the user
@@ -58,7 +59,7 @@ export const POST = withAuth(async (request, session) => {
           userId: session.user.id,
           name: normalizedName,
           label,
-          color: color || null,
+          color: color || getRandomColor(),
         },
       });
 
@@ -107,7 +108,7 @@ export const POST = withAuth(async (request, session) => {
           userId: session.user.id,
           name: inverseName,
           label: inverseLabel,
-          color: color || null,
+          color: color || getRandomColor(),
           // Leave inverseId null for now, will update after creating the main type
         },
       });
@@ -121,7 +122,7 @@ export const POST = withAuth(async (request, session) => {
         userId: session.user.id,
         name: normalizedName,
         label,
-        color: color || null,
+        color: color || getRandomColor(),
         inverseId: finalInverseId,
       },
       include: {

--- a/tests/api/groups.test.ts
+++ b/tests/api/groups.test.ts
@@ -227,7 +227,7 @@ describe('Groups API', () => {
       expect(mocks.groupCreate).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
-            color: null,
+            color: expect.stringMatching(/^#[0-9a-f]{6}$/),
           }),
         })
       );


### PR DESCRIPTION
## Summary

Follow-up to #289 (API token auth). Fixes issues found when exercising the API with bearer tokens instead of browser sessions:

- **Billing routes blocked from token auth**: All 7 billing routes (`checkout`, `portal`, `cancel`, `subscription`, `history`, `usage`, `apply-promotion`) now set `allowApiToken: false`. These are browser-only Stripe flows, and `checkout` specifically relied on `session.user.email`/`.name` which the bearer auth path doesn't populate.
- **Random color defaults on create**: `POST /api/groups` and `POST /api/relationship-types` now assign a random color via `getRandomColor()` when none is provided, instead of storing `null`. The UI always sent a color, but raw API callers exposed this gap.
- **Preserve existing colors on update**: `PUT /api/groups/[id]` and `PUT /api/relationship-types/[id]` now use `color ?? existing.color ?? getRandomColor()` to keep the current color when the caller omits it, instead of overwriting with `null`.

## Test plan

- [ ] Create a group via API token without `color` field, verify it gets a random color
- [ ] Update a group via API token without `color` field, verify existing color is preserved
- [ ] Create a relationship type via API token without `color`, verify random color assigned
- [ ] Update a relationship type via API token without `color`, verify existing color preserved
- [ ] Confirm all billing endpoints return 401 when called with a bearer token
- [ ] Confirm billing endpoints still work normally with a browser session