### PR TITLE
Honor name display settings in map marker names

### DIFF
--- a/app/api/map/markers/route.ts
+++ b/app/api/map/markers/route.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
-import { formatCanonicalName, type NameDisplayFormat } from '@/lib/nameUtils';
+import { formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
 import { getCountryName } from '@/lib/countries';
 import type { MapGroup, MapMarker, UnlocatedPerson } from '@/lib/map/types';
 
@@ -17,8 +17,6 @@ export const GET = withAuth(async (request, session) => {
           id: true,
           name: true,
           surname: true,
-          middleName: true,
-          secondLastName: true,
           nickname: true,
           displayNameOverride: true,
           addresses: {
@@ -70,13 +68,14 @@ export const GET = withAuth(async (request, session) => {
     const unlocatedPeople: UnlocatedPerson[] = [];
 
     for (const person of people) {
-      const personName =
-        person.displayNameOverride ??
-        formatCanonicalName(
-          person,
-          user?.nameOrder ?? undefined,
-          (user?.nameDisplayFormat as NameDisplayFormat | undefined) ?? undefined,
-        );
+      // formatGraphName honors the user's name display settings (FULL,
+      // NICKNAME_PREFERRED, SHORT) and the per-person override, matching how
+      // names render in the network graph and page titles.
+      const personName = formatGraphName(
+        person,
+        user?.nameOrder ?? undefined,
+        (user?.nameDisplayFormat as NameDisplayFormat | undefined) ?? undefined,
+      );
       const groupIds = person.groups.map((pg) => pg.group.id);
       for (const pg of person.groups) {
         groupsById.set(pg.group.id, pg.group);

--- a/tests/api/map-markers.test.ts
+++ b/tests/api/map-markers.test.ts
@@ -327,6 +327,48 @@ describe('GET /api/map/markers', () => {
     expect(body.markers[0].personName).toBe('Ace');
   });
 
+  it('honors the NICKNAME_PREFERRED name display setting', async () => {
+    mocks.userFindUnique.mockResolvedValue({
+      nameOrder: 'WESTERN',
+      nameDisplayFormat: 'NICKNAME_PREFERRED',
+      geocodingEnabled: true,
+    });
+    mocks.personFindMany.mockResolvedValue([
+      {
+        id: 'person-1',
+        name: 'Alice',
+        surname: 'Smith',
+        middleName: null,
+        secondLastName: null,
+        nickname: 'Ali',
+        displayNameOverride: null,
+        addresses: [
+          {
+            id: 'addr-1',
+            type: 'home',
+            streetLine1: null,
+            streetLine2: null,
+            locality: 'London',
+            region: null,
+            postalCode: null,
+            country: 'GB',
+            latitude: '51.5',
+            longitude: '-0.12',
+            geocodeStatus: 'success',
+          },
+        ],
+        locations: [],
+        groups: [],
+      },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/map/markers'));
+    const body = await response.json();
+
+    // Nickname replaces the first name, like in the network graph
+    expect(body.markers[0].personName).toBe('Ali Smith');
+  });
+
   it('falls back to the formatted canonical name for personName when there is no override', async () => {
     mocks.personFindMany.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary

Names in map marker popups (and the unlocated-addresses drawer) ignored the user's name display settings: they used the canonical formatter, which always renders the full form (middle names, nickname in quotes) and does not implement NICKNAME_PREFERRED. They now use `formatGraphName`, the same helper as the network graph and page titles, so all three display formats (FULL, NICKNAME_PREFERRED, SHORT), the name order setting, and per-person display overrides apply consistently.

Also trims the endpoint's column selection: middle and second-last names are no longer fetched since the graph formatter does not use them.

New test covers NICKNAME_PREFERRED ("Ali Smith" for Alice "Ali" Smith); existing override and fallback tests still pass (10/10).