### PR TITLE
fix(carddav): re-export photo when remote vCard lacks PHOTO field

### DIFF
--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -159,8 +159,11 @@ export async function syncFromServer(
 
     // Pre-load all mappings for this connection in a single query.
     // Index by UID and href for O(1) lookups instead of per-vCard DB queries.
+    // Include person.photo so we can detect stuck photo mismatches without
+    // a per-vCard DB round-trip (see photo mismatch check below).
     const allMappings = await prisma.cardDavMapping.findMany({
       where: { connectionId: connection.id },
+      include: { person: { select: { photo: true } } },
     });
 
     const mappingByUid = new Map<string, typeof allMappings[number]>();
@@ -240,7 +243,20 @@ export async function syncFromServer(
             mapping.lastLocalChange > mapping.lastSyncedAt;
 
           if (!remoteChanged && !localChanged) {
-            // Nothing changed - skip without any DB queries
+            // Heal stuck mappings left by pre-862a415 syncs: local person
+            // has a photo but the server vCard does not and the mapping is
+            // already marked synced with a matching etag. Without this
+            // check these contacts would be skipped forever.
+            if (mapping.person?.photo && !parsedData.photo) {
+              await prisma.cardDavMapping.update({
+                where: { id: mapping.id },
+                data: { syncStatus: 'pending', lastLocalChange: new Date() },
+              });
+              log.info(
+                { event: 'carddav.photo_mismatch', personId: mapping.personId },
+                'Local person has photo but remote vCard does not; marking pending for re-export',
+              );
+            }
             continue;
           }
 

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -384,6 +384,19 @@ export async function syncFromServer(
               }
             }
 
+            // Photo mismatch: local person has a photo but the remote vCard
+            // does not. Many servers strip PHOTO during normalization. Mark
+            // as pending so the push phase re-exports with the photo.
+            if (!parsedData.photo && fullMapping.person.photo) {
+              if (syncStatusAfterImport !== 'pending') {
+                log.info(
+                  { event: 'carddav.photo_mismatch', personId: fullMapping.personId },
+                  'Local person has photo but remote vCard does not; marking pending for re-export',
+                );
+              }
+              syncStatusAfterImport = 'pending';
+            }
+
             await prisma.cardDavMapping.update({
               where: { id: mapping.id },
               data: {

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -596,6 +596,105 @@ describe('CardDAV Sync Engine', () => {
       });
     });
 
+    describe('photo mismatch detection', () => {
+      it('should mark as pending when local person has photo but remote vCard does not', async () => {
+        const uid = 'photo-uid';
+        const mappingId = 'mapping-photo';
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-old',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+          }),
+        ]);
+
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/photo.vcf', 'etag-new', 'HasPhoto'),
+        ]);
+
+        // Remote vCard has no photo
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'HasPhoto'));
+
+        // Local person has a photo
+        mocks.cardDavMappingFindFirst.mockResolvedValue(
+          makeFullMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-old',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            person: { photo: 'person-1.jpg' },
+          })
+        );
+        mocks.$transaction.mockResolvedValue([]);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        // Mapping should be marked as pending (not synced)
+        const updateCall = mocks.cardDavMappingUpdate.mock.calls.find(
+          (call: unknown[]) => {
+            const arg = call[0] as { where: { id: string }; data: { syncStatus?: string } };
+            return arg.where.id === mappingId && arg.data.syncStatus !== undefined;
+          }
+        );
+        expect(updateCall).toBeDefined();
+        const updateData = (updateCall![0] as { data: { syncStatus: string; lastLocalChange?: Date } }).data;
+        expect(updateData.syncStatus).toBe('pending');
+        expect(updateData.lastLocalChange).toBeInstanceOf(Date);
+      });
+
+      it('should mark as synced when both local and remote have no photo', async () => {
+        const uid = 'no-photo-uid';
+        const mappingId = 'mapping-no-photo';
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-old',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+          }),
+        ]);
+
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/no-photo.vcf', 'etag-new', 'NoPhoto'),
+        ]);
+
+        // Remote vCard has no photo
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'NoPhoto'));
+
+        // Local person also has no photo
+        mocks.cardDavMappingFindFirst.mockResolvedValue(
+          makeFullMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-old',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            person: { photo: null },
+          })
+        );
+        mocks.$transaction.mockResolvedValue([]);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        const updateCall = mocks.cardDavMappingUpdate.mock.calls.find(
+          (call: unknown[]) => {
+            const arg = call[0] as { where: { id: string }; data: { syncStatus?: string } };
+            return arg.where.id === mappingId && arg.data.syncStatus !== undefined;
+          }
+        );
+        expect(updateCall).toBeDefined();
+        expect((updateCall![0] as { data: { syncStatus: string } }).data.syncStatus).toBe('synced');
+      });
+    });
+
     describe('exported contacts scenario', () => {
       it('should not re-import contacts that were just exported (UID rewrite)', async () => {
         // Pre-loaded mapping: exported contact with local UID and known href

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -224,8 +224,9 @@ function makeParsedVCard(uid: string, name: string) {
   };
 }
 
-/** Lightweight mapping (as returned by findMany without includes) */
+/** Lightweight mapping (as returned by findMany with person.photo include) */
 function makeLightMapping(overrides: Record<string, unknown> = {}) {
+  const personOverride = typeof overrides.person === 'object' ? overrides.person as Record<string, unknown> : {};
   return {
     id: 'mapping-1',
     connectionId: CONNECTION_ID,
@@ -240,6 +241,7 @@ function makeLightMapping(overrides: Record<string, unknown> = {}) {
     localVersion: null,
     remoteVersion: null,
     ...overrides,
+    person: { photo: null, ...personOverride },
   };
 }
 
@@ -317,6 +319,7 @@ describe('CardDAV Sync Engine', () => {
         expect(mocks.cardDavMappingFindMany).toHaveBeenCalledTimes(1);
         expect(mocks.cardDavMappingFindMany).toHaveBeenCalledWith({
           where: { connectionId: CONNECTION_ID },
+          include: { person: { select: { photo: true } } },
         });
       });
 
@@ -597,7 +600,7 @@ describe('CardDAV Sync Engine', () => {
     });
 
     describe('photo mismatch detection', () => {
-      it('should mark as pending when local person has photo but remote vCard does not', async () => {
+      it('should mark as pending when remote etag changed and local has photo but remote does not', async () => {
         const uid = 'photo-uid';
         const mappingId = 'mapping-photo';
 
@@ -608,6 +611,7 @@ describe('CardDAV Sync Engine', () => {
             etag: 'etag-old',
             lastLocalChange: null,
             lastSyncedAt: new Date('2025-01-01'),
+            person: { photo: 'person-1.jpg' },
           }),
         ]);
 
@@ -692,6 +696,73 @@ describe('CardDAV Sync Engine', () => {
         );
         expect(updateCall).toBeDefined();
         expect((updateCall![0] as { data: { syncStatus: string } }).data.syncStatus).toBe('synced');
+      });
+
+      it('should heal stuck mappings where etag matches but local has photo and remote does not', async () => {
+        const uid = 'stuck-uid';
+        const mappingId = 'mapping-stuck';
+        const sameEtag = 'etag-same';
+
+        // Mapping and server vCard have identical etag (no remote change)
+        // and no local change, but local person has a photo the server lacks
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: sameEtag,
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            person: { photo: 'person-stuck.jpg' },
+          }),
+        ]);
+
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/stuck.vcf', sameEtag, 'StuckPhoto'),
+        ]);
+
+        // Remote vCard has no photo
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'StuckPhoto'));
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        // Should mark stuck mapping as pending even though etags match
+        expect(mocks.cardDavMappingUpdate).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: { id: mappingId },
+            data: expect.objectContaining({
+              syncStatus: 'pending',
+              lastLocalChange: expect.any(Date),
+            }),
+          })
+        );
+      });
+
+      it('should not mark stuck mapping as pending when neither side has a photo', async () => {
+        const uid = 'no-photo-stuck-uid';
+        const sameEtag = 'etag-same';
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            uid,
+            etag: sameEtag,
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            person: { photo: null },
+          }),
+        ]);
+
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/no-photo.vcf', sameEtag, 'NoPhotoEither'),
+        ]);
+
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'NoPhotoEither'));
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        // No mapping updates should happen at all (early return)
+        expect(mocks.cardDavMappingUpdate).not.toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
## Summary

- The previous fix (862a415, PR #281) preserved local photos when the remote vCard had no PHOTO field, but marked the mapping as `synced`. The push phase only processes `pending` mappings, so the photo was never re-exported to the server.
- Now the pull phase detects when a local person has a photo but the remote vCard does not, and marks the mapping as `pending` so the next push re-exports the vCard with the embedded photo.

## Test plan

- [x] New unit test: mapping marked `pending` when local has photo but remote vCard does not
- [x] New unit test: mapping stays `synced` when neither side has a photo (no false positives)
- [x] All 330 existing CardDAV tests pass
- [ ] Manual: upload a photo, trigger sync, confirm photo appears on CardDAV server after a round-trip

Refs #278