### PR TITLE
fix: prevent CardDAV sync from creating duplicate contacts

### DIFF
--- a/lib/carddav/discover.ts
+++ b/lib/carddav/discover.ts
@@ -2,7 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { createCardDavClient } from './client';
 import { getAddressBook } from './address-book';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
-import { getAlreadyMappedPersonUids } from './mapped-uids';
+import { getAlreadyMappedPersonUids, getUnmappedPersonsByUid } from './mapped-uids';
 import { createModuleLogger } from '@/lib/logger';
 
 const log = createModuleLogger('carddav');
@@ -64,6 +64,9 @@ export async function discoverNewContacts(userId: string): Promise<DiscoveryResu
     // existingUids check alone would miss them.
     const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(userId);
 
+    // Pre-load unmapped persons by UID for auto-linking
+    const unmappedPersonsByUid = await getUnmappedPersonsByUid(userId);
+
     // Get all existing pending imports
     const existingPending = await prisma.cardDavPendingImport.findMany({
       where: {
@@ -94,8 +97,28 @@ export async function discoverNewContacts(userId: string): Promise<DiscoveryResu
         const uid = parsed.uid;
         serverUids.add(uid);
 
-        // Skip if already imported, already pending, or person already mapped
+        // Skip if already imported or person already mapped
         if (existingUids.has(uid) || pendingUids.has(uid) || alreadyMappedPersonUids.has(uid)) {
+          continue;
+        }
+
+        // Auto-link if person exists with matching UID but no mapping
+        // (e.g. imported via file upload before CardDAV was connected)
+        if (unmappedPersonsByUid.has(uid)) {
+          const personId = unmappedPersonsByUid.get(uid)!;
+          await prisma.cardDavMapping.create({
+            data: {
+              connectionId: connection.id,
+              personId,
+              uid,
+              href: vCard.url,
+              etag: vCard.etag,
+              syncStatus: 'synced',
+              lastSyncedAt: new Date(),
+            },
+          });
+          unmappedPersonsByUid.delete(uid);
+          log.info({ personId, uid }, 'Auto-linked existing person to server vCard by UID');
           continue;
         }
 

--- a/lib/carddav/mapped-uids.ts
+++ b/lib/carddav/mapped-uids.ts
@@ -19,3 +19,22 @@ export async function getAlreadyMappedPersonUids(userId: string): Promise<Set<st
   });
   return new Set(persons.map((p) => p.uid!));
 }
+
+/**
+ * Returns a map from UID to person ID for all persons (including unmapped ones).
+ *
+ * Used during sync/discovery to auto-link server contacts to existing persons
+ * that were imported via file upload and have matching UIDs but no CardDavMapping.
+ */
+export async function getUnmappedPersonsByUid(userId: string): Promise<Map<string, string>> {
+  const persons = await prisma.person.findMany({
+    where: {
+      userId,
+      deletedAt: null,
+      uid: { not: null },
+      cardDavMapping: null,
+    },
+    select: { id: true, uid: true },
+  });
+  return new Map(persons.map((p) => [p.uid!, p.id]));
+}

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -13,7 +13,7 @@ import { customFieldValuesInclude } from '@/lib/prisma-queries';
 
 import { v4 as uuidv4 } from 'uuid';
 import { buildLocalHash } from './hash';
-import { getAlreadyMappedPersonUids } from './mapped-uids';
+import { getAlreadyMappedPersonUids, getUnmappedPersonsByUid } from './mapped-uids';
 import { createModuleLogger } from '@/lib/logger';
 import { ExternalServiceError } from '@/lib/errors';
 import { updateContext } from '@/lib/logging/context';
@@ -177,6 +177,11 @@ export async function syncFromServer(
     // Prevents creating pending imports for contacts whose person is already
     // mapped (e.g. auto-export with server UID rewrite).
     const alreadyMappedPersonUids = await getAlreadyMappedPersonUids(userId);
+
+    // Pre-load unmapped persons by UID so we can auto-link server contacts to
+    // persons that were imported via file upload (they have matching UIDs but
+    // no CardDavMapping yet).
+    const unmappedPersonsByUid = await getUnmappedPersonsByUid(userId);
 
     // Collect all UIDs seen on the server during processing (for stale import cleanup)
     const serverUids = new Set<string>();
@@ -434,6 +439,27 @@ export async function syncFromServer(
             result.updatedLocally++;
           }
           // If only local changed, we'll push in syncToServer
+        } else if (unmappedPersonsByUid.has(parsedData.uid)) {
+          // Person exists with matching UID but has no mapping (e.g. imported
+          // via file upload before CardDAV was connected). Auto-link them.
+          const personId = unmappedPersonsByUid.get(parsedData.uid)!;
+          await prisma.cardDavMapping.create({
+            data: {
+              connectionId: connection.id,
+              personId,
+              uid: parsedData.uid,
+              href: vCard.url,
+              etag: vCard.etag,
+              syncStatus: 'synced',
+              lastSyncedAt: new Date(),
+            },
+          });
+          unmappedPersonsByUid.delete(parsedData.uid);
+          result.imported++;
+          log.info(
+            { personId, uid: parsedData.uid },
+            'Auto-linked existing person to server vCard by UID',
+          );
         } else if (!alreadyMappedPersonUids.has(parsedData.uid)) {
           // New contact from server - add to pending imports
           await prisma.cardDavPendingImport.upsert({
@@ -955,13 +981,21 @@ export async function syncToServer(
 }
 
 /**
- * Bidirectional sync with overall timeout protection.
- * Default timeout is 5 minutes to prevent slow servers from blocking the cron queue.
+ * Bidirectional sync with inactivity-based timeout protection.
+ *
+ * Instead of a fixed overall timeout, uses a watchdog: the timer resets every
+ * time a progress event fires. This allows large accounts (thousands of
+ * contacts) to sync for as long as needed while still catching stuck syncs
+ * (e.g. unresponsive server).
+ *
+ * @param inactivityMs - Max time without progress before timeout (default 5 min).
+ *   Also serves as the initial deadline for the fetch phase, which doesn't
+ *   emit progress events.
  */
 export async function bidirectionalSync(
   userId: string,
   onProgress?: SyncProgressCallback,
-  timeoutMs: number = 5 * 60 * 1000
+  inactivityMs: number = 5 * 60 * 1000
 ): Promise<SyncResult> {
   const lockAcquired = await acquireSyncLock(userId);
   if (!lockAcquired) {
@@ -980,12 +1014,21 @@ export async function bidirectionalSync(
 
   const syncStart = Date.now();
   let timedOut = false;
-  let timerId: ReturnType<typeof setTimeout> | undefined;
+  let watchdogId: ReturnType<typeof setInterval> | undefined;
+  let lastActivityAt = Date.now();
+
+  const resetWatchdog = () => { lastActivityAt = Date.now(); };
+
+  const wrappedOnProgress = (event: SyncProgressEvent) => {
+    resetWatchdog();
+    onProgress?.(event);
+  };
 
   try {
     const syncOperation = async (): Promise<SyncResult> => {
-      const pullResult = await syncFromServer(userId, onProgress);
-      const pushResult = await syncToServer(userId, onProgress);
+      const pullResult = await syncFromServer(userId, wrappedOnProgress);
+      resetWatchdog();
+      const pushResult = await syncToServer(userId, wrappedOnProgress);
 
       const summary = {
         imported: pullResult.imported,
@@ -1019,9 +1062,7 @@ export async function bidirectionalSync(
 
     return await Promise.race([
       syncOperation().finally(() => {
-        clearTimeout(timerId);
-        // If we timed out, the finally block below skipped lock release.
-        // Release it now that the in-flight operation has actually finished.
+        clearInterval(watchdogId);
         if (timedOut) {
           releaseSyncLock(userId).catch((err) =>
             log.error({ err: err instanceof Error ? err : new Error(String(err)) }, 'Failed to release sync lock after timed-out operation completed')
@@ -1029,16 +1070,19 @@ export async function bidirectionalSync(
         }
       }),
       new Promise<never>((_, reject) => {
-        timerId = setTimeout(() => {
-          timedOut = true;
-          reject(new Error('Sync timed out'));
-        }, timeoutMs);
+        watchdogId = setInterval(() => {
+          if (Date.now() - lastActivityAt > inactivityMs) {
+            timedOut = true;
+            clearInterval(watchdogId);
+            reject(new Error('Sync timed out'));
+          }
+        }, 10_000);
       }),
     ]);
   } finally {
-    clearTimeout(timerId);
+    clearInterval(watchdogId);
     // Only release the lock if the sync completed (success or error).
-    // On timeout, the sync operation is still running — releasing the lock
+    // On timeout, the sync operation is still running - releasing the lock
     // would allow overlapping syncs. The stale lock detection (10min threshold
     // in acquireSyncLock) will break the lock if the operation never finishes.
     if (!timedOut) {

--- a/tests/lib/carddav/sync-domain-events.test.ts
+++ b/tests/lib/carddav/sync-domain-events.test.ts
@@ -94,6 +94,7 @@ vi.mock('@/lib/carddav/address-book', () => ({
 }));
 vi.mock('@/lib/carddav/mapped-uids', () => ({
   getAlreadyMappedPersonUids: vi.fn(async () => new Set<string>()),
+  getUnmappedPersonsByUid: vi.fn(async () => new Map<string, string>()),
 }));
 vi.mock('@/lib/carddav/hash', () => ({ buildLocalHash: vi.fn(() => 'hash') }));
 vi.mock('@/lib/carddav/vcard-import', () => ({

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -52,8 +52,9 @@ const mocks = vi.hoisted(() => ({
   personToVCard: vi.fn(),
   updatePersonFromVCard: vi.fn(),
 
-  // mapped-uids helper
+  // mapped-uids helpers
   getAlreadyMappedPersonUids: vi.fn(),
+  getUnmappedPersonsByUid: vi.fn(),
 }));
 
 vi.mock('@/lib/prisma', () => ({
@@ -130,6 +131,7 @@ vi.mock('@/lib/carddav/retry', () => ({
 
 vi.mock('@/lib/carddav/mapped-uids', () => ({
   getAlreadyMappedPersonUids: mocks.getAlreadyMappedPersonUids,
+  getUnmappedPersonsByUid: mocks.getUnmappedPersonsByUid,
 }));
 
 vi.mock('@/lib/photo-storage', () => ({
@@ -302,6 +304,8 @@ describe('CardDAV Sync Engine', () => {
     mocks.personFindMany.mockResolvedValue([]);
     // Default: no persons already mapped under a different UID
     mocks.getAlreadyMappedPersonUids.mockResolvedValue(new Set());
+    // Default: no unmapped persons with UIDs
+    mocks.getUnmappedPersonsByUid.mockResolvedValue(new Map());
 
     // Default: personToVCard returns a valid vCard string
     mocks.personToVCard.mockReturnValue('BEGIN:VCARD\nVERSION:3.0\nEND:VCARD');
@@ -493,6 +497,41 @@ describe('CardDAV Sync Engine', () => {
         // Should NOT create a pending import
         expect(mocks.cardDavPendingImportUpsert).not.toHaveBeenCalled();
         expect(result.pendingImports).toBeFalsy();
+      });
+
+      it('should auto-link unmapped person when server vCard has matching UID (issue #314)', async () => {
+        const serverUid = 'google-contact-uid';
+        const existingPersonId = 'person-file-imported';
+
+        // No existing mappings
+        mocks.cardDavMappingFindMany.mockResolvedValue([]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(serverUid, '/contacts/gerda.vcf', 'etag-1', 'Gerda'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(serverUid, 'Gerda'));
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+        mocks.cardDavMappingCreate.mockResolvedValue({});
+
+        // Person with this UID exists but has no mapping (file-imported)
+        mocks.getUnmappedPersonsByUid.mockResolvedValue(
+          new Map([[serverUid, existingPersonId]])
+        );
+
+        const result = await syncFromServer(USER_ID);
+
+        // Should auto-create a mapping instead of a pending import
+        expect(mocks.cardDavMappingCreate).toHaveBeenCalledWith({
+          data: expect.objectContaining({
+            connectionId: CONNECTION_ID,
+            personId: existingPersonId,
+            uid: serverUid,
+            href: '/contacts/gerda.vcf',
+            etag: 'etag-1',
+            syncStatus: 'synced',
+          }),
+        });
+        expect(mocks.cardDavPendingImportUpsert).not.toHaveBeenCalled();
+        expect(result.imported).toBe(1);
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes #314. CardDAV sync was creating duplicates in both directions when contacts were file-imported before connecting CardDAV.

- **Root cause**: The sync engine matched contacts exclusively by `CardDavMapping` records, but file-imported persons had UIDs with no mapping. `syncFromServer` treated them as new (pending imports), and `syncToServer` re-exported them as new vCards.
- **Fix**: Auto-link unmapped persons to server vCards by UID during sync and discovery. A new `getUnmappedPersonsByUid` helper finds persons with UIDs but no mapping. When a match is found, a `CardDavMapping` is created instead of a pending import, which also prevents `syncToServer` from re-exporting them.
- **Timeout**: Replaced the fixed 5-minute timeout with an inactivity-based watchdog that resets every time a progress event fires. Large accounts (6000+ contacts) can now sync for as long as needed; the timeout only fires after 5 minutes of zero progress (e.g., unresponsive server).

## Test plan

- [ ] Existing CardDAV tests pass (337/337)
- [ ] New test covers auto-link behavior for file-imported contacts
- [ ] Type-check passes clean
- [ ] Verify with a real Google account: import contacts via .vcf, connect CardDAV, sync - no duplicates created
- [ ] Verify large account sync completes without timeout as long as progress is being made