### PR TITLE
Render photo thumbnails as map markers

### DIFF
--- a/app/api/map/markers/route.ts
+++ b/app/api/map/markers/route.ts
@@ -19,6 +19,7 @@ export const GET = withAuth(async (request, session) => {
           surname: true,
           nickname: true,
           displayNameOverride: true,
+          photo: true,
           addresses: {
             select: {
               id: true,
@@ -45,7 +46,7 @@ export const GET = withAuth(async (request, session) => {
           },
           groups: {
             where: { group: { deletedAt: null } },
-            select: { group: { select: { id: true, name: true } } },
+            select: { group: { select: { id: true, name: true, color: true } } },
           },
         },
       }),
@@ -80,6 +81,10 @@ export const GET = withAuth(async (request, session) => {
       for (const pg of person.groups) {
         groupsById.set(pg.group.id, pg.group);
       }
+      const hasPhoto = Boolean(person.photo);
+      // First group (in returned order) that has a color, matching how the
+      // network graph picks a node's fill/ring color.
+      const groupColor = person.groups.find((pg) => pg.group.color)?.group.color ?? null;
 
       const personFailedCount = person.addresses.filter(
         (address) => address.geocodeStatus === 'failed'
@@ -116,6 +121,8 @@ export const GET = withAuth(async (request, session) => {
           country: address.country,
           addressText: addressText || null,
           groupIds,
+          hasPhoto,
+          groupColor,
         });
       }
 
@@ -133,6 +140,8 @@ export const GET = withAuth(async (request, session) => {
           country: null,
           addressText: null,
           groupIds,
+          hasPhoto,
+          groupColor,
         });
       }
     }

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -16,6 +16,61 @@ const FOCUS_ZOOM = 15;
 // view to one city) can run for several seconds. Cap all camera animations.
 const CAMERA_ANIMATION_MS = 1000;
 
+// Photo marker icons: rendered offscreen at 2x devicePixelRatio (48px bitmap
+// for a 24px displayed icon), matching how the network graph draws person
+// nodes (filled/ringed circle, photo clipped on top).
+const ICON_BITMAP_SIZE = 48;
+const ICON_PIXEL_RATIO = 2; // 48 / 2 = 24px displayed icon
+const ICON_RING_WIDTH = 4; // bitmap-space; 2px at display scale
+const ICON_FILL_RADIUS = 22; // bitmap-space; leaves room for the ring to stay inside the canvas
+// Same fallback grays the network graph uses for ungrouped nodes.
+const RING_FALLBACK_LIGHT = '#d1d5db';
+const RING_FALLBACK_DARK = '#4b5563';
+
+type PhotoEntry = HTMLImageElement | 'loading' | 'error';
+
+function iconIdFor(personId: string): string {
+  return `person-${personId}`;
+}
+
+function ringColorFor(marker: MapMarker, isDark: boolean): string {
+  return marker.groupColor ?? (isDark ? RING_FALLBACK_DARK : RING_FALLBACK_LIGHT);
+}
+
+/** Draws a circle-clipped photo with a colored ring onto an offscreen canvas, like the network graph's person nodes. */
+function compositeIcon(image: HTMLImageElement, ringColor: string): ImageData | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = ICON_BITMAP_SIZE;
+  canvas.height = ICON_BITMAP_SIZE;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  const center = ICON_BITMAP_SIZE / 2;
+
+  ctx.beginPath();
+  ctx.arc(center, center, ICON_FILL_RADIUS, 0, Math.PI * 2);
+  ctx.fillStyle = ringColor;
+  ctx.fill();
+  ctx.lineWidth = ICON_RING_WIDTH;
+  ctx.strokeStyle = ringColor;
+  ctx.stroke();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(center, center, ICON_FILL_RADIUS, 0, Math.PI * 2);
+  ctx.clip();
+  ctx.drawImage(
+    image,
+    center - ICON_FILL_RADIUS,
+    center - ICON_FILL_RADIUS,
+    ICON_FILL_RADIUS * 2,
+    ICON_FILL_RADIUS * 2,
+  );
+  ctx.restore();
+
+  return ctx.getImageData(0, 0, ICON_BITMAP_SIZE, ICON_BITMAP_SIZE);
+}
+
 interface MapViewProps {
   markers: MapMarker[];
   focusId: string | null;
@@ -39,6 +94,10 @@ interface MarkerProperties {
   personName: string;
   label: string;
   addressText?: string;
+  /** Registered icon image id, present only once the person's photo icon has loaded */
+  iconId?: string;
+  /** First group's color, used for the plain dot when there is no photo icon yet */
+  dotColor?: string;
 }
 
 function useIsDarkTheme(): boolean {
@@ -69,7 +128,10 @@ function isWebGLAvailable(): boolean {
   }
 }
 
-function toGeoJSON(markers: MapMarker[]): GeoJSON.FeatureCollection<GeoJSON.Point, MarkerProperties> {
+function toGeoJSON(
+  markers: MapMarker[],
+  registeredIconPersonIds: ReadonlySet<string>
+): GeoJSON.FeatureCollection<GeoJSON.Point, MarkerProperties> {
   return {
     type: 'FeatureCollection',
     features: markers.map((marker) => ({
@@ -83,6 +145,10 @@ function toGeoJSON(markers: MapMarker[]): GeoJSON.FeatureCollection<GeoJSON.Poin
         // Omitted rather than null: null-valued GeoJSON properties do not
         // survive the round trip through queryRenderedFeatures reliably.
         ...(marker.addressText ? { addressText: marker.addressText } : {}),
+        ...(marker.hasPhoto && registeredIconPersonIds.has(marker.personId)
+          ? { iconId: iconIdFor(marker.personId) }
+          : {}),
+        ...(marker.groupColor ? { dotColor: marker.groupColor } : {}),
       },
     })),
   };
@@ -97,8 +163,22 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
   const focusHandledRef = useRef<string | null>(null);
   const appliedFiltersKeyRef = useRef<string | null>(null);
   const isDark = useIsDarkTheme();
+  const isDarkRef = useRef(isDark);
   const translationsRef = useRef({ viewContact: t('viewContact'), directions: t('directions') });
   const [webglUnavailable, setWebglUnavailable] = useState(false);
+
+  // Photo marker icon caches. These live for the component's lifetime (not
+  // per map instance) so a theme switch or style reload only has to
+  // re-register already-composited bitmaps, never re-fetch photos.
+  const photoElementCacheRef = useRef(new Map<string, PhotoEntry>());
+  const bitmapCacheRef = useRef(new Map<string, ImageData>());
+  // personId -> ring color currently registered as a map image, scoped to
+  // the CURRENT style: custom images do not survive setStyle, so this is
+  // cleared and rebuilt every time the style (re)loads.
+  const registeredColorRef = useRef(new Map<string, string>());
+  const ensureIconsRef = useRef<(() => void) | null>(null);
+  const disposedRef = useRef(false);
+  const pendingSourceUpdateRef = useRef(false);
 
   // Keep "latest value" refs in sync via effects rather than during render,
   // since the map init effect below registers event handlers once (empty
@@ -111,9 +191,17 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
     translationsRef.current = { viewContact: t('viewContact'), directions: t('directions') };
   }, [t]);
 
+  useEffect(() => {
+    isDarkRef.current = isDark;
+  }, [isDark]);
+
   // Initialize the map once
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
+    // Reset for this mount: StrictMode's dev double-invoke reuses the same
+    // refs across an unmount/remount cycle, and the previous cleanup below
+    // marks this true.
+    disposedRef.current = false;
 
     if (!isWebGLAvailable()) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- reflecting a one-time platform capability check into UI state is intentional
@@ -143,13 +231,100 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
 
     map.addControl(new maplibregl.NavigationControl({ showCompass: false }), 'top-right');
 
+    // Coalesces synchronous or rapid-fire icon updates (a batch of photo
+    // loads finishing around the same time) into a single setData call.
+    const scheduleSourceUpdate = () => {
+      if (pendingSourceUpdateRef.current) return;
+      pendingSourceUpdateRef.current = true;
+      queueMicrotask(() => {
+        pendingSourceUpdateRef.current = false;
+        if (disposedRef.current) return;
+        const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
+        if (!source) return;
+        source.setData(toGeoJSON(markersRef.current, new Set(registeredColorRef.current.keys())));
+      });
+    };
+
+    const registerBitmap = (personId: string, bitmap: ImageData, color: string) => {
+      const iconId = iconIdFor(personId);
+      if (map.hasImage(iconId)) {
+        map.updateImage(iconId, bitmap);
+      } else {
+        map.addImage(iconId, bitmap, { pixelRatio: ICON_PIXEL_RATIO });
+      }
+      registeredColorRef.current.set(personId, color);
+    };
+
+    // Loads and composites each photo marker's icon (from cache when
+    // possible) and registers it as a map image. Re-entrant and safe to call
+    // repeatedly: markers already registered with the current ring color are
+    // skipped, so this never loops. Called on marker changes, when a photo
+    // finishes loading, and on every style reload (setStyle drops custom
+    // images, so re-registering from the bitmap cache is required, but never
+    // re-fetches the photo itself).
+    const ensureIcons = () => {
+      let didRegisterAny = false;
+      for (const marker of markersRef.current) {
+        if (!marker.hasPhoto) continue;
+        const personId = marker.personId;
+        const color = ringColorFor(marker, isDarkRef.current);
+        if (registeredColorRef.current.get(personId) === color && map.hasImage(iconIdFor(personId))) {
+          continue;
+        }
+
+        const bitmapKey = `${personId}:${color}`;
+        const cachedBitmap = bitmapCacheRef.current.get(bitmapKey);
+        if (cachedBitmap) {
+          registerBitmap(personId, cachedBitmap, color);
+          didRegisterAny = true;
+          continue;
+        }
+
+        const photoEntry = photoElementCacheRef.current.get(personId);
+        if (photoEntry === 'error') continue; // permanently falls back to the dot for this session
+        if (photoEntry === 'loading') continue; // already in flight; onload will re-run ensureIcons
+        if (photoEntry instanceof HTMLImageElement) {
+          const bitmap = compositeIcon(photoEntry, color);
+          if (bitmap) {
+            bitmapCacheRef.current.set(bitmapKey, bitmap);
+            registerBitmap(personId, bitmap, color);
+            didRegisterAny = true;
+          }
+          continue;
+        }
+
+        // Not cached yet: kick off a same-origin photo fetch (canvas
+        // compositing stays untainted).
+        photoElementCacheRef.current.set(personId, 'loading');
+        const img = new Image();
+        img.onload = () => {
+          if (disposedRef.current) return;
+          photoElementCacheRef.current.set(personId, img);
+          ensureIcons();
+        };
+        img.onerror = () => {
+          if (disposedRef.current) return;
+          photoElementCacheRef.current.set(personId, 'error');
+        };
+        img.src = `/api/photos/${personId}`;
+      }
+      if (didRegisterAny) scheduleSourceUpdate();
+    };
+    ensureIconsRef.current = ensureIcons;
+
     const addDataLayers = () => {
       if (map.getSource(SOURCE_ID)) return;
+      // Custom images do not survive setStyle; every registration here is
+      // for the fresh style, even if the underlying bitmap was cached.
+      registeredColorRef.current.clear();
       const primary =
         getComputedStyle(document.documentElement).getPropertyValue('--primary').trim() || '#2563EB';
+
+      ensureIcons();
+
       map.addSource(SOURCE_ID, {
         type: 'geojson',
-        data: toGeoJSON(markersRef.current),
+        data: toGeoJSON(markersRef.current, new Set(registeredColorRef.current.keys())),
         cluster: true,
         clusterMaxZoom: 14,
         clusterRadius: 50,
@@ -179,16 +354,32 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
         paint: { 'text-color': '#ffffff' },
       });
 
+      // Plain colored dot: markers without a photo, or whose photo icon
+      // has not registered yet (upgrades to the photo layer once ready).
       map.addLayer({
         id: 'unclustered-point',
         type: 'circle',
         source: SOURCE_ID,
-        filter: ['!', ['has', 'point_count']],
+        filter: ['all', ['!', ['has', 'point_count']], ['!', ['has', 'iconId']]],
         paint: {
-          'circle-color': primary,
+          'circle-color': ['coalesce', ['get', 'dotColor'], primary],
           'circle-radius': 7,
           'circle-stroke-width': 2,
           'circle-stroke-color': '#ffffff',
+        },
+      });
+
+      // Circular photo thumbnail, ringed with the person's first group
+      // color, matching the network graph's person nodes.
+      map.addLayer({
+        id: 'unclustered-photo',
+        type: 'symbol',
+        source: SOURCE_ID,
+        filter: ['all', ['!', ['has', 'point_count']], ['has', 'iconId']],
+        layout: {
+          'icon-image': ['get', 'iconId'],
+          'icon-size': 1,
+          'icon-allow-overlap': true,
         },
       });
     };
@@ -218,15 +409,18 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
         });
     });
 
-    map.on('click', 'unclustered-point', (event) => {
+    const handleUnclusteredClick = (event: maplibregl.MapLayerMouseEvent) => {
       const feature = event.features?.[0];
       if (!feature) return;
       const props = feature.properties as unknown as MarkerProperties;
       const geometry = feature.geometry as GeoJSON.Point;
       openPopup(map, geometry.coordinates as [number, number], props, translationsRef.current);
-    });
+    };
 
-    for (const layer of ['clusters', 'unclustered-point']) {
+    map.on('click', 'unclustered-point', handleUnclusteredClick);
+    map.on('click', 'unclustered-photo', handleUnclusteredClick);
+
+    for (const layer of ['clusters', 'unclustered-point', 'unclustered-photo']) {
       map.on('mouseenter', layer, () => {
         map.getCanvas().style.cursor = 'pointer';
       });
@@ -235,7 +429,18 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
       });
     }
 
+    // Captured once for the cleanup below: it is always the same Map
+    // instance for the component's lifetime (only ever mutated, never
+    // reassigned), so reading it via this local satisfies the lint rule
+    // without changing behavior.
+    const registeredColors = registeredColorRef.current;
+
     return () => {
+      disposedRef.current = true;
+      ensureIconsRef.current = null;
+      // Registered images belonged to this map instance; a remount starts
+      // from an empty style with no custom images.
+      registeredColors.clear();
       map.remove();
       mapRef.current = null;
       // The popup and camera state died with the map; let the focus and
@@ -256,13 +461,16 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
     map.setStyle(nextStyle);
   }, [isDark]);
 
-  // Push marker updates into the source
+  // Push marker updates into the source, and load/register any newly
+  // visible photo icons (upgrading their markers from dot to photo once
+  // ready; see ensureIcons in the map init effect).
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
+    ensureIconsRef.current?.();
     const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
     if (source) {
-      source.setData(toGeoJSON(markers));
+      source.setData(toGeoJSON(markers, new Set(registeredColorRef.current.keys())));
     }
   }, [markers]);
 

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -21,7 +21,9 @@ const CAMERA_ANIMATION_MS = 1000;
 // nodes (filled/ringed circle, photo clipped on top).
 const ICON_BITMAP_SIZE = 48;
 const ICON_PIXEL_RATIO = 2; // 48 / 2 = 24px displayed icon
-const ICON_RING_WIDTH = 4; // bitmap-space; 2px at display scale
+// Bitmap-space stroke width. The photo clip covers the inner half of the
+// stroke, so the visible ring is 2 bitmap pixels = 1px at display scale.
+const ICON_RING_WIDTH = 4;
 const ICON_FILL_RADIUS = 22; // bitmap-space; leaves room for the ring to stay inside the canvas
 // Same fallback grays the network graph uses for ungrouped nodes.
 const RING_FALLBACK_LIGHT = '#d1d5db';

--- a/components/map/MapView.tsx
+++ b/components/map/MapView.tsx
@@ -177,7 +177,6 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
   // cleared and rebuilt every time the style (re)loads.
   const registeredColorRef = useRef(new Map<string, string>());
   const ensureIconsRef = useRef<(() => void) | null>(null);
-  const disposedRef = useRef(false);
   const pendingSourceUpdateRef = useRef(false);
 
   // Keep "latest value" refs in sync via effects rather than during render,
@@ -198,10 +197,12 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
   // Initialize the map once
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
-    // Reset for this mount: StrictMode's dev double-invoke reuses the same
-    // refs across an unmount/remount cycle, and the previous cleanup below
-    // marks this true.
-    disposedRef.current = false;
+    // Per-map-instance disposed flag. Deliberately a closure variable and
+    // NOT a shared ref: async photo loads started by one map instance can
+    // complete after a StrictMode unmount/remount cycle, and a shared ref
+    // reset by the new mount would let the stale closure operate on the
+    // removed map (whose style is gone, crashing hasImage/addImage).
+    let mapDisposed = false;
 
     if (!isWebGLAvailable()) {
       // eslint-disable-next-line react-hooks/set-state-in-effect -- reflecting a one-time platform capability check into UI state is intentional
@@ -238,7 +239,7 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
       pendingSourceUpdateRef.current = true;
       queueMicrotask(() => {
         pendingSourceUpdateRef.current = false;
-        if (disposedRef.current) return;
+        if (mapDisposed) return;
         const source = map.getSource(SOURCE_ID) as maplibregl.GeoJSONSource | undefined;
         if (!source) return;
         source.setData(toGeoJSON(markersRef.current, new Set(registeredColorRef.current.keys())));
@@ -263,6 +264,7 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
     // images, so re-registering from the bitmap cache is required, but never
     // re-fetches the photo itself).
     const ensureIcons = () => {
+      if (mapDisposed) return;
       let didRegisterAny = false;
       for (const marker of markersRef.current) {
         if (!marker.hasPhoto) continue;
@@ -297,13 +299,15 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
         // compositing stays untainted).
         photoElementCacheRef.current.set(personId, 'loading');
         const img = new Image();
+        // The caches are shared across map instances on purpose (photos and
+        // bitmaps stay valid), but re-entry goes through ensureIconsRef so
+        // it always runs against the LIVE map instance, which self-guards
+        // with its own mapDisposed flag.
         img.onload = () => {
-          if (disposedRef.current) return;
           photoElementCacheRef.current.set(personId, img);
-          ensureIcons();
+          ensureIconsRef.current?.();
         };
         img.onerror = () => {
-          if (disposedRef.current) return;
           photoElementCacheRef.current.set(personId, 'error');
         };
         img.src = `/api/photos/${personId}`;
@@ -436,7 +440,7 @@ export default function MapView({ markers, focusId, filtersKey }: MapViewProps) 
     const registeredColors = registeredColorRef.current;
 
     return () => {
-      disposedRef.current = true;
+      mapDisposed = true;
       ensureIconsRef.current = null;
       // Registered images belonged to this map instance; a remount starts
       // from an empty style with no custom images.

--- a/docs/src/content/docs/features/map.md
+++ b/docs/src/content/docs/features/map.md
@@ -13,7 +13,7 @@ When you add an address to a contact, Nametag geocodes it in the background, con
 
 ## The map interface
 
-The map itself is built on MapLibre GL, giving you smooth zooming, panning, and clustering of nearby markers. Click a marker (or a cluster) to see who it belongs to and the full address it represents, with a link to their contact page and a link to get directions.
+The map itself is built on MapLibre GL, giving you smooth zooming, panning, and clustering of nearby markers. Contacts with a photo appear as a small circular photo thumbnail, ringed in the color of the first group they belong to; contacts without a photo show as a plain colored dot in that same group color, falling back to the default marker color when they aren't in a colored group. Click a marker (or a cluster) to see who it belongs to and the full address it represents, with a link to their contact page and a link to get directions.
 
 ## Filtering
 

--- a/lib/map/types.ts
+++ b/lib/map/types.ts
@@ -18,11 +18,16 @@ export interface MapMarker {
   addressText: string | null;
   country: string | null;
   groupIds: string[];
+  /** Whether the contact has a photo, used to render a photo thumbnail marker instead of a dot */
+  hasPhoto: boolean;
+  /** First group's color (in returned order), like the network graph; null falls back to the default dot color */
+  groupColor: string | null;
 }
 
 export interface MapGroup {
   id: string;
   name: string;
+  color: string | null;
 }
 
 /** A contact with at least one address the geocoder could not locate */

--- a/lib/openapi/map.ts
+++ b/lib/openapi/map.ts
@@ -34,6 +34,11 @@ export function mapPaths(): Record<string, Record<string, unknown>> {
                     },
                     country: { type: ['string', 'null'] },
                     groupIds: { type: 'array', items: { type: 'string' } },
+                    hasPhoto: { type: 'boolean', description: 'Whether the contact has a photo' },
+                    groupColor: {
+                      type: ['string', 'null'],
+                      description: "First group's color (in returned order), like the network graph",
+                    },
                   },
                 },
               },
@@ -41,7 +46,11 @@ export function mapPaths(): Record<string, Record<string, unknown>> {
                 type: 'array',
                 items: {
                   type: 'object',
-                  properties: { id: { type: 'string' }, name: { type: 'string' } },
+                  properties: {
+                    id: { type: 'string' },
+                    name: { type: 'string' },
+                    color: { type: ['string', 'null'] },
+                  },
                 },
               },
               pendingCount: { type: 'integer' },

--- a/tests/api/map-markers.test.ts
+++ b/tests/api/map-markers.test.ts
@@ -41,6 +41,7 @@ describe('GET /api/map/markers', () => {
         secondLastName: null,
         nickname: null,
         displayNameOverride: null,
+        photo: 'photo.jpg',
         addresses: [
           {
             id: 'addr-1',
@@ -68,7 +69,7 @@ describe('GET /api/map/markers', () => {
         locations: [
           { id: 'loc-1', type: 'other', label: 'Cabin', latitude: '60.1', longitude: '10.2' },
         ],
-        groups: [{ group: { id: 'group-1', name: 'Friends' } }],
+        groups: [{ group: { id: 'group-1', name: 'Friends', color: '#ff2600' } }],
       },
     ]);
 
@@ -89,6 +90,8 @@ describe('GET /api/map/markers', () => {
       country: 'GB',
       addressText: '10 Downing Street, London, Greater London, SW1A 2AA, United Kingdom',
       groupIds: ['group-1'],
+      hasPhoto: true,
+      groupColor: '#ff2600',
     });
     expect(body.markers[1]).toMatchObject({
       id: 'loc_loc-1',
@@ -98,10 +101,75 @@ describe('GET /api/map/markers', () => {
       region: null,
       country: null,
       addressText: null,
+      hasPhoto: true,
+      groupColor: '#ff2600',
     });
-    expect(body.groups).toEqual([{ id: 'group-1', name: 'Friends' }]);
+    expect(body.groups).toEqual([{ id: 'group-1', name: 'Friends', color: '#ff2600' }]);
     expect(body.unlocatedPeople).toEqual([]);
     expect(body.geocodingEnabled).toBe(true);
+  });
+
+  it('defaults hasPhoto to false and groupColor to null when the person has no photo or colored group', async () => {
+    mocks.personFindMany.mockResolvedValue([
+      {
+        id: 'person-1',
+        name: 'Alice',
+        surname: 'Smith',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        displayNameOverride: null,
+        photo: null,
+        addresses: [
+          {
+            id: 'addr-1',
+            type: 'home',
+            locality: 'London',
+            region: null,
+            country: 'GB',
+            latitude: '51.5',
+            longitude: '-0.12',
+            geocodeStatus: 'success',
+          },
+        ],
+        locations: [],
+        groups: [{ group: { id: 'group-1', name: 'Friends', color: null } }],
+      },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/map/markers'));
+    const body = await response.json();
+
+    expect(body.markers[0].hasPhoto).toBe(false);
+    expect(body.markers[0].groupColor).toBeNull();
+  });
+
+  it('uses the first group with a color when the person belongs to multiple groups', async () => {
+    mocks.personFindMany.mockResolvedValue([
+      {
+        id: 'person-1',
+        name: 'Alice',
+        surname: 'Smith',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        displayNameOverride: null,
+        photo: null,
+        addresses: [],
+        locations: [
+          { id: 'loc-1', type: 'other', label: 'Cabin', latitude: '60.1', longitude: '10.2' },
+        ],
+        groups: [
+          { group: { id: 'group-nocolor', name: 'NoColor', color: null } },
+          { group: { id: 'group-color', name: 'Colored', color: '#00ff00' } },
+        ],
+      },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/map/markers'));
+    const body = await response.json();
+
+    expect(body.markers[0].groupColor).toBe('#00ff00');
   });
 
   it('scopes the query to the session user and excludes soft-deleted people', async () => {
@@ -113,6 +181,7 @@ describe('GET /api/map/markers', () => {
       expect.objectContaining({
         where: { userId: 'user-123', deletedAt: null },
         select: expect.objectContaining({
+          photo: true,
           addresses: {
             select: {
               id: true,
@@ -139,6 +208,7 @@ describe('GET /api/map/markers', () => {
           },
           groups: expect.objectContaining({
             where: { group: { deletedAt: null } },
+            select: { group: { select: { id: true, name: true, color: true } } },
           }),
         }),
       })

--- a/tests/lib/filter-markers.test.ts
+++ b/tests/lib/filter-markers.test.ts
@@ -16,6 +16,8 @@ function marker(overrides: Partial<MapMarker>): MapMarker {
     country: 'GB',
     addressText: null,
     groupIds: ['g1'],
+    hasPhoto: false,
+    groupColor: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

Contacts with photos now appear on the map as tiny circular photo thumbnails ringed with their group's color, matching how they look in the network graph. Contacts without photos get a dot in their group color (theme-aware gray fallback for ungrouped contacts) instead of the fixed blue.

## Implementation

- The markers endpoint exposes `hasPhoto` (a boolean, never the photo payload) and `groupColor` (first colored group, like the graph), and groups now carry their `color`; documented in the OpenAPI spec
- Icons are composited client-side onto an offscreen canvas (circle-clipped photo + group-color ring, 2x bitmap for retina) from the same-origin `/api/photos/<id>` route, registered with `map.addImage`, and cached so theme switches re-register without re-fetching
- Two unclustered layers (circle for dots, symbol for photo icons) share the same popup and hover handlers; clustering is untouched; markers render as dots first and upgrade in place when their thumbnail is ready
- Includes a fix for a StrictMode race found during live verification: photo loads finishing after a map teardown could crash MapLibre; the disposed guard is now per map instance and async callbacks re-enter through a ref that always targets the live map

## Verification

- Independently reviewed (lifecycle paths traced callback-by-callback; ready-for-PR verdict, two minor notes of which the comment one is fixed here)
- Verified live in a real browser: photo + ring in dark and light themes, live theme switch keeps icons with zero page errors, group-colored dot fallback, clusters and popups unchanged
- Full test suite passes; typecheck, lint, docs build clean

Heads-up for reviewers: markers briefly render as dots before upgrading to photos on first load while thumbnails composite; that's by design.