### PR TITLE
fix: add state parameter to OIDC authorization requests

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -246,6 +246,7 @@ const providers = [
           // Use /userinfo instead of ID-token claims. Many providers
           // (Authentik, Keycloak) put email/name only in userinfo.
           idToken: false,
+          checks: ['pkce', 'state'] as ('pkce' | 'state')[],
           profile(profile: Record<string, unknown>) {
             if (!profile.email || typeof profile.email !== 'string') {
               throw new Error('OIDC provider did not return an email address');


### PR DESCRIPTION
## Summary

- Adds `checks: ['pkce', 'state']` to the OIDC provider config in `lib/auth.ts`
- Without this, Auth.js defaulted to PKCE-only and omitted the `state` parameter from the authorization URL
- Providers that enforce RFC-compliant `state` (e.g. Pocket ID >= v2.10 / Fosite) rejected the request, causing a `CallbackRouteError`

Fixes #337

## Test plan

- [ ] OIDC login with a spec-strict provider (Pocket ID, Fosite-based) no longer returns `invalid_state`
- [ ] OIDC login with permissive providers (Authentik, Keycloak) continues to work
- [ ] Password login is unaffected