### PR TITLE
Respect geocoder rate limits and prevent overlapping cron runs

### DIFF
--- a/app/api/cron/geocode/route.ts
+++ b/app/api/cron/geocode/route.ts
@@ -13,11 +13,18 @@ const log = createModuleLogger('cron-geocode');
 // minute, keeping runs short even when a large backlog exists.
 const BATCH_SIZE = 50;
 
+// Guards against overlapping runs in this process (a slow run overlapping the
+// next scheduled one, or a manual trigger during a scheduled run). Overlaps
+// double the geocoder traffic for no benefit since both runs would pick up
+// the same rows.
+let runInProgress = false;
+
 export const GET = withLogging(async function GET(request: Request) {
   const startTime = Date.now();
   updateContext({ jobId: `geocode:${randomUUID()}` });
 
   let cronLogId: string | null = null;
+  let acquiredRunLock = false;
 
   try {
     const authHeader = request.headers.get('authorization');
@@ -29,6 +36,13 @@ export const GET = withLogging(async function GET(request: Request) {
     if (env.DISABLE_GEOCODING) {
       return NextResponse.json({ success: true, disabled: true, reason: 'Geocoding disabled' });
     }
+
+    if (runInProgress) {
+      log.info({ event: 'cron.geocode.already_running' });
+      return NextResponse.json({ success: true, alreadyRunning: true, reason: 'A geocode run is already in progress' });
+    }
+    runInProgress = true;
+    acquiredRunLock = true;
 
     const cronLog = await prisma.cronJobLog.create({
       data: { jobName: 'geocode', status: 'started' },
@@ -50,6 +64,7 @@ export const GET = withLogging(async function GET(request: Request) {
     let failed = 0;
     let pending = 0;
     let skipped = 0;
+    let rateLimited = false;
 
     for (const address of addresses) {
       try {
@@ -57,7 +72,15 @@ export const GET = withLogging(async function GET(request: Request) {
         if (outcome === 'success') geocoded++;
         else if (outcome === 'failed') failed++;
         else if (outcome === 'pending') pending++;
-        else skipped++;
+        else if (outcome === 'rate_limited') {
+          // The provider asked us to back off: stop the batch instead of
+          // feeding it more traffic. Untouched rows stay eligible for the
+          // next run.
+          pending++;
+          rateLimited = true;
+          log.warn({ event: 'cron.geocode.rate_limited', remaining: addresses.length - (geocoded + failed + pending + skipped) });
+          break;
+        } else skipped++;
       } catch (error) {
         log.warn({
           event: 'cron.geocode.item_failed',
@@ -69,13 +92,16 @@ export const GET = withLogging(async function GET(request: Request) {
       }
     }
 
+    const processed = geocoded + failed + pending + skipped;
+
     log.info({
       event: 'cron.geocode.finished',
-      processed: addresses.length,
+      processed,
       geocoded,
       failed,
       pending,
       skipped,
+      rateLimited,
       durationMs: Date.now() - startTime,
     });
 
@@ -84,17 +110,18 @@ export const GET = withLogging(async function GET(request: Request) {
       data: {
         status: pending > 0 ? 'completed_with_errors' : 'completed',
         duration: Date.now() - startTime,
-        message: `Processed ${addresses.length} addresses: ${geocoded} geocoded, ${failed} failed, ${pending} pending, ${skipped} skipped`,
+        message: `Processed ${processed} of ${addresses.length} addresses: ${geocoded} geocoded, ${failed} failed, ${pending} pending, ${skipped} skipped${rateLimited ? ' (stopped early: provider rate limited)' : ''}`,
       },
     });
 
     return NextResponse.json({
       success: true,
-      processed: addresses.length,
+      processed,
       geocoded,
       failed,
       pending,
       skipped,
+      rateLimited,
     });
   } catch (error) {
     if (cronLogId) {
@@ -108,5 +135,9 @@ export const GET = withLogging(async function GET(request: Request) {
       });
     }
     return handleApiError(error, 'cron-geocode');
+  } finally {
+    if (acquiredRunLock) {
+      runInProgress = false;
+    }
   }
 });

--- a/lib/geocoding/geocode-person.ts
+++ b/lib/geocoding/geocode-person.ts
@@ -4,11 +4,10 @@ import { env } from '@/lib/env';
 import { createModuleLogger } from '@/lib/logger';
 import { buildAddressHash, hasGeocodableContent } from './hash';
 import { geocodeAddress, GeocodingProviderError, type GeocodeResult } from './provider';
-import { enqueueGeocodeRequest } from './queue';
 
 const log = createModuleLogger('geocoding');
 
-export type GeocodeOutcome = 'success' | 'failed' | 'pending' | 'skipped';
+export type GeocodeOutcome = 'success' | 'failed' | 'pending' | 'skipped' | 'rate_limited';
 
 /**
  * Geocode one address row if it needs it. Uses updateMany for row updates
@@ -51,17 +50,28 @@ export async function geocodeSingleAddress(address: PersonAddress): Promise<Geoc
   try {
     let result: GeocodeResult | null;
     try {
-      result = await enqueueGeocodeRequest(() => geocodeAddress(address));
+      result = await geocodeAddress(address);
     } catch (error) {
+      // A 429 means the provider wants LESS traffic: retrying immediately is
+      // the one thing guaranteed to make it worse. Leave the address pending
+      // and tell the caller to back off.
+      if (error instanceof GeocodingProviderError && error.status === 429) {
+        log.warn({ addressId: address.id }, 'Geocoder rate limited, backing off');
+        await prisma.personAddress.updateMany({
+          where: { id: address.id },
+          data: { geocodeStatus: 'pending' },
+        });
+        return 'rate_limited';
+      }
       if (!(error instanceof GeocodingProviderError)) {
         throw error;
       }
-      // One retry for transient provider failures. The common cause is a
-      // stale kept-alive connection, where the immediate second attempt gets
-      // a fresh socket and succeeds. Going through the queue again keeps the
-      // provider rate limit intact; a second failure falls through to the
-      // outer catch and leaves the address pending for the cron.
-      result = await enqueueGeocodeRequest(() => geocodeAddress(address));
+      // One retry for other transient provider failures. The common cause is
+      // a stale kept-alive connection, where the immediate second attempt
+      // gets a fresh socket and succeeds. Each request goes through the rate
+      // limit queue inside the provider; a second failure falls through to
+      // the outer catch and leaves the address pending for the cron.
+      result = await geocodeAddress(address);
     }
     const status = result ? 'success' : 'failed';
 
@@ -105,6 +115,9 @@ export async function geocodeSingleAddress(address: PersonAddress): Promise<Geoc
       where: { id: address.id },
       data: { geocodeStatus: 'pending' },
     });
+    if (error instanceof GeocodingProviderError && error.status === 429) {
+      return 'rate_limited';
+    }
     return 'pending';
   }
 }
@@ -138,6 +151,11 @@ export async function geocodePersonAddresses(personId: string): Promise<void> {
   }
 
   for (const address of person.addresses) {
-    await geocodeSingleAddress(address);
+    const outcome = await geocodeSingleAddress(address);
+    if (outcome === 'rate_limited') {
+      // The provider asked us to back off; the remaining addresses stay
+      // eligible for the cron, which retries them later.
+      break;
+    }
   }
 }

--- a/lib/geocoding/provider.ts
+++ b/lib/geocoding/provider.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { env } from '@/lib/env';
 import type { AddressFields } from './hash';
+import { enqueueGeocodeRequest } from './queue';
 
 export interface GeocodeResult {
   latitude: number;
@@ -9,9 +10,13 @@ export interface GeocodeResult {
 
 /** Transient provider failure (network, 5xx, rate limit). Safe to retry later. */
 export class GeocodingProviderError extends Error {
-  constructor(message: string) {
+  /** HTTP status when the provider responded (e.g. 429); undefined for network errors */
+  readonly status?: number;
+
+  constructor(message: string, status?: number) {
     super(message);
     this.name = 'GeocodingProviderError';
+    this.status = status;
   }
 }
 
@@ -20,37 +25,43 @@ const nominatimResponseSchema = z.array(z.object({ lat: z.string(), lon: z.strin
 // Identify ourselves to the provider, required by the OSM Nominatim usage policy.
 const USER_AGENT = 'Nametag (+https://github.com/mattogodoy/nametag)';
 
+// Every HTTP request goes through the rate-limit queue individually. Wrapping
+// anything coarser (a whole address, which may need a structured attempt plus
+// a free-text fallback) lets bursts of back-to-back requests through and gets
+// the instance 429-banned by the public Nominatim.
 async function search(params: URLSearchParams): Promise<GeocodeResult | null> {
   params.set('format', 'jsonv2');
   params.set('limit', '1');
   const base = env.GEOCODER_URL.replace(/\/+$/, '');
 
-  let response: Response;
-  try {
-    response = await fetch(`${base}/search?${params.toString()}`, {
-      headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
-    });
-  } catch (error) {
-    throw new GeocodingProviderError(
-      error instanceof Error ? error.message : 'Network error contacting geocoder'
-    );
-  }
+  return enqueueGeocodeRequest(async () => {
+    let response: Response;
+    try {
+      response = await fetch(`${base}/search?${params.toString()}`, {
+        headers: { 'User-Agent': USER_AGENT, Accept: 'application/json' },
+      });
+    } catch (error) {
+      throw new GeocodingProviderError(
+        error instanceof Error ? error.message : 'Network error contacting geocoder'
+      );
+    }
 
-  if (!response.ok) {
-    throw new GeocodingProviderError(`Geocoder responded with status ${response.status}`);
-  }
+    if (!response.ok) {
+      throw new GeocodingProviderError(`Geocoder responded with status ${response.status}`, response.status);
+    }
 
-  const parsed = nominatimResponseSchema.safeParse(await response.json());
-  if (!parsed.success || parsed.data.length === 0) {
-    return null;
-  }
+    const parsed = nominatimResponseSchema.safeParse(await response.json());
+    if (!parsed.success || parsed.data.length === 0) {
+      return null;
+    }
 
-  const latitude = Number.parseFloat(parsed.data[0].lat);
-  const longitude = Number.parseFloat(parsed.data[0].lon);
-  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-    return null;
-  }
-  return { latitude, longitude };
+    const latitude = Number.parseFloat(parsed.data[0].lat);
+    const longitude = Number.parseFloat(parsed.data[0].lon);
+    if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      return null;
+    }
+    return { latitude, longitude };
+  });
 }
 
 /**
@@ -78,6 +89,9 @@ export async function geocodeAddress(address: AddressFields): Promise<GeocodeRes
       if (result) return result;
     } catch (error) {
       if (!(error instanceof GeocodingProviderError)) throw error;
+      // The provider is telling us to slow down: more requests (the fallback)
+      // would make it worse, so surface the 429 to the caller immediately.
+      if (error.status === 429) throw error;
       // Structured query failed transiently: fall through to the free-text
       // attempt below rather than aborting, unless there is nothing to try.
       if (!freeText) throw error;

--- a/lib/geocoding/queue.ts
+++ b/lib/geocoding/queue.ts
@@ -3,7 +3,10 @@
 // With multiple app instances the worst case is N requests per second, which
 // is acceptable at Nametag's scale; self-hosters can point GEOCODER_URL at
 // their own instance to remove the shared-provider concern entirely.
-const MIN_INTERVAL_MS = 1000;
+// Slightly above 1000ms: the policy caps at 1 request per second and exact
+// 1000ms spacing sits right on the limit, where scheduler jitter can tip
+// individual gaps under a second.
+const MIN_INTERVAL_MS = 1100;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/lib/openapi/index.ts
+++ b/lib/openapi/index.ts
@@ -183,7 +183,7 @@ export function generateOpenAPISpec(): OpenAPISpec {
         get: {
           tags: ['Cron'],
           summary: 'Geocode pending addresses',
-          description: 'Processes a bounded batch of addresses awaiting geocoding for users who have opted in, skipping soft-deleted people. When geocoding is disabled instance-wide, returns { success, disabled, reason } instead of batch counts.',
+          description: 'Processes a bounded batch of addresses awaiting geocoding for users who have opted in, skipping soft-deleted people. When geocoding is disabled instance-wide, returns { success, disabled, reason } instead of batch counts. When a run is already in progress, returns { success, alreadyRunning, reason }. When the provider rate limits, the batch stops early and rateLimited is true.',
           security: [{ cronBearer: [] }],
           responses: {
             '200': jsonResponse('Geocoding batch results', {
@@ -195,7 +195,9 @@ export function generateOpenAPISpec(): OpenAPISpec {
                 failed: { type: 'integer' },
                 pending: { type: 'integer' },
                 skipped: { type: 'integer' },
+                rateLimited: { type: 'boolean' },
                 disabled: { type: 'boolean' },
+                alreadyRunning: { type: 'boolean' },
                 reason: { type: 'string' },
               },
             }),

--- a/tests/api/cron-geocode.test.ts
+++ b/tests/api/cron-geocode.test.ts
@@ -96,4 +96,56 @@ describe('GET /api/cron/geocode', () => {
       })
     );
   });
+
+  it('stops the batch early when the provider rate limits', async () => {
+    mocks.addressFindMany.mockResolvedValue([{ id: 'a1' }, { id: 'a2' }, { id: 'a3' }]);
+    mocks.geocodeSingleAddress
+      .mockResolvedValueOnce('success')
+      .mockResolvedValueOnce('rate_limited');
+
+    const response = await GET(makeRequest());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({
+      success: true,
+      processed: 2,
+      geocoded: 1,
+      failed: 0,
+      pending: 1,
+      skipped: 0,
+      rateLimited: true,
+    });
+    // The third address was never attempted
+    expect(mocks.geocodeSingleAddress).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects overlapping runs while one is in progress', async () => {
+    mocks.addressFindMany.mockResolvedValue([{ id: 'a1' }]);
+    let releaseFirstRun: (value: 'success') => void = () => undefined;
+    mocks.geocodeSingleAddress.mockImplementationOnce(
+      () => new Promise((resolve) => {
+        releaseFirstRun = resolve;
+      })
+    );
+
+    const firstRun = GET(makeRequest());
+    // Give the first run a chance to acquire the lock and start its batch
+    await vi.waitFor(() => {
+      expect(mocks.geocodeSingleAddress).toHaveBeenCalledTimes(1);
+    });
+
+    const secondResponse = await GET(makeRequest());
+    const secondBody = await secondResponse.json();
+    expect(secondBody).toMatchObject({ success: true, alreadyRunning: true });
+
+    releaseFirstRun('success');
+    const firstBody = await (await firstRun).json();
+    expect(firstBody).toMatchObject({ success: true, processed: 1, geocoded: 1 });
+
+    // The lock is released: a subsequent run proceeds normally
+    mocks.addressFindMany.mockResolvedValue([]);
+    const thirdBody = await (await GET(makeRequest())).json();
+    expect(thirdBody).toMatchObject({ success: true, processed: 0 });
+  });
 });

--- a/tests/lib/geocode-person.test.ts
+++ b/tests/lib/geocode-person.test.ts
@@ -27,7 +27,13 @@ vi.mock('@/lib/env', () => ({
 
 vi.mock('../../lib/geocoding/provider', () => ({
   geocodeAddress: mocks.geocodeAddress,
-  GeocodingProviderError: class GeocodingProviderError extends Error {},
+  GeocodingProviderError: class GeocodingProviderError extends Error {
+    readonly status?: number;
+    constructor(message: string, status?: number) {
+      super(message);
+      this.status = status;
+    }
+  },
 }));
 
 // Run queue tasks immediately in tests
@@ -187,6 +193,32 @@ describe('geocodeSingleAddress', () => {
     expect(outcome).toBe('pending');
     expect(mocks.geocodeAddress).toHaveBeenCalledTimes(1);
   });
+
+  it('backs off without retrying when the provider rate limits', async () => {
+    mocks.cacheFindUnique.mockResolvedValue(null);
+    mocks.geocodeAddress.mockRejectedValue(new GeocodingProviderError('slow down', 429));
+
+    const outcome = await geocodeSingleAddress(makeAddress());
+
+    expect(outcome).toBe('rate_limited');
+    expect(mocks.geocodeAddress).toHaveBeenCalledTimes(1);
+    expect(mocks.cacheUpsert).not.toHaveBeenCalled();
+    expect(mocks.addressUpdateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { geocodeStatus: 'pending' } })
+    );
+  });
+
+  it('returns rate_limited when the retry hits a 429', async () => {
+    mocks.cacheFindUnique.mockResolvedValue(null);
+    mocks.geocodeAddress
+      .mockRejectedValueOnce(new GeocodingProviderError('stale connection'))
+      .mockRejectedValueOnce(new GeocodingProviderError('slow down', 429));
+
+    const outcome = await geocodeSingleAddress(makeAddress());
+
+    expect(outcome).toBe('rate_limited');
+    expect(mocks.geocodeAddress).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('geocodePersonAddresses', () => {
@@ -246,5 +278,19 @@ describe('geocodePersonAddresses', () => {
     await geocodePersonAddresses('person-1');
 
     expect(mocks.geocodeAddress).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops geocoding the remaining addresses when rate limited', async () => {
+    mocks.personFindUnique.mockResolvedValue({
+      id: 'person-1',
+      addresses: [makeAddress(), makeAddress({ id: 'addr-2', locality: 'Shelbyville' })],
+      user: { geocodingEnabled: true },
+    });
+    mocks.cacheFindUnique.mockResolvedValue(null);
+    mocks.geocodeAddress.mockRejectedValue(new GeocodingProviderError('slow down', 429));
+
+    await geocodePersonAddresses('person-1');
+
+    expect(mocks.geocodeAddress).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/lib/geocoding-provider.test.ts
+++ b/tests/lib/geocoding-provider.test.ts
@@ -4,6 +4,12 @@ vi.mock('@/lib/env', () => ({
   env: { GEOCODER_URL: 'https://geocoder.test' },
 }));
 
+// Run queued requests immediately: the provider routes every HTTP request
+// through the rate-limit queue, which would otherwise add real delays here.
+vi.mock('../../lib/geocoding/queue', () => ({
+  enqueueGeocodeRequest: <T,>(task: () => Promise<T>) => task(),
+}));
+
 import { geocodeAddress, GeocodingProviderError } from '../../lib/geocoding/provider';
 
 const address = {
@@ -97,5 +103,21 @@ describe('geocodeAddress', () => {
 
     await expect(geocodeAddress(address)).rejects.toBeInstanceOf(GeocodingProviderError);
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('exposes the HTTP status on provider errors', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'slow down' }, 429));
+
+    const error = await geocodeAddress(address).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(GeocodingProviderError);
+    expect((error as GeocodingProviderError).status).toBe(429);
+  });
+
+  it('does not attempt the free-text fallback when rate limited', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: 'slow down' }, 429));
+
+    await expect(geocodeAddress(address)).rejects.toBeInstanceOf(GeocodingProviderError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/lib/geocoding-queue.test.ts
+++ b/tests/lib/geocoding-queue.test.ts
@@ -24,12 +24,12 @@ describe('enqueueGeocodeRequest', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(startTimes).toHaveLength(1);
 
-    await vi.advanceTimersByTimeAsync(999);
+    await vi.advanceTimersByTimeAsync(1099);
     expect(startTimes).toHaveLength(1);
 
     await vi.advanceTimersByTimeAsync(1);
     expect(startTimes).toHaveLength(2);
-    expect(startTimes[1] - startTimes[0]).toBeGreaterThanOrEqual(1000);
+    expect(startTimes[1] - startTimes[0]).toBeGreaterThanOrEqual(1100);
 
     await expect(first).resolves.toBe('ok');
     await expect(second).resolves.toBe('ok');


### PR DESCRIPTION
## Summary

Production logs showed sustained `429` responses from the public Nominatim during the geocode backfill, with two cron runs interleaved. Root causes and fixes:

1. **The rate limiter wrapped the wrong unit.** One queue slot ran a whole address lookup, which can fire a structured query plus an immediate free-text fallback, and the transient retry doubled that again, so bursts reached 2-4 requests in quick succession. Every HTTP request now passes through the queue individually, with the minimum spacing raised to 1100ms for margin over the 1 req/s policy.
2. **429 responses were amplified instead of respected.** `GeocodingProviderError` now carries the HTTP status; on a 429 the provider skips the free-text fallback, the orchestrator skips the retry, the batch (cron and per-person background loop alike) stops immediately, and untouched rows stay `pending` for the next run. The cron response and `CronJobLog` message report the early stop via `rateLimited`.
3. **Cron runs could overlap** (two concurrent job ids observed in production, doubling traffic for no benefit since both runs select the same rows). The endpoint now refuses to start while a run is in progress in the same process, returning `{ success, alreadyRunning }`.

## Testing

- 8 new/updated tests: 429 status propagation, no fallback and no retry on 429, `rate_limited` outcome, batch early-stop, per-person loop early-stop, overlap guard (with lock release), queue spacing at 1100ms
- Full geocoding suites plus the OpenAPI spec test pass; typecheck and lint clean

## Operational notes

After deploying, the backfill self-heals: rate-limited addresses remain `pending` and are retried on later runs. If Nominatim temporarily banned the instance IP, expect 429s to continue for a while; runs now stop after a single request instead of hammering.