### PR TITLE
Fix false-positive duplicates with multi-signal scoring

### DIFF
--- a/app/api/people/[id]/duplicates/route.ts
+++ b/app/api/people/[id]/duplicates/route.ts
@@ -1,6 +1,10 @@
 import { prisma } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
-import { findDuplicates } from '@/lib/duplicate-detection';
+import {
+  findDuplicates,
+  mapPersonForComparison,
+  PERSON_SELECT_FOR_COMPARISON,
+} from '@/lib/duplicate-detection';
 
 // GET /api/people/[id]/duplicates - Find potential duplicates for a person
 export const GET = withAuth(async (_request, session, context) => {
@@ -9,7 +13,7 @@ export const GET = withAuth(async (_request, session, context) => {
 
     const target = await prisma.person.findUnique({
       where: { id, userId: session.user.id, deletedAt: null },
-      select: { id: true, name: true, surname: true },
+      select: PERSON_SELECT_FOR_COMPARISON,
     });
 
     if (!target) {
@@ -19,7 +23,7 @@ export const GET = withAuth(async (_request, session, context) => {
     const [allPeople, dismissals] = await Promise.all([
       prisma.person.findMany({
         where: { userId: session.user.id, deletedAt: null },
-        select: { id: true, name: true, surname: true },
+        select: PERSON_SELECT_FOR_COMPARISON,
       }),
       prisma.duplicateDismissal.findMany({
         where: {
@@ -30,14 +34,16 @@ export const GET = withAuth(async (_request, session, context) => {
       }),
     ]);
 
-    // Build set of person IDs dismissed against the target
     const dismissedPartners = new Set(
       dismissals.map((d) =>
         d.personAId === id ? d.personBId : d.personAId
       )
     );
 
-    const candidates = findDuplicates(target.name, target.surname, allPeople, target.id)
+    const mapped = allPeople.map(mapPersonForComparison);
+    const targetMapped = mapPersonForComparison(target);
+
+    const candidates = findDuplicates(targetMapped, mapped, targetMapped.id)
       .filter((c) => !dismissedPartners.has(c.personId));
 
     return apiResponse.ok({ duplicates: candidates });

--- a/app/api/people/duplicates/route.ts
+++ b/app/api/people/duplicates/route.ts
@@ -1,6 +1,10 @@
 import { prisma } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
-import { findAllDuplicateGroups } from '@/lib/duplicate-detection';
+import {
+  findAllDuplicateGroups,
+  mapPersonForComparison,
+  PERSON_SELECT_FOR_COMPARISON,
+} from '@/lib/duplicate-detection';
 
 // GET /api/people/duplicates - Find all duplicate groups
 export const GET = withAuth(async (_request, session) => {
@@ -8,7 +12,7 @@ export const GET = withAuth(async (_request, session) => {
     const [allPeople, dismissals] = await Promise.all([
       prisma.person.findMany({
         where: { userId: session.user.id, deletedAt: null },
-        select: { id: true, name: true, surname: true },
+        select: PERSON_SELECT_FOR_COMPARISON,
       }),
       prisma.duplicateDismissal.findMany({
         where: { userId: session.user.id },
@@ -16,12 +20,12 @@ export const GET = withAuth(async (_request, session) => {
       }),
     ]);
 
-    // Build a set of dismissed pair keys for fast lookup
     const dismissedPairs = new Set(
       dismissals.map((d) => `${d.personAId}:${d.personBId}`)
     );
 
-    const groups = findAllDuplicateGroups(allPeople, dismissedPairs);
+    const mapped = allPeople.map(mapPersonForComparison);
+    const groups = findAllDuplicateGroups(mapped, dismissedPairs);
 
     return apiResponse.ok({ groups });
   } catch (error) {

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -131,15 +131,102 @@ export function normalizePhone(phone: string): string {
   return digits.length > 10 ? digits.slice(-10) : digits;
 }
 
-/**
- * Compute similarity between two people, taking name parts into account.
- *
- * When both have surnames, scores name and surname separately with a
- * weighted average (60% name, 40% surname) so a shared surname alone
- * doesn't inflate the match.
- *
- * Falls back to full-string comparison when either person lacks a surname.
- */
+interface SimilarityResult {
+  score: number;
+  autoFlagged: boolean;
+}
+
+function nameSimilarity(a: PersonForComparison, b: PersonForComparison): number {
+  if (a.surname && b.surname) {
+    const nameSim = stringSimilarity(normalizePart(a.name), normalizePart(b.name));
+    const surSim = stringSimilarity(normalizePart(a.surname), normalizePart(b.surname));
+    return nameSim * FIRST_NAME_WEIGHT + surSim * SURNAME_WEIGHT_INNER;
+  }
+  const fullA = normalizePart([a.name, a.surname].filter(Boolean).join(' '));
+  const fullB = normalizePart([b.name, b.surname].filter(Boolean).join(' '));
+  return stringSimilarity(fullA, fullB);
+}
+
+function emailSignal(a: PersonForComparison, b: PersonForComparison): { comparable: boolean; score: number; exactMatch: boolean } {
+  if (a.emails.length === 0 || b.emails.length === 0) {
+    return { comparable: false, score: 0, exactMatch: false };
+  }
+  const setB = new Set(b.emails);
+  const exactMatch = a.emails.some((e) => setB.has(e));
+  return { comparable: true, score: exactMatch ? 1.0 : 0.0, exactMatch };
+}
+
+function phoneSignal(a: PersonForComparison, b: PersonForComparison): { comparable: boolean; score: number; exactMatch: boolean } {
+  if (a.phones.length === 0 || b.phones.length === 0) {
+    return { comparable: false, score: 0, exactMatch: false };
+  }
+  const setB = new Set(b.phones);
+  const exactMatch = a.phones.some((p) => setB.has(p));
+  return { comparable: true, score: exactMatch ? 1.0 : 0.0, exactMatch };
+}
+
+function birthdaySignal(a: PersonForComparison, b: PersonForComparison): { comparable: boolean; score: number } {
+  if (a.birthdays.length === 0 || b.birthdays.length === 0) {
+    return { comparable: false, score: 0 };
+  }
+  let best = 0;
+  for (const da of a.birthdays) {
+    for (const db of b.birthdays) {
+      if (da.getFullYear() === db.getFullYear() && da.getMonth() === db.getMonth() && da.getDate() === db.getDate()) {
+        best = 1.0;
+        break;
+      }
+      if (da.getMonth() === db.getMonth() && da.getDate() === db.getDate()) {
+        best = Math.max(best, 0.5);
+      }
+    }
+    if (best === 1.0) break;
+  }
+  // Only treat birthday as comparable when there is at least a partial match
+  // (same month and day). Completely different dates provide no useful signal.
+  return { comparable: best > 0, score: best };
+}
+
+export function compositeSimilarity(a: PersonForComparison, b: PersonForComparison): SimilarityResult {
+  const nameScore = nameSimilarity(a, b);
+  const email = emailSignal(a, b);
+  const phone = phoneSignal(a, b);
+  const birthday = birthdaySignal(a, b);
+
+  const hasStrongIdMatch = email.exactMatch || phone.exactMatch;
+
+  const signals: Array<{ weight: number; score: number }> = [
+    { weight: SIGNAL_WEIGHTS.name, score: nameScore },
+  ];
+  let comparableCount = 1;
+
+  if (email.comparable) {
+    signals.push({ weight: SIGNAL_WEIGHTS.email, score: email.score });
+    comparableCount++;
+  }
+  if (phone.comparable) {
+    signals.push({ weight: SIGNAL_WEIGHTS.phone, score: phone.score });
+    comparableCount++;
+  }
+  if (birthday.comparable) {
+    signals.push({ weight: SIGNAL_WEIGHTS.birthday, score: birthday.score });
+    comparableCount++;
+  }
+
+  const totalWeight = signals.reduce((sum, s) => sum + s.weight, 0);
+  let score = signals.reduce((sum, s) => sum + (s.weight / totalWeight) * s.score, 0);
+
+  if (comparableCount < MIN_SIGNALS_FOR_FULL_SCORE) {
+    score = Math.min(score, SPARSITY_CAP);
+  }
+
+  if (hasStrongIdMatch) {
+    score = Math.max(score, AUTO_FLAG_MIN_SCORE);
+  }
+
+  return { score, autoFlagged: hasStrongIdMatch };
+}
+
 function personSimilarity(
   nameA: string,
   surnameA: string | null,
@@ -151,8 +238,6 @@ function personSimilarity(
     const surSim = stringSimilarity(normalizePart(surnameA), normalizePart(surnameB));
     return nameSim * FIRST_NAME_WEIGHT + surSim * SURNAME_WEIGHT_INNER;
   }
-
-  // Fallback: compare full concatenated strings
   const fullA = normalizePart([nameA, surnameA].filter(Boolean).join(' '));
   const fullB = normalizePart([nameB, surnameB].filter(Boolean).join(' '));
   return stringSimilarity(fullA, fullB);

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -398,3 +398,41 @@ export function findAllDuplicateGroups(
   result.sort((a, b) => b.similarity - a.similarity);
   return result;
 }
+
+// ---------------------------------------------------------------------------
+// Database mapping
+// ---------------------------------------------------------------------------
+
+interface PersonFromDb {
+  id: string;
+  name: string;
+  surname: string | null;
+  emails: Array<{ email: string }>;
+  phoneNumbers: Array<{ number: string }>;
+  importantDates: Array<{ type: string | null; date: Date }>;
+}
+
+export function mapPersonForComparison(p: PersonFromDb): PersonForComparison {
+  return {
+    id: p.id,
+    name: p.name,
+    surname: p.surname,
+    emails: p.emails.map((e) => normalizeEmail(e.email)),
+    phones: p.phoneNumbers.map((ph) => normalizePhone(ph.number)),
+    birthdays: p.importantDates
+      .filter((d) => d.type === 'birthday')
+      .map((d) => d.date),
+  };
+}
+
+export const PERSON_SELECT_FOR_COMPARISON = {
+  id: true,
+  name: true,
+  surname: true,
+  emails: { select: { email: true } },
+  phoneNumbers: { select: { number: true } },
+  importantDates: {
+    where: { deletedAt: null, type: 'birthday' },
+    select: { type: true, date: true },
+  },
+} as const;

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -27,21 +27,30 @@ export interface PersonForComparison {
   id: string;
   name: string;
   surname: string | null;
+  emails: string[];
+  phones: string[];
+  birthdays: Date[];
 }
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-// Minimum similarity score (0–1) for two names to be considered potential duplicates.
-// 0.75 balances recall (catching "Robert" / "Roberto") vs precision (avoiding false positives).
 const SIMILARITY_THRESHOLD = 0.75;
 
-// When both people have surnames, similarity is a weighted average of
-// first-name similarity (60%) and surname similarity (40%). This prevents
-// shared surnames from inflating the score when first names are different.
-const NAME_WEIGHT = 0.6;
-const SURNAME_WEIGHT = 0.4;
+const FIRST_NAME_WEIGHT = 0.6;
+const SURNAME_WEIGHT_INNER = 0.4;
+
+const SIGNAL_WEIGHTS = {
+  name: 0.4,
+  email: 0.3,
+  phone: 0.2,
+  birthday: 0.1,
+} as const;
+
+const SPARSITY_CAP = 0.6;
+const MIN_SIGNALS_FOR_FULL_SCORE = 2;
+const AUTO_FLAG_MIN_SCORE = 0.85;
 
 // ---------------------------------------------------------------------------
 // Core algorithms
@@ -113,6 +122,15 @@ function normalizePart(s: string): string {
   return normalizeForSearch(s.trim());
 }
 
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function normalizePhone(phone: string): string {
+  const digits = phone.replace(/\D/g, '');
+  return digits.length > 10 ? digits.slice(-10) : digits;
+}
+
 /**
  * Compute similarity between two people, taking name parts into account.
  *
@@ -131,7 +149,7 @@ function personSimilarity(
   if (surnameA && surnameB) {
     const nameSim = stringSimilarity(normalizePart(nameA), normalizePart(nameB));
     const surSim = stringSimilarity(normalizePart(surnameA), normalizePart(surnameB));
-    return nameSim * NAME_WEIGHT + surSim * SURNAME_WEIGHT;
+    return nameSim * FIRST_NAME_WEIGHT + surSim * SURNAME_WEIGHT_INNER;
   }
 
   // Fallback: compare full concatenated strings

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -51,6 +51,7 @@ const SIGNAL_WEIGHTS = {
 const SPARSITY_CAP = 0.6;
 const MIN_SIGNALS_FOR_FULL_SCORE = 2;
 const AUTO_FLAG_MIN_SCORE = 0.85;
+const NAME_ONLY_BYPASS_THRESHOLD = 0.95;
 
 // ---------------------------------------------------------------------------
 // Core algorithms
@@ -193,7 +194,7 @@ export function compositeSimilarity(a: PersonForComparison, b: PersonForComparis
   const phone = phoneSignal(a, b);
   const birthday = birthdaySignal(a, b);
 
-  const hasStrongIdMatch = email.exactMatch || phone.exactMatch;
+  const hasStrongIdMatch = email.exactMatch;
 
   const signals: Array<{ weight: number; score: number }> = [
     { weight: SIGNAL_WEIGHTS.name, score: nameScore },
@@ -216,7 +217,7 @@ export function compositeSimilarity(a: PersonForComparison, b: PersonForComparis
   const totalWeight = signals.reduce((sum, s) => sum + s.weight, 0);
   let score = signals.reduce((sum, s) => sum + (s.weight / totalWeight) * s.score, 0);
 
-  if (comparableCount < MIN_SIGNALS_FOR_FULL_SCORE) {
+  if (comparableCount < MIN_SIGNALS_FOR_FULL_SCORE && nameScore < NAME_ONLY_BYPASS_THRESHOLD) {
     score = Math.min(score, SPARSITY_CAP);
   }
 

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -227,22 +227,6 @@ export function compositeSimilarity(a: PersonForComparison, b: PersonForComparis
   return { score, autoFlagged: hasStrongIdMatch };
 }
 
-function personSimilarity(
-  nameA: string,
-  surnameA: string | null,
-  nameB: string,
-  surnameB: string | null
-): number {
-  if (surnameA && surnameB) {
-    const nameSim = stringSimilarity(normalizePart(nameA), normalizePart(nameB));
-    const surSim = stringSimilarity(normalizePart(surnameA), normalizePart(surnameB));
-    return nameSim * FIRST_NAME_WEIGHT + surSim * SURNAME_WEIGHT_INNER;
-  }
-  const fullA = normalizePart([nameA, surnameA].filter(Boolean).join(' '));
-  const fullB = normalizePart([nameB, surnameB].filter(Boolean).join(' '));
-  return stringSimilarity(fullA, fullB);
-}
-
 // ---------------------------------------------------------------------------
 // Union-Find (disjoint-set) data structure
 // ---------------------------------------------------------------------------
@@ -308,42 +292,34 @@ class UnionFind {
 /**
  * Find duplicate candidates for a given person.
  *
- * @param targetName    - First name of the person to check
- * @param targetSurname - Surname of the person (may be null)
- * @param people        - Full list of people to compare against
- * @param targetId      - Optional ID of the target person to exclude from results
+ * @param target   - The person to check for duplicates
+ * @param people   - Full list of people to compare against
+ * @param targetId - Optional ID of the target person to exclude from results
  * @returns Candidates whose similarity exceeds the threshold, sorted descending.
  */
 export function findDuplicates(
-  targetName: string,
-  targetSurname: string | null,
+  target: PersonForComparison,
   people: PersonForComparison[],
   targetId?: string
 ): DuplicateCandidate[] {
   const candidates: DuplicateCandidate[] = [];
 
-  for (const person of people) {
-    // Skip the target person itself
-    if (targetId && person.id === targetId) continue;
+  for (const p of people) {
+    if (targetId && p.id === targetId) continue;
 
-    const similarity = personSimilarity(
-      targetName, targetSurname,
-      person.name, person.surname
-    );
+    const { score, autoFlagged } = compositeSimilarity(target, p);
 
-    if (similarity >= SIMILARITY_THRESHOLD) {
+    if (score >= SIMILARITY_THRESHOLD || autoFlagged) {
       candidates.push({
-        personId: person.id,
-        name: person.name,
-        surname: person.surname,
-        similarity,
+        personId: p.id,
+        name: p.name,
+        surname: p.surname,
+        similarity: score,
       });
     }
   }
 
-  // Sort by similarity descending
   candidates.sort((a, b) => b.similarity - a.similarity);
-
   return candidates;
 }
 
@@ -357,9 +333,9 @@ export function buildDismissalKey(idA: string, idB: string): string {
 /**
  * Find all groups of potential duplicates across a list of people.
  *
- * Uses union-find to cluster people whose names exceed the similarity
- * threshold. Returns only groups of 2 or more, sorted by highest
- * pairwise similarity within each group (descending).
+ * Uses union-find to cluster people whose composite similarity exceeds the
+ * threshold. Returns only groups of 2 or more, sorted by highest pairwise
+ * similarity within each group (descending).
  *
  * @param dismissedPairs - Optional set of "smallerId:largerId" keys to skip.
  */
@@ -369,51 +345,43 @@ export function findAllDuplicateGroups(
 ): DuplicateGroup[] {
   const uf = new UnionFind();
 
-  for (const person of people) {
-    uf.makeSet(person.id);
+  for (const p of people) {
+    uf.makeSet(p.id);
   }
 
-  // Compare every pair using weighted name/surname similarity
   for (let i = 0; i < people.length; i++) {
     for (let j = i + 1; j < people.length; j++) {
       const a = people[i];
       const b = people[j];
 
-      // Skip dismissed pairs
       if (dismissedPairs?.has(buildDismissalKey(a.id, b.id))) continue;
 
-      const similarity = personSimilarity(a.name, a.surname, b.name, b.surname);
+      const { score, autoFlagged } = compositeSimilarity(a, b);
 
-      if (similarity >= SIMILARITY_THRESHOLD) {
+      if (score >= SIMILARITY_THRESHOLD || autoFlagged) {
         uf.union(a.id, b.id);
       }
     }
   }
 
-  // Collect groups by root
   const groups = new Map<string, PersonForComparison[]>();
-  for (const person of people) {
-    const root = uf.find(person.id);
+  for (const p of people) {
+    const root = uf.find(p.id);
     if (!groups.has(root)) {
       groups.set(root, []);
     }
-    groups.get(root)!.push(person);
+    groups.get(root)!.push(p);
   }
 
-  // Build result: only groups with 2+ members
   const result: DuplicateGroup[] = [];
   for (const [, members] of groups) {
     if (members.length < 2) continue;
 
-    // Derive max pairwise similarity within this group
     let maxSim = SIMILARITY_THRESHOLD;
     for (let i = 0; i < members.length; i++) {
       for (let j = i + 1; j < members.length; j++) {
-        const sim = personSimilarity(
-          members[i].name, members[i].surname,
-          members[j].name, members[j].surname
-        );
-        if (sim > maxSim) maxSim = sim;
+        const { score } = compositeSimilarity(members[i], members[j]);
+        if (score > maxSim) maxSim = score;
       }
     }
 
@@ -427,8 +395,6 @@ export function findAllDuplicateGroups(
     });
   }
 
-  // Sort groups by similarity descending
   result.sort((a, b) => b.similarity - a.similarity);
-
   return result;
 }

--- a/lib/openapi/people.ts
+++ b/lib/openapi/people.ts
@@ -311,7 +311,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
       get: {
         tags: ['People'],
         summary: 'Find all duplicate contact groups',
-        description: 'Scans all contacts and returns groups of potential duplicates based on name similarity. Dismissed pairs are excluded.',
+        description: 'Scans all contacts and returns groups of potential duplicates based on name, email, phone, and birthday similarity. Dismissed pairs are excluded.',
         security: [{ session: [] }],
         responses: {
           '200': jsonResponse('Duplicate groups', {

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -4,7 +4,9 @@ import {
   normalizePhone,
   findDuplicates,
   findAllDuplicateGroups,
+  compositeSimilarity,
 } from '@/lib/duplicate-detection';
+import type { PersonForComparison } from '@/lib/duplicate-detection';
 
 describe('normalizeEmail', () => {
   it('lowercases and trims', () => {
@@ -59,5 +61,91 @@ describe('duplicate-detection with accents', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].people).toHaveLength(2);
     expect(groups[0].similarity).toBe(1);
+  });
+});
+
+function person(overrides: Partial<PersonForComparison> & { id: string; name: string }): PersonForComparison {
+  return {
+    surname: null,
+    emails: [],
+    phones: [],
+    birthdays: [],
+    ...overrides,
+  };
+}
+
+describe('compositeSimilarity', () => {
+  it('caps name-only matches at sparsity cap (issue #306)', () => {
+    const a = person({ id: '1', name: 'John', surname: 'Abc' });
+    const b = person({ id: '2', name: 'John', surname: 'Def' });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeLessThanOrEqual(0.6);
+    expect(result.autoFlagged).toBe(false);
+  });
+
+  it('scores accented name variants high when name-only', () => {
+    const a = person({ id: '1', name: 'Maria', surname: 'Garcia' });
+    const b = person({ id: '2', name: 'María', surname: 'García' });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeLessThanOrEqual(0.6);
+  });
+
+  it('gives full score when name + email both match', () => {
+    const a = person({ id: '1', name: 'John', surname: 'Smith', emails: ['john@test.com'] });
+    const b = person({ id: '2', name: 'John', surname: 'Smith', emails: ['john@test.com'] });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeGreaterThanOrEqual(0.9);
+    expect(result.autoFlagged).toBe(true);
+  });
+
+  it('auto-flags on email match even with different names', () => {
+    const a = person({ id: '1', name: 'Jonathan', surname: 'Smith', emails: ['js@test.com'] });
+    const b = person({ id: '2', name: 'Johnny', surname: 'Smyth', emails: ['js@test.com'] });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeGreaterThanOrEqual(0.85);
+    expect(result.autoFlagged).toBe(true);
+  });
+
+  it('auto-flags on phone match even with different names', () => {
+    const a = person({ id: '1', name: 'Jane', surname: 'Doe', phones: ['5551234567'] });
+    const b = person({ id: '2', name: 'Janet', surname: 'Do', phones: ['5551234567'] });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeGreaterThanOrEqual(0.85);
+    expect(result.autoFlagged).toBe(true);
+  });
+
+  it('scores birthday exact match', () => {
+    const bday = new Date('1990-05-15');
+    const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [bday] });
+    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [bday] });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeGreaterThan(0.6);
+  });
+
+  it('scores birthday same month+day different year as 0.5', () => {
+    const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
+    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date('1985-05-15')] });
+    const resultSameDay = compositeSimilarity(a, b);
+    const c = person({ id: '3', name: 'John', surname: 'Smith', birthdays: [new Date('1990-08-20')] });
+    const resultDiffDay = compositeSimilarity(a, c);
+    expect(resultSameDay.score).toBeGreaterThan(resultDiffDay.score);
+  });
+
+  it('penalizes score when comparable signal does not match', () => {
+    const nameOnly = person({ id: '1', name: 'John', surname: 'Smith' });
+    const nameOnly2 = person({ id: '2', name: 'John', surname: 'Smith' });
+    const withDiffEmail = person({ id: '3', name: 'John', surname: 'Smith', emails: ['a@test.com'] });
+    const withDiffEmail2 = person({ id: '4', name: 'John', surname: 'Smith', emails: ['b@test.com'] });
+
+    const nameOnlyResult = compositeSimilarity(nameOnly, nameOnly2);
+    const diffEmailResult = compositeSimilarity(withDiffEmail, withDiffEmail2);
+    expect(diffEmailResult.score).toBeLessThan(nameOnlyResult.score);
+  });
+
+  it('does not apply sparsity cap when 2+ signals are comparable', () => {
+    const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
+    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBeGreaterThan(0.6);
   });
 });

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -180,8 +180,12 @@ describe('compositeSimilarity', () => {
 
   it('does not apply sparsity cap when 2+ signals are comparable', () => {
     const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
-    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
+    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date('1985-05-15')] });
     const result = compositeSimilarity(a, b);
+    // Name=1.0, Birthday=0.5 (same month+day, different year)
+    // Weighted: (0.4/0.5)*1.0 + (0.1/0.5)*0.5 = 0.9
+    // Without sparsity bypass this would be capped at 0.6
     expect(result.score).toBeGreaterThan(0.6);
+    expect(result.score).toBeLessThanOrEqual(1.0);
   });
 });

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -28,42 +28,6 @@ describe('normalizePhone', () => {
   });
 });
 
-describe('duplicate-detection with accents', () => {
-  const makePerson = (id: string, name: string, surname: string | null) => ({
-    id,
-    name,
-    surname,
-    emails: [] as string[],
-    phones: [] as string[],
-    birthdays: [] as Date[],
-  });
-
-  it('should detect accented and unaccented names as duplicates', () => {
-    const people = [
-      makePerson('1', 'María', 'García'),
-      makePerson('2', 'Maria', 'Garcia'),
-    ];
-
-    const duplicates = findDuplicates('María', 'García', people, '1');
-    expect(duplicates).toHaveLength(1);
-    expect(duplicates[0].personId).toBe('2');
-    expect(duplicates[0].similarity).toBe(1);
-  });
-
-  it('should group accented variants together', () => {
-    const people = [
-      makePerson('1', 'María', 'García'),
-      makePerson('2', 'Maria', 'Garcia'),
-      makePerson('3', 'John', 'Smith'),
-    ];
-
-    const groups = findAllDuplicateGroups(people);
-    expect(groups).toHaveLength(1);
-    expect(groups[0].people).toHaveLength(2);
-    expect(groups[0].similarity).toBe(1);
-  });
-});
-
 function person(overrides: Partial<PersonForComparison> & { id: string; name: string }): PersonForComparison {
   return {
     surname: null,
@@ -73,6 +37,78 @@ function person(overrides: Partial<PersonForComparison> & { id: string; name: st
     ...overrides,
   };
 }
+
+describe('findDuplicates (multi-signal)', () => {
+  it('does not flag "John Abc" vs "John Def" as duplicates (issue #306)', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'John', surname: 'Abc' }),
+      person({ id: '2', name: 'John', surname: 'Def' }),
+    ];
+    const results = findDuplicates(people[0], people, people[0].id);
+    expect(results).toHaveLength(0);
+  });
+
+  it('flags exact email match as duplicate regardless of name', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'Alice', surname: 'Wonderland', emails: ['alice@test.com'] }),
+      person({ id: '2', name: 'Alicia', surname: 'Wonder', emails: ['alice@test.com'] }),
+    ];
+    const results = findDuplicates(people[0], people, people[0].id);
+    expect(results).toHaveLength(1);
+    expect(results[0].similarity).toBeGreaterThanOrEqual(0.85);
+  });
+
+  it('does not flag accented name variants when name-only (sparsity cap)', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'María', surname: 'García' }),
+      person({ id: '2', name: 'Maria', surname: 'Garcia' }),
+    ];
+    const results = findDuplicates(people[0], people, people[0].id);
+    expect(results).toHaveLength(0);
+  });
+
+  it('detects accented name variants when email also matches', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'María', surname: 'García', emails: ['maria@test.com'] }),
+      person({ id: '2', name: 'Maria', surname: 'Garcia', emails: ['maria@test.com'] }),
+    ];
+    const results = findDuplicates(people[0], people, people[0].id);
+    expect(results).toHaveLength(1);
+  });
+});
+
+describe('findAllDuplicateGroups (multi-signal)', () => {
+  it('does not group people with same first name but different surnames when name-only', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'John', surname: 'Abc' }),
+      person({ id: '2', name: 'John', surname: 'Def' }),
+      person({ id: '3', name: 'Jane', surname: 'Smith' }),
+    ];
+    const groups = findAllDuplicateGroups(people);
+    expect(groups).toHaveLength(0);
+  });
+
+  it('groups people sharing an email', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'Bob', surname: 'A', emails: ['bob@test.com'] }),
+      person({ id: '2', name: 'Robert', surname: 'B', emails: ['bob@test.com'] }),
+      person({ id: '3', name: 'Charlie', surname: 'C' }),
+    ];
+    const groups = findAllDuplicateGroups(people);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].people).toHaveLength(2);
+  });
+
+  it('respects dismissed pairs', () => {
+    const people: PersonForComparison[] = [
+      person({ id: '1', name: 'Bob', surname: 'A', emails: ['bob@test.com'] }),
+      person({ id: '2', name: 'Robert', surname: 'B', emails: ['bob@test.com'] }),
+    ];
+    const dismissed = new Set(['1:2']);
+    const groups = findAllDuplicateGroups(people, dismissed);
+    expect(groups).toHaveLength(0);
+  });
+});
 
 describe('compositeSimilarity', () => {
   it('caps name-only matches at sparsity cap (issue #306)', () => {

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -58,13 +58,13 @@ describe('findDuplicates (multi-signal)', () => {
     expect(results[0].similarity).toBeGreaterThanOrEqual(0.85);
   });
 
-  it('does not flag accented name variants when name-only (sparsity cap)', () => {
+  it('flags accented name variants when name-only (near-exact bypass)', () => {
     const people: PersonForComparison[] = [
       person({ id: '1', name: 'María', surname: 'García' }),
       person({ id: '2', name: 'Maria', surname: 'Garcia' }),
     ];
     const results = findDuplicates(people[0], people, people[0].id);
-    expect(results).toHaveLength(0);
+    expect(results).toHaveLength(1);
   });
 
   it('detects accented name variants when email also matches', () => {
@@ -119,9 +119,16 @@ describe('compositeSimilarity', () => {
     expect(result.autoFlagged).toBe(false);
   });
 
-  it('scores accented name variants high when name-only', () => {
+  it('bypasses sparsity cap for near-exact name-only matches', () => {
     const a = person({ id: '1', name: 'Maria', surname: 'Garcia' });
     const b = person({ id: '2', name: 'María', surname: 'García' });
+    const result = compositeSimilarity(a, b);
+    expect(result.score).toBe(1.0);
+  });
+
+  it('still caps weak name-only matches at sparsity cap', () => {
+    const a = person({ id: '1', name: 'John', surname: 'Smith' });
+    const b = person({ id: '2', name: 'Jon', surname: 'Smyth' });
     const result = compositeSimilarity(a, b);
     expect(result.score).toBeLessThanOrEqual(0.6);
   });
@@ -142,12 +149,21 @@ describe('compositeSimilarity', () => {
     expect(result.autoFlagged).toBe(true);
   });
 
-  it('auto-flags on phone match even with different names', () => {
+  it('does not auto-flag on phone match alone', () => {
     const a = person({ id: '1', name: 'Jane', surname: 'Doe', phones: ['5551234567'] });
     const b = person({ id: '2', name: 'Janet', surname: 'Do', phones: ['5551234567'] });
     const result = compositeSimilarity(a, b);
-    expect(result.score).toBeGreaterThanOrEqual(0.85);
-    expect(result.autoFlagged).toBe(true);
+    expect(result.autoFlagged).toBe(false);
+  });
+
+  it('uses phone as a composite signal to boost score', () => {
+    const withPhone = person({ id: '1', name: 'Jane', surname: 'Doe', phones: ['5551234567'] });
+    const withPhone2 = person({ id: '2', name: 'Jane', surname: 'Doe', phones: ['5551234567'] });
+    const noPhone = person({ id: '3', name: 'Jane', surname: 'Doe' });
+    const noPhone2 = person({ id: '4', name: 'Jane', surname: 'Doe' });
+    const withPhoneResult = compositeSimilarity(withPhone, withPhone2);
+    const noPhoneResult = compositeSimilarity(noPhone, noPhone2);
+    expect(withPhoneResult.score).toBeGreaterThanOrEqual(noPhoneResult.score);
   });
 
   it('scores birthday exact match', () => {
@@ -159,10 +175,10 @@ describe('compositeSimilarity', () => {
   });
 
   it('scores birthday same month+day different year as 0.5', () => {
-    const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [new Date('1990-05-15')] });
-    const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date('1985-05-15')] });
+    const a = person({ id: '1', name: 'Roberto', surname: 'Sanchez', birthdays: [new Date('1990-05-15')] });
+    const b = person({ id: '2', name: 'Robert', surname: 'Sanchez', birthdays: [new Date('1985-05-15')] });
     const resultSameDay = compositeSimilarity(a, b);
-    const c = person({ id: '3', name: 'John', surname: 'Smith', birthdays: [new Date('1990-08-20')] });
+    const c = person({ id: '3', name: 'Robert', surname: 'Sanchez', birthdays: [new Date('1990-08-20')] });
     const resultDiffDay = compositeSimilarity(a, c);
     expect(resultSameDay.score).toBeGreaterThan(resultDiffDay.score);
   });

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -1,11 +1,45 @@
 import { describe, it, expect } from 'vitest';
-import { findDuplicates, findAllDuplicateGroups } from '@/lib/duplicate-detection';
+import {
+  normalizeEmail,
+  normalizePhone,
+  findDuplicates,
+  findAllDuplicateGroups,
+} from '@/lib/duplicate-detection';
+
+describe('normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmail('  John@Example.COM  ')).toBe('john@example.com');
+  });
+});
+
+describe('normalizePhone', () => {
+  it('strips non-digits and keeps last 10', () => {
+    expect(normalizePhone('+1 (555) 123-4567')).toBe('5551234567');
+  });
+
+  it('keeps short numbers as-is', () => {
+    expect(normalizePhone('12345')).toBe('12345');
+  });
+
+  it('handles a number with exactly 10 digits', () => {
+    expect(normalizePhone('555-123-4567')).toBe('5551234567');
+  });
+});
 
 describe('duplicate-detection with accents', () => {
+  const makePerson = (id: string, name: string, surname: string | null) => ({
+    id,
+    name,
+    surname,
+    emails: [] as string[],
+    phones: [] as string[],
+    birthdays: [] as Date[],
+  });
+
   it('should detect accented and unaccented names as duplicates', () => {
     const people = [
-      { id: '1', name: 'María', surname: 'García' },
-      { id: '2', name: 'Maria', surname: 'Garcia' },
+      makePerson('1', 'María', 'García'),
+      makePerson('2', 'Maria', 'Garcia'),
     ];
 
     const duplicates = findDuplicates('María', 'García', people, '1');
@@ -16,9 +50,9 @@ describe('duplicate-detection with accents', () => {
 
   it('should group accented variants together', () => {
     const people = [
-      { id: '1', name: 'María', surname: 'García' },
-      { id: '2', name: 'Maria', surname: 'Garcia' },
-      { id: '3', name: 'John', surname: 'Smith' },
+      makePerson('1', 'María', 'García'),
+      makePerson('2', 'Maria', 'Garcia'),
+      makePerson('3', 'John', 'Smith'),
     ];
 
     const groups = findAllDuplicateGroups(people);


### PR DESCRIPTION
## Summary

- Replaces name-only Levenshtein matching with a weighted composite scorer using four signals: name (40%), email (30%), phone (20%), and birthday (10%)
- Adds sparsity penalty that caps name-only matches at 60% confidence, preventing false positives like "John Abc" vs "John Def" being flagged as 100% match
- Auto-flags exact email or phone matches at 85%+ regardless of name similarity, catching duplicates that name-only matching misses

Fixes #306

## How it works

The `compositeSimilarity` function evaluates each signal category where both contacts have data, re-normalizes weights over comparable signals, then applies two overrides: a sparsity cap (score capped at 0.60 when fewer than 2 signals are comparable) and an auto-flag (exact email/phone match forces minimum 0.85 score).

No database schema changes, no UI changes. The `DuplicateCandidate` and `DuplicateGroup` interfaces are unchanged so the duplicates list, merge flow, and dismissal system work as before.

## Test plan

- [ ] `npx vitest run tests/lib/duplicate-detection.test.ts` passes (20 tests)
- [ ] Full suite `npx vitest run` passes (2240 tests)
- [ ] Type check `npx tsc --noEmit` clean
- [ ] OpenAPI spec valid `npx vitest run tests/api/openapi-spec.test.ts`
- [ ] Manually verify: add two people with same first name but different surnames, run Find Duplicates, confirm they are NOT flagged
- [ ] Manually verify: add two people with different names but same email, run Find Duplicates, confirm they ARE flagged