### PR TITLE
fix(auth): send `state` in OIDC authorize request (fixes strict servers like Pocket ID)

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -246,6 +246,15 @@ const providers = [
           // Use /userinfo instead of ID-token claims. Many providers
           // (Authentik, Keycloak) put email/name only in userinfo.
           idToken: false,
+          // Send the `state` parameter (CSRF protection) alongside PKCE.
+          // With idToken:false Auth.js otherwise defaults `checks` to ['pkce']
+          // here and omits `state`. Spec-strict OAuth servers (e.g. Fosite-based
+          // Pocket ID >= v2.10) reject an authorize request without `state`,
+          // which surfaces as a CallbackRouteError / error=Configuration page.
+          // Cast is required: a bare ['pkce', 'state'] literal is inferred as
+          // string[], not the ('pkce' | 'state' | 'nonce' | 'none')[] union that
+          // Auth.js's OIDCConfig.checks expects.
+          checks: ['pkce', 'state'] as ('pkce' | 'state')[],
           profile(profile: Record<string, unknown>) {
             if (!profile.email || typeof profile.email !== 'string') {
               throw new Error('OIDC provider did not return an email address');


### PR DESCRIPTION
## Summary

Adds `checks: ['pkce', 'state']` to the generic OIDC provider so the authorization request includes the `state` parameter (CSRF protection) in addition to PKCE.

Because the provider sets `idToken: false` and specifies no `checks`, Auth.js currently defaults to `checks: ['pkce']` and omits `state`. OAuth servers that don't strictly enforce `state` tolerate this, but spec-strict servers reject the authorize request. Concretely, **Pocket ID >= v2.10** (which migrated to the Fosite OAuth2 engine) returns `invalid_state`, so the callback never receives a code and Auth.js throws `CallbackRouteError`, rendered to the user as the generic `error=Configuration` "Server error" page.

Adding `state` makes the flow spec-compliant and restores CSRF protection, while keeping PKCE. No behavior change for providers that already worked.

The array literal is cast to `('pkce' | 'state')[]` — a bare literal is inferred as `string[]`, which doesn't satisfy `OIDCConfig.checks`' union element type `('none' | 'nonce' | 'pkce' | 'state')[]` (the build fails without the cast).

## Testing

Built and ran the patched image locally (`docker build`, Node 20) against a real Fosite-based Pocket ID instance:

- **`npm run build` passes** (TypeScript type-check included). Without the cast it fails with `Type 'string[]' is not assignable to type '("none" | "nonce" | "pkce" | "state")[]'`.
- **Verified the fix at runtime:** initiated OIDC sign-in and captured the resulting `/authorize` redirect. The patched build now emits `state=` alongside `code_challenge=`:

  ```
  https://<pocket-id>/authorize?response_type=code&client_id=…&redirect_uri=…&scope=openid+email+profile&state=eyJhbGciOiJkaXIi…&code_challenge=…&code_challenge_method=S256
  ```

  Before the change, the same request contained `code_challenge` but no `state`, which is exactly what Fosite rejected with `invalid_state`.

## Checklist

- [x] I've run tests locally — built the image (`npm run build` incl. type-check passes) and verified at runtime that the `/authorize` request now includes `state=` against a live Fosite/Pocket ID instance.
- [x] I've updated documentation where needed — inline comments explain both why `state` is set and why the cast is required.
- [ ] I've added/updated tests for the change — auth-provider config isn't covered by the unit suite; happy to add one if you'd like.
- [x] I've considered backwards compatibility — `state` is a standard, widely-supported parameter; adding it does not break providers that already worked.
- [x] I've added/updated translations — n/a, no user-facing strings changed.

## Related issues

Closes #337
