### PR TITLE
feat: make photo compression configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,6 +129,16 @@ CRON_SECRET=your-cron-secret-here-minimum-16-characters
 # In production, ensure this path is backed by a persistent volume.
 # PHOTO_STORAGE_PATH=/app/data/photos
 
+# Photo dimensions in pixels (square). Default: 256. Range: 64-4096.
+# Higher values produce sharper photos but use more disk space.
+# The client automatically sends 2x this value for retina display quality.
+# PHOTO_SIZE=256
+
+# JPEG quality for opaque photos. Default: 80. Range: 1-100.
+# Higher values produce better quality but larger files. PNG (transparent
+# images) is always lossless regardless of this setting.
+# PHOTO_QUALITY=80
+
 # ===========================================
 # Redis (Rate Limiting & Caching)
 # ===========================================

--- a/components/PhotoCropModal.tsx
+++ b/components/PhotoCropModal.tsx
@@ -12,10 +12,8 @@ interface PhotoCropModalProps {
   onCancel: () => void;
 }
 
-// Server stores the photo at 256x256; 512 gives 2x headroom for retina displays
-// while keeping the upload payload small regardless of source resolution.
-const OUTPUT_SIZE = 512;
-const JPEG_QUALITY = 0.92;
+const OUTPUT_SIZE = Number(process.env.NEXT_PUBLIC_PHOTO_SIZE || 256) * 2;
+const JPEG_QUALITY = Number(process.env.NEXT_PUBLIC_PHOTO_QUALITY || 80) / 100;
 
 function canvasHasAlpha(ctx: CanvasRenderingContext2D, width: number, height: number): boolean {
   const { data } = ctx.getImageData(0, 0, width, height);

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -78,6 +78,10 @@ const envSchema = z.object({
 
   // Application URL for generating links in emails (optional, defaults to NEXTAUTH_URL)
   NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+
+  // Photo processing
+  PHOTO_SIZE: z.coerce.number().int().min(64).max(4096).default(256),
+  PHOTO_QUALITY: z.coerce.number().int().min(1).max(100).default(80),
 });
 
 /**

--- a/lib/photo-storage.ts
+++ b/lib/photo-storage.ts
@@ -8,14 +8,20 @@ import { validateServerUrl } from '@/lib/carddav/url-validation';
 const log = createModuleLogger('photos');
 
 const MAX_PHOTO_SIZE = 50 * 1024 * 1024; // 50MB
-const PHOTO_SIZE = 256;
-const JPEG_QUALITY = 80;
 const FETCH_TIMEOUT_MS = 15000;
 // Bound decoded-pixel memory independently of byte size. Sharp's default
 // (268MP) is too generous: an attacker can craft a small file that decodes
 // into hundreds of MB of RGBA pixels. 100MP covers any realistic phone or
 // DSLR sensor (Hasselblad H6D-100c is ~100MP at the high end).
 const SHARP_MAX_INPUT_PIXELS = 100 * 1024 * 1024;
+
+function getPhotoSize(): number {
+  return Number(process.env.PHOTO_SIZE) || 256;
+}
+
+function getJpegQuality(): number {
+  return Number(process.env.PHOTO_QUALITY) || 80;
+}
 
 /**
  * Atomically write data to filePath: write to a temp file in the same
@@ -185,7 +191,9 @@ export function isValidImageBuffer(buffer: Buffer): boolean {
 
 /**
  * Process a photo buffer: validate format, enforce size limit,
- * resize to PHOTO_SIZE x PHOTO_SIZE (cover), convert to JPEG at JPEG_QUALITY, strip EXIF.
+ * resize to PHOTO_SIZE x PHOTO_SIZE (cover), convert to JPEG at PHOTO_QUALITY, strip EXIF.
+ * PHOTO_SIZE and PHOTO_QUALITY are read from the environment (see lib/env.ts), with
+ * defaults of 256 and 80 respectively.
  * Throws on invalid input.
  */
 export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasAlpha: boolean }> {
@@ -197,8 +205,9 @@ export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasA
     throw new Error(`Photo exceeds maximum size of ${MAX_PHOTO_SIZE / (1024 * 1024)}MB`);
   }
 
+  const photoSize = getPhotoSize();
   const image = sharp(buffer, { limitInputPixels: SHARP_MAX_INPUT_PIXELS })
-    .resize(PHOTO_SIZE, PHOTO_SIZE, { fit: 'cover' })
+    .resize(photoSize, photoSize, { fit: 'cover' })
     .rotate(); // auto-rotate based on EXIF before stripping
 
   // Check if the source format has an alpha channel
@@ -211,7 +220,7 @@ export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasA
   }
 
   // No alpha — save as JPEG (smaller file size)
-  return { data: await image.jpeg({ quality: JPEG_QUALITY }).toBuffer(), hasAlpha: false };
+  return { data: await image.jpeg({ quality: getJpegQuality() }).toBuffer(), hasAlpha: false };
 }
 
 /**

--- a/next.config.ts
+++ b/next.config.ts
@@ -6,6 +6,11 @@ const withNextIntl = createNextIntlPlugin('./i18n.ts');
 const nextConfig: NextConfig = {
   devIndicators: false,
 
+  env: {
+    NEXT_PUBLIC_PHOTO_SIZE: String(process.env.PHOTO_SIZE || '256'),
+    NEXT_PUBLIC_PHOTO_QUALITY: String(process.env.PHOTO_QUALITY || '80'),
+  },
+
   // Externalize Pino from Next.js webpack bundle (uses Node.js native modules)
   serverExternalPackages: ['pino', 'pino-pretty'],
 

--- a/tests/lib/photo-storage.test.ts
+++ b/tests/lib/photo-storage.test.ts
@@ -65,6 +65,18 @@ async function createTestImage(
   return img.toFormat(format).toBuffer();
 }
 
+// A flat solid-color image compresses to the same size regardless of JPEG
+// quality (no detail for the DCT to discard), so quality-sensitive tests
+// need actual pixel variation to produce a measurable size difference.
+async function createNoisyTestImage(width: number, height: number): Promise<Buffer> {
+  const channels = 3;
+  const raw = Buffer.alloc(width * height * channels);
+  for (let i = 0; i < raw.length; i++) {
+    raw[i] = Math.floor(Math.random() * 256);
+  }
+  return sharp(raw, { raw: { width, height, channels } }).jpeg().toBuffer();
+}
+
 describe('isValidImageBuffer', () => {
   it('should accept JPEG buffers', () => {
     expect(isValidImageBuffer(makeJpegBuffer())).toBe(true);
@@ -203,6 +215,62 @@ describe('processPhoto', () => {
     expect(metadata.width).toBe(256);
     expect(metadata.height).toBe(256);
     expect(output.hasAlpha).toBe(true);
+  });
+
+  it('should respect PHOTO_SIZE env var', async () => {
+    const originalSize = process.env.PHOTO_SIZE;
+    process.env.PHOTO_SIZE = '512';
+    try {
+      const input = await createTestImage(1024, 1024, 'png');
+      const output = await processPhoto(input);
+
+      const metadata = await sharp(output.data).metadata();
+      expect(metadata.width).toBe(512);
+      expect(metadata.height).toBe(512);
+    } finally {
+      if (originalSize === undefined) {
+        delete process.env.PHOTO_SIZE;
+      } else {
+        process.env.PHOTO_SIZE = originalSize;
+      }
+    }
+  });
+
+  it('should respect PHOTO_QUALITY env var', async () => {
+    const originalQuality = process.env.PHOTO_QUALITY;
+    process.env.PHOTO_QUALITY = '95';
+    try {
+      const input = await createNoisyTestImage(512, 512);
+      const highQuality = await processPhoto(input);
+
+      process.env.PHOTO_QUALITY = '20';
+      const lowQuality = await processPhoto(input);
+
+      expect(highQuality.data.length).toBeGreaterThan(lowQuality.data.length);
+    } finally {
+      if (originalQuality === undefined) {
+        delete process.env.PHOTO_QUALITY;
+      } else {
+        process.env.PHOTO_QUALITY = originalQuality;
+      }
+    }
+  });
+
+  it('should default to 256x256 when PHOTO_SIZE is unset', async () => {
+    const originalSize = process.env.PHOTO_SIZE;
+    delete process.env.PHOTO_SIZE;
+    try {
+      const input = await createTestImage(512, 512, 'png');
+      const output = await processPhoto(input);
+
+      const metadata = await sharp(output.data).metadata();
+      expect(metadata.width).toBe(256);
+      expect(metadata.height).toBe(256);
+    } finally {
+      if (originalSize !== undefined) {
+        process.env.PHOTO_SIZE = originalSize;
+      }
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `PHOTO_SIZE` (default 256, range 64-4096) and `PHOTO_QUALITY` (default 80, range 1-100) environment variables so self-hosted users can increase photo storage quality
- Server-side `processPhoto()` reads these at call time instead of using hardcoded constants
- Values are piped to the client via `next.config.ts`; the crop modal applies a 2x retina multiplier to the configured size

Closes #320

## Test plan

- [ ] Verify existing tests pass (2277 passing, 3 new tests added)
- [ ] Set `PHOTO_SIZE=512` and `PHOTO_QUALITY=95` in `.env`, upload a photo, confirm stored file is 512x512
- [ ] Leave both vars unset, upload a photo, confirm stored file is 256x256 at quality 80 (backward compatible)
- [ ] Set an out-of-range value (e.g. `PHOTO_SIZE=0`), confirm Zod validation rejects it at startup