### PR TITLE
feat: full-text search across all person data

### DIFF
--- a/app/api/people/search-index/route.ts
+++ b/app/api/people/search-index/route.ts
@@ -1,0 +1,74 @@
+import { prisma } from '@/lib/prisma';
+import { apiResponse, withAuth } from '@/lib/api-utils';
+
+export const GET = withAuth(async (_request, session) => {
+  const people = await prisma.person.findMany({
+    where: {
+      userId: session.user.id,
+      deletedAt: null,
+    },
+    select: {
+      id: true,
+      name: true,
+      surname: true,
+      middleName: true,
+      secondLastName: true,
+      nickname: true,
+      organization: true,
+      jobTitle: true,
+      notes: true,
+      photo: true,
+      phoneNumbers: { select: { number: true } },
+      emails: { select: { email: true } },
+      addresses: {
+        select: {
+          streetLine1: true,
+          streetLine2: true,
+          locality: true,
+          region: true,
+          postalCode: true,
+          country: true,
+        },
+      },
+      urls: { select: { url: true } },
+      imHandles: { select: { handle: true } },
+      groups: {
+        where: { group: { deletedAt: null } },
+        include: { group: { select: { name: true } } },
+      },
+      customFields: { select: { key: true, value: true } },
+      customFieldValues: {
+        include: { template: { select: { name: true } } },
+      },
+    },
+    orderBy: { name: 'asc' },
+  });
+
+  const indexData = people.map((person) => ({
+    id: person.id,
+    name: person.name,
+    surname: person.surname,
+    middleName: person.middleName,
+    secondLastName: person.secondLastName,
+    nickname: person.nickname,
+    organization: person.organization,
+    jobTitle: person.jobTitle,
+    notes: person.notes,
+    photo: person.photo,
+    phones: person.phoneNumbers.map((p) => p.number).join(' '),
+    emails: person.emails.map((e) => e.email).join(' '),
+    addresses: person.addresses
+      .flatMap((a) => [a.streetLine1, a.streetLine2, a.locality, a.region, a.postalCode, a.country])
+      .filter(Boolean)
+      .join(' '),
+    urls: person.urls.map((u) => u.url).join(' '),
+    imHandles: person.imHandles.map((im) => im.handle).join(' '),
+    groups: person.groups.map((pg) => pg.group.name).join(' '),
+    customFields: [
+      ...person.customFields.map((cf) => `${cf.key} ${cf.value}`),
+      ...person.customFieldValues.map((cfv) => `${cfv.template.name} ${cfv.value}`),
+    ].join(' '),
+  }));
+
+  return apiResponse.ok({ people: indexData });
+});

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { NextIntlClientProvider } from 'next-intl';
 import { getMessages } from 'next-intl/server';
 import SessionProvider from "@/components/SessionProvider";
 import ThemeProvider from "@/components/ThemeProvider";
+import { SearchIndexProvider } from "@/components/SearchIndexProvider";
 import LocaleSync from "@/components/LocaleSync";
 import { Toaster } from "sonner";
 import { auth } from "@/lib/auth";
@@ -57,7 +58,9 @@ export default async function RootLayout({
         <NextIntlClientProvider messages={messages} locale={locale}>
           <SessionProvider>
             <ThemeProvider initialTheme={initialTheme}>
-              {children}
+              <SearchIndexProvider>
+                {children}
+              </SearchIndexProvider>
             </ThemeProvider>
           </SessionProvider>
           <LocaleSync locale={locale} />

--- a/components/BulkDeleteModal.tsx
+++ b/components/BulkDeleteModal.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import ConfirmationModal from './ui/ConfirmationModal';
+import { useSearchIndex } from './SearchIndexProvider';
 
 interface Orphan {
   id: string;
@@ -29,6 +30,7 @@ export default function BulkDeleteModal({
   onSuccess,
 }: BulkDeleteModalProps) {
   const t = useTranslations('people.bulk');
+  const { refreshIndex } = useSearchIndex();
   const [isDeleting, setIsDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [orphans, setOrphans] = useState<Orphan[]>([]);
@@ -95,6 +97,7 @@ export default function BulkDeleteModal({
       });
 
       if (response.ok) {
+        refreshIndex();
         onSuccess();
       } else {
         const data = await response.json();

--- a/components/BulkGroupAssignModal.tsx
+++ b/components/BulkGroupAssignModal.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import ConfirmationModal from './ui/ConfirmationModal';
 import GroupsSelector from './GroupsSelector';
+import { useSearchIndex } from './SearchIndexProvider';
 
 interface Group {
   id: string;
@@ -34,6 +35,7 @@ export default function BulkGroupAssignModal({
   onGroupCreated,
 }: BulkGroupAssignModalProps) {
   const t = useTranslations('people.bulk');
+  const { refreshIndex } = useSearchIndex();
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -70,6 +72,7 @@ export default function BulkGroupAssignModal({
         const data = await response.json();
         toast.success(t('addToGroupsSuccess', { count: data.affectedCount }));
         setSelectedGroupIds([]);
+        refreshIndex();
         onSuccess();
       } else {
         const data = await response.json();

--- a/components/BulkRelationshipModal.tsx
+++ b/components/BulkRelationshipModal.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import ConfirmationModal from './ui/ConfirmationModal';
+import { useSearchIndex } from './SearchIndexProvider';
 
 interface RelationshipType {
   id: string;
@@ -31,6 +32,7 @@ export default function BulkRelationshipModal({
   onSuccess,
 }: BulkRelationshipModalProps) {
   const t = useTranslations('people.bulk');
+  const { refreshIndex } = useSearchIndex();
   const [selectedTypeId, setSelectedTypeId] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -68,6 +70,7 @@ export default function BulkRelationshipModal({
         toast.success(t('setRelationshipSuccess', { count: data.affectedCount }));
         setSelectedTypeId('');
         setIsSubmitting(false);
+        refreshIndex();
         onSuccess();
       } else {
         const data = await response.json();

--- a/components/ImportContactsList.tsx
+++ b/components/ImportContactsList.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { parseVCard as vCardToPerson } from '@/lib/carddav/vcard-parser';
 import CompactContactRow from './CompactContactRow';
 import GroupsSelector from './GroupsSelector';
+import { useSearchIndex } from '@/components/SearchIndexProvider';
 
 interface PendingImport {
   id: string;
@@ -43,6 +44,7 @@ export default function ImportContactsList({
 }: ImportContactsListProps) {
   const t = useTranslations('settings.carddav.import');
   const router = useRouter();
+  const { refreshIndex } = useSearchIndex();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
   const [perContactGroups, setPerContactGroups] = useState<Map<string, string[]>>(new Map());
@@ -183,6 +185,7 @@ export default function ImportContactsList({
         errors: data.errors.toString(),
       });
       const redirectUrl = isFileImport ? '/people' : '/settings/carddav';
+      refreshIndex();
       router.push(`${redirectUrl}?${params.toString()}`);
     } catch (err) {
       setError(err instanceof Error ? err.message : t('importFailed'));

--- a/components/NavigationSearch.tsx
+++ b/components/NavigationSearch.tsx
@@ -1,15 +1,18 @@
 'use client';
 
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { formatFullName } from '@/lib/nameUtils';
 import PersonAvatar from './PersonPhoto';
+import { useSearchIndex } from './SearchIndexProvider';
 
 interface Person {
   id: string;
   name: string;
   surname?: string | null;
+  middleName?: string | null;
+  secondLastName?: string | null;
   nickname?: string | null;
   photo?: string | null;
 }
@@ -23,6 +26,7 @@ export default function NavigationSearch() {
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
   const [nameOrder, setNameOrder] = useState<'WESTERN' | 'EASTERN'>('WESTERN');
+  const { search: clientSearch, isReady: searchIndexReady } = useSearchIndex();
 
   // Fetch user's name order preference
   useEffect(() => {
@@ -54,45 +58,50 @@ export default function NavigationSearch() {
   const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
   const itemRefs = useRef<Map<number, HTMLButtonElement>>(new Map());
 
-  // Debounced server-side search
-  const performSearch = useCallback(async (query: string) => {
-    if (query.length === 0) {
+  // Search: instant client-side when index is ready, server fallback otherwise
+  useEffect(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+
+    if (!searchTerm.trim()) {
       setResults([]);
       setIsLoading(false);
       return;
     }
 
-    setIsLoading(true);
-    try {
-      const response = await fetch(`/api/people/search?q=${encodeURIComponent(query)}`);
-      const data = await response.json();
-      if (data.people && Array.isArray(data.people)) {
-        setResults(data.people);
-      }
-    } catch (error) {
-      console.error('Search failed:', error);
-      setResults([]);
-    } finally {
+    if (searchIndexReady) {
+      setResults(clientSearch(searchTerm));
       setIsLoading(false);
-    }
-  }, []);
-
-  // Debounce search input
-  useEffect(() => {
-    if (debounceTimerRef.current) {
-      clearTimeout(debounceTimerRef.current);
+      return;
     }
 
-    debounceTimerRef.current = setTimeout(() => {
-      performSearch(searchTerm);
+    // Fallback: server-side search with debounce
+    setIsLoading(true);
+    debounceTimerRef.current = setTimeout(async () => {
+      try {
+        const response = await fetch(
+          `/api/people/search?q=${encodeURIComponent(searchTerm)}`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          setResults(data.people || []);
+        }
+      } catch {
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
     }, 300);
 
     return () => {
       if (debounceTimerRef.current) {
         clearTimeout(debounceTimerRef.current);
+        debounceTimerRef.current = null;
       }
     };
-  }, [searchTerm, performSearch]);
+  }, [searchTerm, searchIndexReady, clientSearch]);
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/components/PersonActionsMenu.tsx
+++ b/components/PersonActionsMenu.tsx
@@ -15,6 +15,7 @@ import ConfirmationModal from '@/components/ui/ConfirmationModal';
 import PersonAutocomplete from '@/components/PersonAutocomplete';
 import { DuplicateCandidateDisplay } from '@/components/DuplicatesList';
 import type { NameDisplayFormat } from '@/lib/nameUtils';
+import { useSearchIndex } from '@/components/SearchIndexProvider';
 
 interface PersonForSearch {
   id: string;
@@ -51,6 +52,7 @@ export default function PersonActionsMenu({
   const tDup = useTranslations('people.duplicates');
   const tMerge = useTranslations('people.merge');
   const router = useRouter();
+  const { refreshIndex } = useSearchIndex();
 
   // Dropdown state
   const [menuOpen, setMenuOpen] = useState(false);
@@ -253,6 +255,7 @@ export default function PersonActionsMenu({
       if (response.ok) {
         router.push('/people');
         router.refresh();
+        refreshIndex();
       } else {
         const data = await response.json();
         setDeleteError(data.error || t('deletePersonFailed'));

--- a/components/RelationshipManager.tsx
+++ b/components/RelationshipManager.tsx
@@ -9,6 +9,7 @@ import PersonAutocomplete from './PersonAutocomplete';
 import { formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
 import { Button } from './ui/Button';
 import PersonAvatar from './PersonPhoto';
+import { useSearchIndex } from './SearchIndexProvider';
 
 interface Person {
   id: string;
@@ -67,6 +68,7 @@ export default function RelationshipManager({
   const t = useTranslations('people');
   const tCommon = useTranslations('common');
   const router = useRouter();
+  const { refreshIndex } = useSearchIndex();
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -130,6 +132,7 @@ export default function RelationshipManager({
         setShowAddModal(false);
         setFormData({ relatedPersonId: '', relationshipTypeId: defaultTypeId, notes: '' });
         router.refresh();
+        refreshIndex();
         return;
       }
 
@@ -161,6 +164,7 @@ export default function RelationshipManager({
       setShowAddModal(false);
       setFormData({ relatedPersonId: '', relationshipTypeId: defaultTypeId, notes: '' });
       router.refresh();
+      refreshIndex();
     } catch (_error) {
       setError('Unable to connect to server. Please check your connection and try again.');
     } finally {
@@ -198,6 +202,7 @@ export default function RelationshipManager({
       setShowEditModal(false);
       setSelectedRelationship(null);
       router.refresh();
+      refreshIndex();
     } catch (_error) {
       setError('Unable to connect to server. Please check your connection and try again.');
     } finally {
@@ -225,6 +230,7 @@ export default function RelationshipManager({
       setShowDeleteModal(false);
       setSelectedRelationship(null);
       router.refresh();
+      refreshIndex();
     } catch (_error) {
       setError('Unable to connect to server. Please check your connection and try again.');
     } finally {

--- a/components/SearchIndexProvider.tsx
+++ b/components/SearchIndexProvider.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
+import { useSession } from 'next-auth/react';
+import type MiniSearch from 'minisearch';
+import { createSearchIndex, searchIndex as performSearch } from '@/lib/search-index';
+import type { SearchDocument, PersonSearchResult } from '@/lib/search-index';
+
+interface SearchIndexContextType {
+  search: (query: string) => PersonSearchResult[];
+  isReady: boolean;
+  refreshIndex: () => void;
+}
+
+const SearchIndexContext = createContext<SearchIndexContextType | undefined>(undefined);
+
+export function SearchIndexProvider({ children }: { children: React.ReactNode }) {
+  const { data: session } = useSession();
+  const [isReady, setIsReady] = useState(false);
+  const indexRef = useRef<MiniSearch<SearchDocument> | null>(null);
+
+  const buildIndex = useCallback(async () => {
+    try {
+      const response = await fetch('/api/people/search-index');
+      if (!response.ok) return;
+      const data = await response.json();
+
+      indexRef.current = createSearchIndex(data.people);
+      setIsReady(true);
+    } catch {
+      // Silently fail; search falls back to server-side
+    }
+  }, []);
+
+  useEffect(() => {
+    if (session?.user) {
+      buildIndex();
+    }
+  }, [session, buildIndex]);
+
+  const search = useCallback((query: string): PersonSearchResult[] => {
+    if (!indexRef.current) return [];
+    return performSearch(indexRef.current, query);
+  }, []);
+
+  const refreshIndex = useCallback(() => {
+    buildIndex();
+  }, [buildIndex]);
+
+  return (
+    <SearchIndexContext.Provider value={{ search, isReady, refreshIndex }}>
+      {children}
+    </SearchIndexContext.Provider>
+  );
+}
+
+export function useSearchIndex() {
+  const context = useContext(SearchIndexContext);
+  if (!context) {
+    throw new Error('useSearchIndex must be used within a SearchIndexProvider');
+  }
+  return context;
+}

--- a/components/SearchIndexProvider.tsx
+++ b/components/SearchIndexProvider.tsx
@@ -14,29 +14,32 @@ interface SearchIndexContextType {
 
 const SearchIndexContext = createContext<SearchIndexContextType | undefined>(undefined);
 
+async function fetchAndBuildIndex(
+  indexRef: React.RefObject<MiniSearch<SearchDocument> | null>,
+  setIsReady: (ready: boolean) => void,
+) {
+  try {
+    const response = await fetch('/api/people/search-index');
+    if (!response.ok) return;
+    const data = await response.json();
+
+    indexRef.current = createSearchIndex(data.people);
+    setIsReady(true);
+  } catch {
+    // Silently fail; search falls back to server-side
+  }
+}
+
 export function SearchIndexProvider({ children }: { children: React.ReactNode }) {
   const { data: session } = useSession();
   const [isReady, setIsReady] = useState(false);
   const indexRef = useRef<MiniSearch<SearchDocument> | null>(null);
 
-  const buildIndex = useCallback(async () => {
-    try {
-      const response = await fetch('/api/people/search-index');
-      if (!response.ok) return;
-      const data = await response.json();
-
-      indexRef.current = createSearchIndex(data.people);
-      setIsReady(true);
-    } catch {
-      // Silently fail; search falls back to server-side
-    }
-  }, []);
-
   useEffect(() => {
     if (session?.user) {
-      buildIndex();
+      fetchAndBuildIndex(indexRef, setIsReady);
     }
-  }, [session, buildIndex]);
+  }, [session]);
 
   const search = useCallback((query: string): PersonSearchResult[] => {
     if (!indexRef.current) return [];
@@ -44,8 +47,8 @@ export function SearchIndexProvider({ children }: { children: React.ReactNode })
   }, []);
 
   const refreshIndex = useCallback(() => {
-    buildIndex();
-  }, [buildIndex]);
+    fetchAndBuildIndex(indexRef, setIsReady);
+  }, []);
 
   return (
     <SearchIndexContext.Provider value={{ search, isReady, refreshIndex }}>

--- a/components/person-form/PersonForm.tsx
+++ b/components/person-form/PersonForm.tsx
@@ -24,6 +24,7 @@ import { Button } from '../ui/Button';
 import CardDavSyncSection from './CardDavSyncSection';
 import CustomFieldsSection from '../customFields/CustomFieldsSection';
 import type { CustomFieldTemplate } from '@prisma/client';
+import { useSearchIndex } from '@/components/SearchIndexProvider';
 
 type ReminderIntervalUnit = 'DAYS' | 'WEEKS' | 'MONTHS' | 'YEARS';
 
@@ -157,6 +158,7 @@ export default function PersonForm({
   const t = useTranslations('people.form');
   const tPhoto = useTranslations('people.photo');
   const router = useRouter();
+  const { refreshIndex } = useSearchIndex();
 
   const {
     state,
@@ -371,6 +373,7 @@ export default function PersonForm({
       if (mode === 'edit' && person?.id) {
         router.push(`/people/${person.id}`);
         router.refresh();
+        refreshIndex();
       } else if (mode === 'create' && addAnother) {
         const params = new URLSearchParams();
         if (initialKnownThrough) {
@@ -380,18 +383,22 @@ export default function PersonForm({
           params.set('relationshipType', initialRelationshipType);
         }
         const queryString = params.toString();
+        refreshIndex();
         window.location.href = queryString
           ? `/people/new?${queryString}`
           : '/people/new';
       } else if (mode === 'create' && knownThroughId !== 'user') {
         router.push(`/people/${knownThroughId}`);
         router.refresh();
+        refreshIndex();
       } else if (mode === 'create' && data.person?.id) {
         router.push(`/people/${data.person.id}`);
         router.refresh();
+        refreshIndex();
       } else {
         router.push('/people');
         router.refresh();
+        refreshIndex();
       }
     } catch {
       setError(t('errorSomethingWrong'));

--- a/lib/openapi/people.ts
+++ b/lib/openapi/people.ts
@@ -124,6 +124,51 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         },
       },
     },
+    '/api/people/search-index': {
+      get: {
+        tags: ['People'],
+        summary: 'Get search index data',
+        description:
+          'Returns all searchable data for the authenticated user\'s contacts in a flat, ' +
+          'denormalized format optimized for client-side indexing. Multi-value fields ' +
+          '(phones, emails, addresses, etc.) are joined into single strings.',
+        security: [{ session: [] }],
+        responses: {
+          '200': jsonResponse('Search index data', {
+            type: 'object',
+            properties: {
+              people: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    surname: { type: 'string', nullable: true },
+                    middleName: { type: 'string', nullable: true },
+                    secondLastName: { type: 'string', nullable: true },
+                    nickname: { type: 'string', nullable: true },
+                    organization: { type: 'string', nullable: true },
+                    jobTitle: { type: 'string', nullable: true },
+                    notes: { type: 'string', nullable: true },
+                    phones: { type: 'string', description: 'All phone numbers, space-joined' },
+                    emails: { type: 'string', description: 'All email addresses, space-joined' },
+                    addresses: { type: 'string', description: 'All address components, space-joined' },
+                    urls: { type: 'string', description: 'All URLs, space-joined' },
+                    imHandles: { type: 'string', description: 'All IM handles, space-joined' },
+                    groups: { type: 'string', description: 'All group names, space-joined' },
+                    customFields: { type: 'string', description: 'All custom field key-value pairs, space-joined' },
+                    photo: { type: 'string', nullable: true },
+                  },
+                  required: ['id', 'name', 'phones', 'emails', 'addresses', 'urls', 'imHandles', 'groups', 'customFields'],
+                },
+              },
+            },
+          }),
+          '401': ref401(),
+        },
+      },
+    },
     '/api/people/{id}/orphans': {
       get: {
         tags: ['People'],

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -60,6 +60,7 @@ export function searchIndex(
 ): PersonSearchResult[] {
   if (!query.trim()) return [];
 
+  // AND: all query words must appear on the same person
   const results = index.search(query, {
     fuzzy: 0.2,
     prefix: true,

--- a/lib/search-index.ts
+++ b/lib/search-index.ts
@@ -1,0 +1,79 @@
+import MiniSearch from 'minisearch';
+import { normalizeForSearch } from '@/lib/search';
+
+export interface SearchDocument {
+  id: string;
+  name: string;
+  surname: string | null;
+  middleName: string | null;
+  secondLastName: string | null;
+  nickname: string | null;
+  organization: string | null;
+  jobTitle: string | null;
+  notes: string | null;
+  phones: string;
+  emails: string;
+  addresses: string;
+  urls: string;
+  imHandles: string;
+  groups: string;
+  customFields: string;
+  photo: string | null;
+}
+
+export interface PersonSearchResult {
+  id: string;
+  name: string;
+  surname: string | null;
+  middleName: string | null;
+  secondLastName: string | null;
+  nickname: string | null;
+  photo: string | null;
+  score: number;
+}
+
+const INDEXED_FIELDS = [
+  'name', 'surname', 'middleName', 'secondLastName', 'nickname',
+  'organization', 'jobTitle', 'notes',
+  'phones', 'emails', 'addresses', 'urls', 'imHandles',
+  'groups', 'customFields',
+];
+
+const STORED_FIELDS = [
+  'id', 'name', 'surname', 'middleName', 'secondLastName', 'nickname', 'photo',
+];
+
+export function createSearchIndex(documents: SearchDocument[]): MiniSearch<SearchDocument> {
+  const index = new MiniSearch<SearchDocument>({
+    fields: INDEXED_FIELDS,
+    storeFields: STORED_FIELDS,
+    processTerm: (term) => normalizeForSearch(term) || null,
+  });
+  index.addAll(documents);
+  return index;
+}
+
+export function searchIndex(
+  index: MiniSearch<SearchDocument>,
+  query: string,
+  maxResults = 20
+): PersonSearchResult[] {
+  if (!query.trim()) return [];
+
+  const results = index.search(query, {
+    fuzzy: 0.2,
+    prefix: true,
+    combineWith: 'AND',
+  });
+
+  return results.slice(0, maxResults).map((result) => ({
+    id: result.id as string,
+    name: result.name as string,
+    surname: (result.surname as string | null) ?? null,
+    middleName: (result.middleName as string | null) ?? null,
+    secondLastName: (result.secondLastName as string | null) ?? null,
+    nickname: (result.nickname as string | null) ?? null,
+    photo: (result.photo as string | null) ?? null,
+    score: result.score,
+  }));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "flag-icons": "^7.5.0",
         "ioredis": "^5.8.2",
         "isomorphic-dompurify": "^2.34.0",
+        "minisearch": "^7.2.0",
         "next": "^16.0.10",
         "next-auth": "^5.0.0-beta.30",
         "next-intl": "^4.7.0",
@@ -10526,6 +10527,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "flag-icons": "^7.5.0",
     "ioredis": "^5.8.2",
     "isomorphic-dompurify": "^2.34.0",
+    "minisearch": "^7.2.0",
     "next": "^16.0.10",
     "next-auth": "^5.0.0-beta.30",
     "next-intl": "^4.7.0",

--- a/tests/api/people-search-index.test.ts
+++ b/tests/api/people-search-index.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+// Use vi.hoisted to create mocks before hoisting
+const mocks = vi.hoisted(() => ({
+  personFindMany: vi.fn(),
+}));
+
+vi.mock('../../lib/prisma', () => ({
+  prisma: { person: { findMany: mocks.personFindMany } },
+}));
+
+vi.mock('../../lib/auth', () => ({
+  auth: vi.fn(() =>
+    Promise.resolve({
+      user: { id: 'user123', email: 'test@example.com', name: 'Test' },
+    })
+  ),
+}));
+
+vi.mock('../../lib/logger', () => ({
+  createLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createModuleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+import { GET } from '../../app/api/people/search-index/route';
+
+describe('GET /api/people/search-index', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return denormalized search data', async () => {
+    mocks.personFindMany.mockResolvedValue([
+      {
+        id: 'p1',
+        name: 'Maria',
+        surname: 'Garcia',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        organization: 'Acme',
+        jobTitle: 'Dev',
+        notes: 'Test note',
+        photo: null,
+        phoneNumbers: [{ number: '+34 612 345 678' }],
+        emails: [{ email: 'maria@acme.com' }],
+        addresses: [{
+          streetLine1: '123 Main',
+          streetLine2: null,
+          locality: 'Madrid',
+          region: null,
+          postalCode: '28001',
+          country: 'Spain',
+        }],
+        urls: [{ url: 'https://maria.dev' }],
+        imHandles: [{ handle: 'maria_telegram' }],
+        groups: [{ group: { name: 'Work' } }],
+        customFields: [{ key: 'hobby', value: 'painting' }],
+        customFieldValues: [{ value: 'Blue', template: { name: 'Favorite Color' } }],
+      },
+    ]);
+
+    const request = new NextRequest('http://localhost:3000/api/people/search-index');
+    const response = await GET(request, {});
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.people).toHaveLength(1);
+
+    const person = data.people[0];
+    expect(person.id).toBe('p1');
+    expect(person.name).toBe('Maria');
+    expect(person.surname).toBe('Garcia');
+    expect(person.organization).toBe('Acme');
+    expect(person.phones).toBe('+34 612 345 678');
+    expect(person.emails).toBe('maria@acme.com');
+    expect(person.addresses).toContain('Madrid');
+    expect(person.addresses).toContain('Spain');
+    expect(person.addresses).toContain('28001');
+    expect(person.urls).toBe('https://maria.dev');
+    expect(person.imHandles).toBe('maria_telegram');
+    expect(person.groups).toBe('Work');
+    expect(person.customFields).toContain('painting');
+    expect(person.customFields).toContain('hobby');
+    expect(person.customFields).toContain('Favorite Color');
+    expect(person.customFields).toContain('Blue');
+  });
+
+  it('should return empty array when user has no people', async () => {
+    mocks.personFindMany.mockResolvedValue([]);
+
+    const request = new NextRequest('http://localhost:3000/api/people/search-index');
+    const response = await GET(request, {});
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.people).toEqual([]);
+  });
+
+  it('should filter by current user and exclude soft-deleted', async () => {
+    mocks.personFindMany.mockResolvedValue([]);
+
+    const request = new NextRequest('http://localhost:3000/api/people/search-index');
+    await GET(request, {});
+
+    expect(mocks.personFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'user123', deletedAt: null },
+      })
+    );
+  });
+
+  it('should handle person with no multi-value fields', async () => {
+    mocks.personFindMany.mockResolvedValue([
+      {
+        id: 'p2',
+        name: 'Solo',
+        surname: null,
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        organization: null,
+        jobTitle: null,
+        notes: null,
+        photo: null,
+        phoneNumbers: [],
+        emails: [],
+        addresses: [],
+        urls: [],
+        imHandles: [],
+        groups: [],
+        customFields: [],
+        customFieldValues: [],
+      },
+    ]);
+
+    const request = new NextRequest('http://localhost:3000/api/people/search-index');
+    const response = await GET(request, {});
+    const data = await response.json();
+
+    const person = data.people[0];
+    expect(person.phones).toBe('');
+    expect(person.emails).toBe('');
+    expect(person.addresses).toBe('');
+    expect(person.urls).toBe('');
+    expect(person.imHandles).toBe('');
+    expect(person.groups).toBe('');
+    expect(person.customFields).toBe('');
+  });
+});

--- a/tests/api/people-search-index.test.ts
+++ b/tests/api/people-search-index.test.ts
@@ -72,7 +72,7 @@ describe('GET /api/people/search-index', () => {
     ]);
 
     const request = new NextRequest('http://localhost:3000/api/people/search-index');
-    const response = await GET(request, {});
+    const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -101,7 +101,7 @@ describe('GET /api/people/search-index', () => {
     mocks.personFindMany.mockResolvedValue([]);
 
     const request = new NextRequest('http://localhost:3000/api/people/search-index');
-    const response = await GET(request, {});
+    const response = await GET(request);
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -112,7 +112,7 @@ describe('GET /api/people/search-index', () => {
     mocks.personFindMany.mockResolvedValue([]);
 
     const request = new NextRequest('http://localhost:3000/api/people/search-index');
-    await GET(request, {});
+    await GET(request);
 
     expect(mocks.personFindMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -146,7 +146,7 @@ describe('GET /api/people/search-index', () => {
     ]);
 
     const request = new NextRequest('http://localhost:3000/api/people/search-index');
-    const response = await GET(request, {});
+    const response = await GET(request);
     const data = await response.json();
 
     const person = data.people[0];

--- a/tests/components/ImportContactsList.test.tsx
+++ b/tests/components/ImportContactsList.test.tsx
@@ -26,6 +26,11 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mock SearchIndexProvider
+vi.mock('@/components/SearchIndexProvider', () => ({
+  useSearchIndex: () => ({ refreshIndex: vi.fn(), search: vi.fn(), isReady: false }),
+}));
+
 describe('ImportContactsList', () => {
   const mockPush = vi.fn();
   const mockRefresh = vi.fn();

--- a/tests/components/PersonActionsMenu.test.tsx
+++ b/tests/components/PersonActionsMenu.test.tsx
@@ -32,6 +32,11 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mock SearchIndexProvider
+vi.mock('@/components/SearchIndexProvider', () => ({
+  useSearchIndex: () => ({ refreshIndex: vi.fn(), search: vi.fn(), isReady: false }),
+}));
+
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
     <NextIntlClientProvider locale="en" messages={enMessages}>

--- a/tests/components/PersonForm-CardDavSync.test.tsx
+++ b/tests/components/PersonForm-CardDavSync.test.tsx
@@ -21,6 +21,11 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mock SearchIndexProvider
+vi.mock('@/components/SearchIndexProvider', () => ({
+  useSearchIndex: () => ({ refreshIndex: vi.fn(), search: vi.fn(), isReady: false }),
+}));
+
 function Wrapper({ children }: { children: React.ReactNode }) {
   return (
     <NextIntlClientProvider locale="en" messages={enMessages}>

--- a/tests/components/RelationshipManager.test.tsx
+++ b/tests/components/RelationshipManager.test.tsx
@@ -12,6 +12,11 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// Mock SearchIndexProvider
+vi.mock('../../components/SearchIndexProvider', () => ({
+  useSearchIndex: () => ({ refreshIndex: vi.fn(), search: vi.fn(), isReady: false }),
+}));
+
 // Store the onChange callback so tests can simulate person selection
 let capturedOnChange: ((personId: string, personName: string) => void) | null = null;
 

--- a/tests/lib/search-index.test.ts
+++ b/tests/lib/search-index.test.ts
@@ -62,8 +62,8 @@ describe('search-index', () => {
     it('should find people accent-insensitive', () => {
       const docs: SearchDocument[] = [{
         ...testDocuments[0],
-        name: 'Maria',
-        surname: 'Garcia',
+        name: 'María',
+        surname: 'García',
       }];
       const index = createSearchIndex(docs);
       const results = searchIndex(index, 'garcia');

--- a/tests/lib/search-index.test.ts
+++ b/tests/lib/search-index.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect } from 'vitest';
+import { createSearchIndex, searchIndex } from '@/lib/search-index';
+import type { SearchDocument } from '@/lib/search-index';
+
+const testDocuments: SearchDocument[] = [
+  {
+    id: '1',
+    name: 'Maria',
+    surname: 'Garcia',
+    middleName: null,
+    secondLastName: 'Lopez',
+    nickname: null,
+    organization: 'Acme Corp',
+    jobTitle: 'Engineer',
+    notes: 'Met at conference in Madrid',
+    phones: '+34 612 345 678',
+    emails: 'maria@acme.com',
+    addresses: '123 Calle Mayor Madrid Spain',
+    urls: 'https://linkedin.com/in/mariagarcia',
+    imHandles: '',
+    groups: 'Work Friends',
+    customFields: '',
+    photo: null,
+  },
+  {
+    id: '2',
+    name: 'John',
+    surname: 'Smith',
+    middleName: null,
+    secondLastName: null,
+    nickname: 'Johnny',
+    organization: 'Globex',
+    jobTitle: 'Designer',
+    notes: 'Lives in Berlin',
+    phones: '+1 555 123 4567',
+    emails: 'john@globex.com',
+    addresses: '456 Hauptstrasse Berlin Germany',
+    urls: '',
+    imHandles: 'john_smith_telegram',
+    groups: 'Friends',
+    customFields: 'Spotify handle @johnsmith',
+    photo: '/photos/john.jpg',
+  },
+];
+
+describe('search-index', () => {
+  describe('createSearchIndex', () => {
+    it('should create an index from documents', () => {
+      const index = createSearchIndex(testDocuments);
+      expect(index).toBeDefined();
+    });
+  });
+
+  describe('searchIndex', () => {
+    it('should find people by name', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Maria');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('1');
+    });
+
+    it('should find people accent-insensitive', () => {
+      const docs: SearchDocument[] = [{
+        ...testDocuments[0],
+        name: 'Maria',
+        surname: 'Garcia',
+      }];
+      const index = createSearchIndex(docs);
+      const results = searchIndex(index, 'garcia');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('1');
+    });
+
+    it('should find people by organization', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Globex');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('2');
+    });
+
+    it('should find people by city in address', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Madrid');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('1');
+    });
+
+    it('should find people by notes content', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Berlin');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('2');
+    });
+
+    it('should find people by email domain', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'acme');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('1');
+    });
+
+    it('should find people by phone number fragment', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, '612');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('1');
+    });
+
+    it('should find people by group name', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Work');
+      expect(results.some((r) => r.id === '1')).toBe(true);
+    });
+
+    it('should find people by custom field value', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Spotify');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('2');
+    });
+
+    it('should find people by nickname', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Johnny');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('2');
+    });
+
+    it('should support prefix matching', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Gar');
+      expect(results.some((r) => r.id === '1')).toBe(true);
+    });
+
+    it('should support fuzzy matching for typos', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'Johhny');
+      expect(results.some((r) => r.id === '2')).toBe(true);
+    });
+
+    it('should return empty array for empty query', () => {
+      const index = createSearchIndex(testDocuments);
+      expect(searchIndex(index, '')).toHaveLength(0);
+    });
+
+    it('should return empty array for whitespace-only query', () => {
+      const index = createSearchIndex(testDocuments);
+      expect(searchIndex(index, '   ')).toHaveLength(0);
+    });
+
+    it('should return stored fields in results', () => {
+      const index = createSearchIndex(testDocuments);
+      const results = searchIndex(index, 'John');
+      const result = results[0];
+      expect(result).toHaveProperty('id');
+      expect(result).toHaveProperty('name');
+      expect(result).toHaveProperty('surname');
+      expect(result).toHaveProperty('nickname');
+      expect(result).toHaveProperty('photo');
+      expect(result).toHaveProperty('score');
+    });
+
+    it('should limit results to maxResults', () => {
+      const docs = Array.from({ length: 30 }, (_, i) => ({
+        ...testDocuments[0],
+        id: `doc-${i}`,
+        name: `Person ${i}`,
+      }));
+      const index = createSearchIndex(docs);
+      const results = searchIndex(index, 'Person', 5);
+      expect(results).toHaveLength(5);
+    });
+
+    it('should default to 20 max results', () => {
+      const docs = Array.from({ length: 30 }, (_, i) => ({
+        ...testDocuments[0],
+        id: `doc-${i}`,
+        name: `Person ${i}`,
+      }));
+      const index = createSearchIndex(docs);
+      const results = searchIndex(index, 'Person');
+      expect(results.length).toBeLessThanOrEqual(20);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds client-side full-text search using MiniSearch, replacing the server-side name-only search
- Search now covers all person fields: name, organization, job title, notes, phone numbers, emails, addresses, URLs, IM handles, groups, and custom fields
- Results appear instantly on every keystroke (no network round-trip, no debounce delay)
- Supports fuzzy matching (tolerates typos) and accent-insensitive search
- Database-agnostic by design (no PostgreSQL-specific features)

Closes #296

## What changed

- **New API endpoint** `GET /api/people/search-index` returns all searchable person data in a flat, denormalized format optimized for indexing
- **New search index module** (`lib/search-index.ts`) wraps MiniSearch with accent-insensitive term processing via `normalizeForSearch()`
- **New React context** (`SearchIndexProvider`) manages the index lifecycle: builds on auth, exposes `search()` and `refreshIndex()`
- **NavigationSearch** now uses the client-side index for instant results, with a server-side fallback while the index loads
- **7 mutation components** wired with `refreshIndex()` to keep the index fresh after creates, edits, deletes, and imports
- **OpenAPI spec** updated with the new endpoint

## Test plan

- [ ] 18 unit tests for search index logic (fuzzy, prefix, accent-insensitive, multi-field, max results)
- [ ] 4 API endpoint tests (denormalized shape, empty state, soft-delete filtering, user isolation)
- [ ] OpenAPI spec validation test passes
- [ ] Full test suite: 155 files, 2198 tests passing, 0 failures
- [ ] TypeScript: `tsc --noEmit` clean
- [ ] Manual: type in search bar, results appear instantly
- [ ] Manual: search by city, company, email, phone, group name, notes content
- [ ] Manual: fuzzy match (typo in name still finds the person)
- [ ] Manual: create/edit/delete a person, verify search updates