### PR TITLE
Retry geocoding without the second address line

### DIFF
--- a/docs/src/content/docs/features/map.md
+++ b/docs/src/content/docs/features/map.md
@@ -11,6 +11,8 @@ The Map tab shows where your contacts are, plotted on an interactive world map f
 
 When you add an address to a contact, Nametag geocodes it in the background, converting the street address into latitude and longitude using a Nominatim-compatible geocoding service. Once geocoding succeeds, the address appears as a marker on the Map tab. You don't need to do anything beyond entering the address.
 
+The second address line gets special treatment: lookups try the full address first, then retry without the second line. So apartment numbers, building names, or any extra text there can help locate the address but never prevent it from being found.
+
 ## The map interface
 
 The map itself is built on MapLibre GL, giving you smooth zooming, panning, and clustering of nearby markers. Click a marker (or a cluster) to see who it belongs to and the full address it represents, with a link to their contact page and a link to get directions.

--- a/lib/geocoding/provider.ts
+++ b/lib/geocoding/provider.ts
@@ -70,35 +70,78 @@ async function search(params: URLSearchParams): Promise<GeocodeResult | null> {
  * better with unusual formats. Returns null when the provider finds nothing.
  */
 export async function geocodeAddress(address: AddressFields): Promise<GeocodeResult | null> {
-  const street = [address.streetLine1, address.streetLine2].filter(Boolean).join(', ');
+  const line2 = address.streetLine2?.trim() || null;
+  let firstTransientError: GeocodingProviderError | null = null;
 
+  // Runs one lookup in the cascade. A 429 aborts the whole cascade (the
+  // provider wants LESS traffic); other transient errors are remembered and
+  // the cascade continues, so one flaky attempt cannot mask a fallback that
+  // would have succeeded.
+  const attempt = async (params: URLSearchParams): Promise<GeocodeResult | null> => {
+    try {
+      return await search(params);
+    } catch (error) {
+      if (!(error instanceof GeocodingProviderError)) throw error;
+      if (error.status === 429) throw error;
+      firstTransientError ??= error;
+      return null;
+    }
+  };
+
+  // 1. Structured query, first street line only. Nominatim's street
+  // parameter expects "housenumber streetname"; unit numbers, building
+  // names, or free-form annotations in the second line only break the
+  // match, so the second line never participates here.
   const structured = new URLSearchParams();
-  if (street) structured.set('street', street);
+  if (address.streetLine1) structured.set('street', address.streetLine1);
   if (address.locality) structured.set('city', address.locality);
   if (address.region) structured.set('state', address.region);
   if (address.postalCode) structured.set('postalcode', address.postalCode);
   if (address.country) structured.set('country', address.country);
 
-  const freeText = [street, address.locality, address.region, address.postalCode, address.country]
+  if ([...structured.keys()].length > 0) {
+    const result = await attempt(structured);
+    if (result) return result;
+  }
+
+  // 2. Free text including the second line: the only query where legitimate
+  // second-line content (building names, neighborhoods, colonias) can
+  // contribute or disambiguate.
+  const withoutLine2 = [
+    address.streetLine1,
+    address.locality,
+    address.region,
+    address.postalCode,
+    address.country,
+  ]
+    .filter(Boolean)
+    .join(', ');
+  const withLine2 = [
+    address.streetLine1,
+    line2,
+    address.locality,
+    address.region,
+    address.postalCode,
+    address.country,
+  ]
     .filter(Boolean)
     .join(', ');
 
-  if ([...structured.keys()].length > 0) {
-    try {
-      const result = await search(structured);
-      if (result) return result;
-    } catch (error) {
-      if (!(error instanceof GeocodingProviderError)) throw error;
-      // The provider is telling us to slow down: more requests (the fallback)
-      // would make it worse, so surface the 429 to the caller immediately.
-      if (error.status === 429) throw error;
-      // Structured query failed transiently: fall through to the free-text
-      // attempt below rather than aborting, unless there is nothing to try.
-      if (!freeText) throw error;
-    }
+  if (withLine2) {
+    const result = await attempt(new URLSearchParams({ q: withLine2 }));
+    if (result) return result;
   }
 
-  if (!freeText) return null;
+  // 3. Free text without the second line: rescues addresses whose second
+  // line is noise the provider chokes on (annotations, unit numbers).
+  if (line2 && withoutLine2) {
+    const result = await attempt(new URLSearchParams({ q: withoutLine2 }));
+    if (result) return result;
+  }
 
-  return search(new URLSearchParams({ q: freeText }));
+  // Exhausted without a hit. If any attempt failed transiently, surface the
+  // error so the caller keeps the address pending instead of caching a
+  // permanent failure the provider never actually asserted.
+  if (firstTransientError) throw firstTransientError;
+  return null;
 }

--- a/prisma/migrations/20260721104759_requeue_failed_geocodes/migration.sql
+++ b/prisma/migrations/20260721104759_requeue_failed_geocodes/migration.sql
@@ -1,0 +1,5 @@
+-- Data-only migration: the geocoding cascade now retries without the second
+-- address line, so previously failed lookups may succeed. Drop the cached
+-- negative results and re-queue failed addresses for the background cron.
+DELETE FROM "geocode_cache" WHERE "status" = 'failed';
+UPDATE "person_addresses" SET "geocodeStatus" = 'pending' WHERE "geocodeStatus" = 'failed';

--- a/tests/lib/geocoding-provider.test.ts
+++ b/tests/lib/geocoding-provider.test.ts
@@ -21,6 +21,11 @@ const address = {
   country: 'US',
 };
 
+/** URLSearchParams encodes spaces as '+', which decodeURIComponent leaves alone. */
+function decodedUrl(url: string): string {
+  return decodeURIComponent(url.replace(/\+/g, ' '));
+}
+
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -119,5 +124,66 @@ describe('geocodeAddress', () => {
 
     await expect(geocodeAddress(address)).rejects.toBeInstanceOf(GeocodingProviderError);
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never sends the second address line in the structured query', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ lat: '39.78', lon: '-89.65' }]));
+
+    const result = await geocodeAddress({ ...address, streetLine2: 'works at Random Company' });
+
+    expect(result).toEqual({ latitude: 39.78, longitude: -89.65 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toContain('street=123+Main+St');
+    expect(url).not.toContain('Random');
+  });
+
+  it('lets a meaningful second line contribute via free text before dropping it', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([{ lat: '19.43', lon: '-99.13' }]));
+
+    const result = await geocodeAddress({ ...address, streetLine2: 'Colonia Centro' });
+
+    expect(result).toEqual({ latitude: 19.43, longitude: -99.13 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [secondUrl] = fetchMock.mock.calls[1] as [string];
+    expect(decodedUrl(secondUrl)).toContain('Colonia Centro');
+  });
+
+  it('retries the free-text query without a noisy second line as a last resort', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([{ lat: '39.78', lon: '-89.65' }]));
+
+    const result = await geocodeAddress({ ...address, streetLine2: 'works at Random Company' });
+
+    expect(result).toEqual({ latitude: 39.78, longitude: -89.65 });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const [secondUrl] = fetchMock.mock.calls[1] as [string];
+    const [thirdUrl] = fetchMock.mock.calls[2] as [string];
+    expect(decodedUrl(secondUrl)).toContain('Random Company');
+    expect(decodedUrl(thirdUrl)).not.toContain('Random Company');
+    expect(decodedUrl(thirdUrl)).toContain('123 Main St');
+  });
+
+  it('skips the third attempt when there is no second line', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([])).mockResolvedValueOnce(jsonResponse([]));
+
+    expect(await geocodeAddress(address)).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces a transient error instead of a permanent failure when later attempts find nothing', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 503))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]));
+
+    await expect(
+      geocodeAddress({ ...address, streetLine2: 'Suite 12' })
+    ).rejects.toBeInstanceOf(GeocodingProviderError);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Summary

Addresses with annotations or unit numbers in the second street line frequently failed to geocode (or worse, risked mislocating via POI matches). The lookup is now a three-stage cascade:

1. **Structured query, first street line only.** Nominatim's `street` parameter expects "housenumber streetname"; anything else there breaks the match, so the second line never participates. This alone should locate most previously-failing addresses.
2. **Free text including the second line.** The only query where legitimate second-line content (building names, neighborhoods, colonias) can contribute or disambiguate.
3. **Free text without the second line.** The last resort that rescues addresses whose second line is noise ("works at Random Company").

Successful addresses cost the same as today; only failures walk further down the cascade (rate-limited as before, and a 429 still aborts everything immediately). One behavioral improvement along the way: a transient provider error in any stage now leaves the address `pending` for retry instead of being cached as a permanent failure when the remaining stages find nothing.

## Rollout

A data-only migration deletes cached negative results and flips `failed` addresses back to `pending`, so the backfill cron automatically re-attempts every previously unlocated address with the new cascade after deploying. No schema changes.

## Verification

- 14 provider tests including the new cascade cases (line 2 never in structured queries, meaningful line 2 contributing via free text, noisy line 2 rescued by the third stage, third stage skipped without a line 2, transient-error-over-permanent-failure semantics)
- Full suite passes (2349 tests); typecheck, lint, docs build clean
- Live verification: "Calle de Alcala 21" with "works at Random Company SL" in the second line, previously a guaranteed failure, geocodes to the correct location on the first attempt