### PR TITLE
Show the address in the map marker popup

### DIFF
--- a/app/api/map/markers/route.ts
+++ b/app/api/map/markers/route.ts
@@ -1,6 +1,7 @@
 import { prisma } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 import { formatCanonicalName, type NameDisplayFormat } from '@/lib/nameUtils';
+import { getCountryName } from '@/lib/countries';
 import type { MapGroup, MapMarker, UnlocatedPerson } from '@/lib/map/types';
 
 export const GET = withAuth(async (request, session) => {
@@ -24,8 +25,11 @@ export const GET = withAuth(async (request, session) => {
             select: {
               id: true,
               type: true,
+              streetLine1: true,
+              streetLine2: true,
               locality: true,
               region: true,
+              postalCode: true,
               country: true,
               latitude: true,
               longitude: true,
@@ -89,6 +93,17 @@ export const GET = withAuth(async (request, session) => {
         if (address.geocodeStatus !== 'success' || address.latitude === null || address.longitude === null) {
           continue;
         }
+        const addressText = [
+          address.streetLine1,
+          address.streetLine2,
+          address.locality,
+          address.region,
+          address.postalCode,
+          address.country ? getCountryName(address.country) || address.country : null,
+        ]
+          .filter((part) => part && part.trim().length > 0)
+          .join(', ');
+
         markers.push({
           id: `addr_${address.id}`,
           source: 'address',
@@ -100,6 +115,7 @@ export const GET = withAuth(async (request, session) => {
           city: address.locality,
           region: address.region,
           country: address.country,
+          addressText: addressText || null,
           groupIds,
         });
       }
@@ -116,6 +132,7 @@ export const GET = withAuth(async (request, session) => {
           city: null,
           region: null,
           country: null,
+          addressText: null,
           groupIds,
         });
       }

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -38,6 +38,7 @@ interface MarkerProperties {
   personId: string;
   personName: string;
   label: string;
+  addressText?: string;
 }
 
 function useIsDarkTheme(): boolean {
@@ -79,6 +80,9 @@ function toGeoJSON(markers: MapMarker[]): GeoJSON.FeatureCollection<GeoJSON.Poin
         personId: marker.personId,
         personName: marker.personName,
         label: marker.label,
+        // Omitted rather than null: null-valued GeoJSON properties do not
+        // survive the round trip through queryRenderedFeatures reliably.
+        ...(marker.addressText ? { addressText: marker.addressText } : {}),
       },
     })),
   };
@@ -278,7 +282,13 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
     openPopup(
       map,
       [target.longitude, target.latitude],
-      { id: target.id, personId: target.personId, personName: target.personName, label: target.label },
+      {
+        id: target.id,
+        personId: target.personId,
+        personName: target.personName,
+        label: target.label,
+        ...(target.addressText ? { addressText: target.addressText } : {}),
+      },
       translationsRef.current
     );
   }, [focusId, markers]);
@@ -354,6 +364,13 @@ function openPopup(
   label.className = 'text-xs opacity-70 capitalize';
   label.textContent = props.label;
   container.appendChild(label);
+
+  if (typeof props.addressText === 'string' && props.addressText.length > 0) {
+    const addressLine = document.createElement('div');
+    addressLine.className = 'text-xs max-w-56';
+    addressLine.textContent = props.addressText;
+    container.appendChild(addressLine);
+  }
 
   const links = document.createElement('div');
   links.className = 'flex gap-3 pt-1 text-xs';

--- a/docs/src/content/docs/features/map.md
+++ b/docs/src/content/docs/features/map.md
@@ -13,7 +13,7 @@ When you add an address to a contact, Nametag geocodes it in the background, con
 
 ## The map interface
 
-The map itself is built on MapLibre GL, giving you smooth zooming, panning, and clustering of nearby markers. Click a marker (or a cluster) to see who it belongs to, with a link to their contact page and a link to get directions.
+The map itself is built on MapLibre GL, giving you smooth zooming, panning, and clustering of nearby markers. Click a marker (or a cluster) to see who it belongs to and the full address it represents, with a link to their contact page and a link to get directions.
 
 ## Filtering
 
@@ -29,7 +29,7 @@ Every filter you set is encoded in the page URL, so a filtered view of the map i
 
 ## Deep linking to a person
 
-Add `?focus=<personId>` to the map URL to center the map on a specific person's location and open their marker's popup automatically. This is how links from other parts of the app (like a person's detail page) jump straight to their spot on the map.
+Add `?focus=<markerId>` to the map URL (where the marker id looks like `addr_<addressId>` or `loc_<locationId>`) to center the map on that marker and open its popup automatically. This is how the "Show on map" links on a person's detail page jump straight to their spot on the map.
 
 ## Auto-zoom
 

--- a/lib/map/types.ts
+++ b/lib/map/types.ts
@@ -14,6 +14,8 @@ export interface MapMarker {
   city: string | null;
   /** State/Province (address region), null for GEO locations */
   region: string | null;
+  /** Full address as a single line for the marker popup; null for GEO locations */
+  addressText: string | null;
   country: string | null;
   groupIds: string[];
 }

--- a/lib/openapi/map.ts
+++ b/lib/openapi/map.ts
@@ -28,6 +28,10 @@ export function mapPaths(): Record<string, Record<string, unknown>> {
                     label: { type: 'string' },
                     city: { type: ['string', 'null'] },
                     region: { type: ['string', 'null'], description: 'State/Province' },
+                    addressText: {
+                      type: ['string', 'null'],
+                      description: 'Full address as a single line for popups; null for GEO locations',
+                    },
                     country: { type: ['string', 'null'] },
                     groupIds: { type: 'array', items: { type: 'string' } },
                   },

--- a/tests/api/map-markers.test.ts
+++ b/tests/api/map-markers.test.ts
@@ -45,8 +45,11 @@ describe('GET /api/map/markers', () => {
           {
             id: 'addr-1',
             type: 'home',
+            streetLine1: '10 Downing Street',
+            streetLine2: null,
             locality: 'London',
             region: 'Greater London',
+            postalCode: 'SW1A 2AA',
             country: 'GB',
             latitude: '51.5',
             longitude: '-0.12',
@@ -84,6 +87,7 @@ describe('GET /api/map/markers', () => {
       city: 'London',
       region: 'Greater London',
       country: 'GB',
+      addressText: '10 Downing Street, London, Greater London, SW1A 2AA, United Kingdom',
       groupIds: ['group-1'],
     });
     expect(body.markers[1]).toMatchObject({
@@ -93,6 +97,7 @@ describe('GET /api/map/markers', () => {
       city: null,
       region: null,
       country: null,
+      addressText: null,
     });
     expect(body.groups).toEqual([{ id: 'group-1', name: 'Friends' }]);
     expect(body.unlocatedPeople).toEqual([]);
@@ -112,8 +117,11 @@ describe('GET /api/map/markers', () => {
             select: {
               id: true,
               type: true,
+              streetLine1: true,
+              streetLine2: true,
               locality: true,
               region: true,
+              postalCode: true,
               country: true,
               latitude: true,
               longitude: true,

--- a/tests/lib/filter-markers.test.ts
+++ b/tests/lib/filter-markers.test.ts
@@ -14,6 +14,7 @@ function marker(overrides: Partial<MapMarker>): MapMarker {
     city: 'London',
     region: 'Greater London',
     country: 'GB',
+    addressText: null,
     groupIds: ['g1'],
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Clicking a marker on the map now shows the full address the marker represents (street, city, state/province, postal code, and country name), between the address type label and the popup links. GEO location markers are unchanged (they have no address text).

## Implementation

- `MapMarker` gains `addressText`, built server-side in the markers endpoint so formatting matches the rest of the app (including country-code-to-name resolution); documented in the OpenAPI spec
- The popup renders it via `textContent` (same XSS-safe DOM construction as the rest of the popup); the GeoJSON property is omitted rather than null so it survives the `queryRenderedFeatures` round trip
- Docs: the map feature page mentions the address in the popup, and its `?focus=` parameter description was corrected (`addr_<addressId>` / `loc_<locationId>` marker ids, not person ids)
- Tests updated; docs site builds (48 pages)

Verified headlessly: popup shows "Marker Person / Home / Calle Gran Via 1, Madrid, Spain / View contact / Directions".