### PR TITLE
fix: show feedback for skipped imports and allow updating existing contacts

### DIFF
--- a/app/api/carddav/import/route.ts
+++ b/app/api/carddav/import/route.ts
@@ -4,7 +4,7 @@ import { prisma, withDeleted } from '@/lib/prisma';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { parseVCard } from '@/lib/carddav/vcard-parser';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
-import { createPersonFromVCardData, restorePersonFromVCardData } from '@/lib/carddav/vcard-import';
+import { createPersonFromVCardData, restorePersonFromVCardData, updatePersonFromVCard } from '@/lib/carddav/vcard-import';
 import { createModuleLogger } from '@/lib/logger';
 import { withLogging } from '@/lib/api-utils';
 import { isSaasMode } from '@/lib/features';
@@ -20,6 +20,7 @@ const importSchema = z.object({
   perContactGroups: z.record(z.string(), z.array(z.string())).optional(),
   globalRelationshipTypeId: z.string().nullable().optional(),
   perContactRelationshipTypeId: z.record(z.string(), z.string()).optional(),
+  updateExistingIds: z.array(z.string()).optional(),
 });
 
 export const POST = withLogging(async function POST(request: Request) {
@@ -40,12 +41,13 @@ export const POST = withLogging(async function POST(request: Request) {
       );
     }
 
-    const { importIds, groupIds, globalGroupIds, perContactGroups, globalRelationshipTypeId, perContactRelationshipTypeId } = validationResult.data;
+    const { importIds, groupIds, globalGroupIds, perContactGroups, globalRelationshipTypeId, perContactRelationshipTypeId, updateExistingIds } = validationResult.data;
 
     // Support both old and new API formats
     const globalGroups = globalGroupIds || groupIds || [];
     const contactGroups = perContactGroups || {};
     const contactRelationships = perContactRelationshipTypeId || {};
+    const updateExistingSet = new Set(updateExistingIds || []);
 
     // Get the user's CardDAV connection (may not exist for file-only imports)
     const connection = await prisma.cardDavConnection.findUnique({
@@ -75,6 +77,7 @@ export const POST = withLogging(async function POST(request: Request) {
 
     const results = {
       imported: 0,
+      updated: 0,
       skipped: 0,
       errors: 0,
       errorMessages: [] as string[],
@@ -236,13 +239,23 @@ export const POST = withLogging(async function POST(request: Request) {
         parsedData.organization = parsedData.organization ? sanitizeName(parsedData.organization) ?? parsedData.organization : parsedData.organization;
         parsedData.jobTitle = parsedData.jobTitle ? sanitizeName(parsedData.jobTitle) ?? parsedData.jobTitle : parsedData.jobTitle;
 
+        const shouldUpdate = updateExistingSet.has(pendingImport.id);
+
         // Check for duplicates by UID (O(1) map lookup instead of per-contact query)
         if (parsedData.uid) {
           const existingMapping = existingMappingsByUid.get(parsedData.uid);
 
           if (existingMapping) {
-            results.skipped++;
-            continue; // Skip duplicate
+            if (shouldUpdate) {
+              await updatePersonFromVCard(existingMapping.personId, parsedData, session.user.id);
+              await prisma.cardDavPendingImport.delete({
+                where: { id: pendingImport.id },
+              });
+              results.updated++;
+            } else {
+              results.skipped++;
+            }
+            continue;
           }
         }
 
@@ -253,8 +266,14 @@ export const POST = withLogging(async function POST(request: Request) {
           const existingPerson = existingPersonsByUid.get(parsedData.uid);
 
           if (existingPerson) {
-            // Person already exists — create a CardDAV mapping (if applicable) and clean up
+            // Person already exists
             const isFileImport = pendingImport.uploadedByUserId !== null;
+
+            if (shouldUpdate) {
+              await updatePersonFromVCard(existingPerson.id, parsedData, session.user.id);
+            }
+
+            // Create a CardDAV mapping if applicable
             if (!isFileImport && connection && !mappingsByPersonId.has(existingPerson.id)) {
               const enhancedParsed = parseVCard(pendingImport.vCardData);
               await prisma.cardDavMapping.create({
@@ -278,7 +297,11 @@ export const POST = withLogging(async function POST(request: Request) {
               where: { id: pendingImport.id },
             });
 
-            results.skipped++;
+            if (shouldUpdate) {
+              results.updated++;
+            } else {
+              results.skipped++;
+            }
             continue;
           }
         }
@@ -399,6 +422,7 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({
       success: true,
       imported: results.imported,
+      updated: results.updated,
       skipped: results.skipped,
       errors: results.errors,
       errorMessages: results.errorMessages,

--- a/app/carddav/import/page.tsx
+++ b/app/carddav/import/page.tsx
@@ -83,6 +83,21 @@ export default async function ImportPage({
     redirect('/settings/account');
   }
 
+  // Detect which pending imports already exist as active persons (by UID).
+  // This lets the UI show an "Already in Nametag" badge and offer an update option.
+  const pendingUids = pendingImports.map((p) => p.uid).filter(Boolean);
+  const existingPersonsByUid = pendingUids.length > 0
+    ? await prisma.person.findMany({
+        where: {
+          uid: { in: pendingUids },
+          userId: session.user.id,
+          deletedAt: null,
+        },
+        select: { uid: true },
+      })
+    : [];
+  const existingUids = existingPersonsByUid.map((p) => p.uid!).filter(Boolean);
+
   // Get user's groups and relationship types for assignment
   const [groups, relationshipTypes] = await Promise.all([
     prisma.group.findMany({
@@ -125,7 +140,12 @@ export default async function ImportPage({
           ) : (
             <>
               <p className="text-muted mb-6">
-                {t('description', { count: pendingImports.length })}
+                {existingUids.length > 0
+                  ? t('descriptionWithDuplicates', {
+                      count: pendingImports.length,
+                      duplicates: existingUids.length,
+                    })
+                  : t('description', { count: pendingImports.length })}
               </p>
 
               <ImportContactsList
@@ -133,6 +153,7 @@ export default async function ImportPage({
                 groups={groups}
                 relationshipTypes={relationshipTypes}
                 isFileImport={isFileImport}
+                existingUids={existingUids}
               />
             </>
           )}

--- a/components/CompactContactRow.tsx
+++ b/components/CompactContactRow.tsx
@@ -50,6 +50,9 @@ interface CompactContactRowProps {
   relationshipTypes: RelationshipType[];
   selectedRelationshipTypeId: string;
   onRelationshipChange: (contactId: string, relationshipTypeId: string) => void;
+  isExisting?: boolean;
+  willUpdate?: boolean;
+  onToggleUpdate?: (id: string) => void;
 }
 
 export default function CompactContactRow({
@@ -64,6 +67,9 @@ export default function CompactContactRow({
   relationshipTypes,
   selectedRelationshipTypeId,
   onRelationshipChange,
+  isExisting = false,
+  willUpdate = false,
+  onToggleUpdate,
 }: CompactContactRowProps) {
   const t = useTranslations('settings.carddav.import');
   const [isExpanded, setIsExpanded] = useState(false);
@@ -128,12 +134,17 @@ export default function CompactContactRow({
           </svg>
         </button>
 
-        {/* Full name */}
+        {/* Full name + existing badge */}
         <div
-          className="flex-1 font-semibold text-foreground cursor-pointer"
+          className="flex-1 flex items-center gap-2 cursor-pointer"
           onClick={() => onToggle(pendingImport.id)}
         >
-          {fullName}
+          <span className="font-semibold text-foreground">{fullName}</span>
+          {isExisting && (
+            <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300 flex-shrink-0">
+              {t('alreadyExists')}
+            </span>
+          )}
         </div>
 
         {/* Group pills (read-only display) */}
@@ -177,6 +188,19 @@ export default function CompactContactRow({
       {/* Expanded details */}
       {isExpanded && (
         <div className="px-3 pb-3 pt-0 border-t border-border mt-2">
+          {isExisting && onToggleUpdate && (
+            <label className="flex items-center gap-2 mt-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={willUpdate}
+                onChange={() => onToggleUpdate(pendingImport.id)}
+                className="w-4 h-4 rounded border-border text-primary focus:ring-primary"
+              />
+              <span className="text-sm font-medium text-foreground">
+                {t('updateExisting')}
+              </span>
+            </label>
+          )}
           {parsedData && (
             <div className="mt-2 space-y-1 text-sm text-muted">
               {parsedData.organization && (

--- a/components/ImportContactsList.tsx
+++ b/components/ImportContactsList.tsx
@@ -34,6 +34,7 @@ interface ImportContactsListProps {
   groups: Group[];
   relationshipTypes: RelationshipType[];
   isFileImport?: boolean;
+  existingUids?: string[];
 }
 
 export default function ImportContactsList({
@@ -41,6 +42,7 @@ export default function ImportContactsList({
   groups,
   relationshipTypes,
   isFileImport = false,
+  existingUids = [],
 }: ImportContactsListProps) {
   const t = useTranslations('settings.carddav.import');
   const router = useRouter();
@@ -53,6 +55,9 @@ export default function ImportContactsList({
   const [perContactRelationshipTypeId, setPerContactRelationshipTypeId] = useState<Map<string, string>>(new Map());
   const [importing, setImporting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const existingUidSet = useMemo(() => new Set(existingUids), [existingUids]);
+  const [updateExistingIds, setUpdateExistingIds] = useState<Set<string>>(new Set());
 
   const handleToggleContact = (id: string) => {
     const newSelected = new Set(selectedIds);
@@ -91,6 +96,18 @@ export default function ImportContactsList({
     });
   };
 
+  const handleToggleUpdateExisting = (id: string) => {
+    setUpdateExistingIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
   const handlePerContactRelationshipChange = (contactId: string, relationshipTypeId: string) => {
     setPerContactRelationshipTypeId((prev) => {
       const newMap = new Map(prev);
@@ -104,7 +121,7 @@ export default function ImportContactsList({
   };
 
   // Detect unsaved changes
-  const hasUnsavedChanges = selectedIds.size > 0 || selectedGroupIds.length > 0 || perContactGroups.size > 0 || globalRelationshipTypeId !== '' || perContactRelationshipTypeId.size > 0;
+  const hasUnsavedChanges = selectedIds.size > 0 || selectedGroupIds.length > 0 || perContactGroups.size > 0 || globalRelationshipTypeId !== '' || perContactRelationshipTypeId.size > 0 || updateExistingIds.size > 0;
 
   // Warn before leaving page with unsaved changes
   useEffect(() => {
@@ -161,6 +178,7 @@ export default function ImportContactsList({
           perContactGroups: perContactGroupsObj,
           globalRelationshipTypeId: globalRelationshipTypeId || null,
           perContactRelationshipTypeId: perContactRelObj,
+          updateExistingIds: Array.from(updateExistingIds),
         }),
       });
 
@@ -181,6 +199,7 @@ export default function ImportContactsList({
       const params = new URLSearchParams({
         importSuccess: 'true',
         imported: data.imported.toString(),
+        updated: (data.updated ?? 0).toString(),
         skipped: data.skipped.toString(),
         errors: data.errors.toString(),
       });
@@ -289,6 +308,9 @@ export default function ImportContactsList({
           const isSelected = selectedIds.has(pendingImport.id);
           const contactGroupIds = perContactGroups.get(pendingImport.id) || [];
 
+          const isExisting = existingUidSet.has(pendingImport.uid);
+          const willUpdate = updateExistingIds.has(pendingImport.id);
+
           return (
             <CompactContactRow
               key={pendingImport.id}
@@ -303,6 +325,9 @@ export default function ImportContactsList({
               relationshipTypes={relationshipTypes}
               selectedRelationshipTypeId={perContactRelationshipTypeId.get(pendingImport.id) || ''}
               onRelationshipChange={handlePerContactRelationshipChange}
+              isExisting={isExisting}
+              willUpdate={willUpdate}
+              onToggleUpdate={handleToggleUpdateExisting}
             />
           );
         })}

--- a/components/ImportSuccessToast.tsx
+++ b/components/ImportSuccessToast.tsx
@@ -27,6 +27,7 @@ export default function ImportSuccessToast({
 
     const importSuccess = searchParams.get('importSuccess');
     const imported = searchParams.get('imported');
+    const updated = searchParams.get('updated');
     const skipped = searchParams.get('skipped');
     const errors = searchParams.get('errors');
 
@@ -34,6 +35,7 @@ export default function ImportSuccessToast({
       hasShownToast.current = true;
 
       const importedCount = parseInt(imported || '0', 10);
+      const updatedCount = parseInt(updated || '0', 10);
       const skippedCount = parseInt(skipped || '0', 10);
       const errorsCount = parseInt(errors || '0', 10);
 
@@ -45,12 +47,17 @@ export default function ImportSuccessToast({
             errors: errorsCount,
           })
         );
-      } else if (importedCount > 0) {
+      } else if (importedCount > 0 || updatedCount > 0) {
         toast.success(
-          t('importSuccessToast', {
+          t('importSuccessWithUpdatesToast', {
             imported: importedCount,
+            updated: updatedCount,
             skipped: skippedCount,
           })
+        );
+      } else if (skippedCount > 0) {
+        toast.warning(
+          t('allSkippedToast', { skipped: skippedCount })
         );
       }
 
@@ -61,6 +68,7 @@ export default function ImportSuccessToast({
         const url = new URL(window.location.href);
         url.searchParams.delete('importSuccess');
         url.searchParams.delete('imported');
+        url.searchParams.delete('updated');
         url.searchParams.delete('skipped');
         url.searchParams.delete('errors');
         router.replace(url.pathname + url.search, { scroll: false });

--- a/docs/src/content/docs/features/carddav.md
+++ b/docs/src/content/docs/features/carddav.md
@@ -58,6 +58,8 @@ Go to **CardDAV > Conflicts** to see a side-by-side comparison of both versions.
 
 New contacts found on the CardDAV server that don't yet exist in Nametag show up as pending imports. Review them and choose which ones to bring in, rather than importing everything automatically.
 
+Contacts that already exist in Nametag (matched by their vCard UID) are marked with an "Already in Nametag" badge. You can still select these contacts and check the **Update existing contact** option to overwrite the existing record with the data from the import. This is useful when re-importing a VCF file with updated information for a contact you already have.
+
 ## Bulk export
 
 If you're setting up sync for the first time and already have contacts in Nametag, use bulk export to push your existing contacts to the CardDAV server in batches.

--- a/lib/openapi/carddav.ts
+++ b/lib/openapi/carddav.ts
@@ -143,6 +143,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
               additionalProperties: { type: 'array', items: { type: 'string' } },
               description: 'Map of import ID to group IDs for per-contact assignment',
             },
+            updateExistingIds: { type: 'array', items: { type: 'string' }, description: 'IDs of pending imports whose existing person should be updated instead of skipped' },
           },
           required: ['importIds'],
         }),
@@ -152,6 +153,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
             properties: {
               success: { type: 'boolean' },
               imported: { type: 'integer' },
+              updated: { type: 'integer' },
               skipped: { type: 'integer' },
               errors: { type: 'integer' },
               errorMessages: { type: 'array', items: { type: 'string' } },

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -377,7 +377,13 @@
         "noRelationship": "[Keine]",
         "relationshipPrecedenceHelp": "Du kannst dies für einzelne Kontakte überschreiben, indem du sie aufklappst und eine andere Beziehung auswählst.",
         "contactRelationship": "Beziehung zu dir: Diese Person ist dein/e...",
-        "useGlobalRelationship": "[Globale Einstellung verwenden]"
+        "useGlobalRelationship": "[Globale Einstellung verwenden]",
+        "alreadyExists": "Bereits in Nametag vorhanden",
+        "updateExisting": "Bestehenden Kontakt aktualisieren",
+        "updated": "{count} Kontakte aktualisiert",
+        "allSkippedToast": "{skipped, plural, =1 {1 Kontakt war bereits in Nametag und wurde uebersprungen} other {# Kontakte waren bereits in Nametag und wurden uebersprungen}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 Kontakt importiert} other {# Kontakte importiert}}{updated, plural, =0 {} =1 {, 1 Kontakt aktualisiert} other {, # Kontakte aktualisiert}}{skipped, plural, =0 {} =1 {, 1 Duplikat uebersprungen} other {, # Duplikate uebersprungen}}",
+        "descriptionWithDuplicates": "{count} Kontakte gefunden, {duplicates} bereits in Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} neue Kontakte gefunden",

--- a/locales/en.json
+++ b/locales/en.json
@@ -377,7 +377,13 @@
         "noRelationship": "[None]",
         "relationshipPrecedenceHelp": "You can override this for individual contacts by expanding them and selecting a different relationship.",
         "contactRelationship": "Relationship to you: This person is your...",
-        "useGlobalRelationship": "[Use global setting]"
+        "useGlobalRelationship": "[Use global setting]",
+        "alreadyExists": "Already in Nametag",
+        "updateExisting": "Update existing contact",
+        "updated": "{count} contacts updated",
+        "allSkippedToast": "{skipped, plural, =1 {1 contact was already in Nametag and was skipped} other {# contacts were already in Nametag and were skipped}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 contact imported} other {# contacts imported}}{updated, plural, =0 {} =1 {, 1 contact updated} other {, # contacts updated}}{skipped, plural, =0 {} =1 {, 1 duplicate skipped} other {, # duplicates skipped}}",
+        "descriptionWithDuplicates": "{count} contacts found, {duplicates} already in Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} new contacts found",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -377,7 +377,13 @@
         "noRelationship": "[Ninguna]",
         "relationshipPrecedenceHelp": "Puedes anular esto para contactos individuales expandiéndolos y seleccionando una relación diferente.",
         "contactRelationship": "Relación contigo: Esta persona es tu...",
-        "useGlobalRelationship": "[Usar configuración global]"
+        "useGlobalRelationship": "[Usar configuración global]",
+        "alreadyExists": "Ya existe en Nametag",
+        "updateExisting": "Actualizar contacto existente",
+        "updated": "{count} contactos actualizados",
+        "allSkippedToast": "{skipped, plural, =1 {1 contacto ya estaba en Nametag y fue omitido} other {# contactos ya estaban en Nametag y fueron omitidos}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 contacto importado} other {# contactos importados}}{updated, plural, =0 {} =1 {, 1 contacto actualizado} other {, # contactos actualizados}}{skipped, plural, =0 {} =1 {, 1 duplicado omitido} other {, # duplicados omitidos}}",
+        "descriptionWithDuplicates": "{count} contactos encontrados, {duplicates} ya en Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} contactos nuevos encontrados",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -360,7 +360,13 @@
         "noRelationship": "[Nessuna]",
         "relationshipPrecedenceHelp": "Puoi sovrascrivere questo per contatti individuali espandendoli e selezionando una relazione diversa.",
         "contactRelationship": "Relazione con te: Questa persona è il tuo...",
-        "useGlobalRelationship": "[Usa impostazione globale]"
+        "useGlobalRelationship": "[Usa impostazione globale]",
+        "alreadyExists": "Gia presente in Nametag",
+        "updateExisting": "Aggiorna contatto esistente",
+        "updated": "{count} contatti aggiornati",
+        "allSkippedToast": "{skipped, plural, =1 {1 contatto era gia in Nametag ed e stato saltato} other {# contatti erano gia in Nametag e sono stati saltati}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 contatto importato} other {# contatti importati}}{updated, plural, =0 {} =1 {, 1 contatto aggiornato} other {, # contatti aggiornati}}{skipped, plural, =0 {} =1 {, 1 duplicato saltato} other {, # duplicati saltati}}",
+        "descriptionWithDuplicates": "{count} contatti trovati, {duplicates} gia in Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} nuovi contatti trovati",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -377,7 +377,13 @@
         "noRelationship": "[なし]",
         "relationshipPrecedenceHelp": "個別の連絡先を展開して別の関係を選択することで、これを上書きできます。",
         "contactRelationship": "あなたとの関係: この人はあなたの...",
-        "useGlobalRelationship": "[グローバル設定を使用]"
+        "useGlobalRelationship": "[グローバル設定を使用]",
+        "alreadyExists": "Nametagに登録済み",
+        "updateExisting": "既存の連絡先を更新",
+        "updated": "{count}件の連絡先を更新しました",
+        "allSkippedToast": "{skipped, plural, =1 {1件の連絡先は既にNametagに登録済みのためスキップされました} other {#件の連絡先は既にNametagに登録済みのためスキップされました}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1件インポート} other {#件インポート}}{updated, plural, =0 {} =1 {, 1件更新} other {, #件更新}}{skipped, plural, =0 {} =1 {, 1件の重複をスキップ} other {, #件の重複をスキップ}}",
+        "descriptionWithDuplicates": "{count}件の連絡先が見つかりました。{duplicates}件は既にNametagに登録済みです"
       },
       "notifications": {
         "newContactsFound": "{count}件の新しい連絡先が見つかりました",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -377,7 +377,13 @@
         "noRelationship": "[Ingen]",
         "relationshipPrecedenceHelp": "Du kan overstyre dette for individuelle kontakter ved å utvide dem og velge en annen relasjon.",
         "contactRelationship": "Relasjon til deg: Denne personen er din...",
-        "useGlobalRelationship": "[Bruk global innstilling]"
+        "useGlobalRelationship": "[Bruk global innstilling]",
+        "alreadyExists": "Finnes allerede i Nametag",
+        "updateExisting": "Oppdater eksisterende kontakt",
+        "updated": "{count} kontakter oppdatert",
+        "allSkippedToast": "{skipped, plural, =1 {1 kontakt var allerede i Nametag og ble hoppet over} other {# kontakter var allerede i Nametag og ble hoppet over}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 kontakt importert} other {# kontakter importert}}{updated, plural, =0 {} =1 {, 1 kontakt oppdatert} other {, # kontakter oppdatert}}{skipped, plural, =0 {} =1 {, 1 duplikat hoppet over} other {, # duplikater hoppet over}}",
+        "descriptionWithDuplicates": "{count} kontakter funnet, {duplicates} finnes allerede i Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} nye kontakter funnet",

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -373,7 +373,13 @@
         "noRelationship": "[Geen]",
         "relationshipPrecedenceHelp": "U kunt dit overschrijven voor individuele contacten door ze uit te vouwen en een andere relatie te selecteren.",
         "contactRelationship": "Relatie tot u: Deze persoon is uw...",
-        "useGlobalRelationship": "[Gebruik globale instelling]"
+        "useGlobalRelationship": "[Gebruik globale instelling]",
+        "alreadyExists": "Bestaat al in Nametag",
+        "updateExisting": "Bestaand contact bijwerken",
+        "updated": "{count} contacten bijgewerkt",
+        "allSkippedToast": "{skipped, plural, =1 {1 contact bestond al in Nametag en is overgeslagen} other {# contacten bestonden al in Nametag en zijn overgeslagen}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 contact geimporteerd} other {# contacten geimporteerd}}{updated, plural, =0 {} =1 {, 1 contact bijgewerkt} other {, # contacten bijgewerkt}}{skipped, plural, =0 {} =1 {, 1 duplicaat overgeslagen} other {, # duplicaten overgeslagen}}",
+        "descriptionWithDuplicates": "{count} contacten gevonden, {duplicates} bestaan al in Nametag"
       },
       "notifications": {
         "newContactsFound": "{count} nieuwe contacten gevonden",

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -360,7 +360,13 @@
         "noRelationship": "[Нет]",
         "relationshipPrecedenceHelp": "Вы можете переопределить это для отдельных контактов, развернув их и выбрав другую связь.",
         "contactRelationship": "Связь с вами: этот человек ваш...",
-        "useGlobalRelationship": "[Использовать общую настройку]"
+        "useGlobalRelationship": "[Использовать общую настройку]",
+        "alreadyExists": "Уже есть в Nametag",
+        "updateExisting": "Обновить существующий контакт",
+        "updated": "{count} контактов обновлено",
+        "allSkippedToast": "{skipped, plural, =1 {1 контакт уже был в Nametag и был пропущен} other {# контактов уже были в Nametag и были пропущены}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {1 контакт импортирован} other {# контактов импортировано}}{updated, plural, =0 {} =1 {, 1 контакт обновлен} other {, # контактов обновлено}}{skipped, plural, =0 {} =1 {, 1 дубликат пропущен} other {, # дубликатов пропущено}}",
+        "descriptionWithDuplicates": "{count} контактов найдено, {duplicates} уже в Nametag"
       },
       "notifications": {
         "newContactsFound": "Найдено {count} новых контактов",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -377,7 +377,13 @@
         "noRelationship": "[无]",
         "relationshipPrecedenceHelp": "您可以通过展开它们并选择不同的关系来覆盖单个联系人的这个设置。",
         "contactRelationship": "与您的关系：这个人是.....",
-        "useGlobalRelationship": "[使用全局设置]"
+        "useGlobalRelationship": "[使用全局设置]",
+        "alreadyExists": "已存在于Nametag中",
+        "updateExisting": "更新已有联系人",
+        "updated": "已更新{count}个联系人",
+        "allSkippedToast": "{skipped, plural, =1 {1个联系人已在Nametag中, 已跳过} other {#个联系人已在Nametag中, 已跳过}}",
+        "importSuccessWithUpdatesToast": "{imported, plural, =0 {} =1 {已导入1个联系人} other {已导入#个联系人}}{updated, plural, =0 {} =1 {, 已更新1个联系人} other {, 已更新#个联系人}}{skipped, plural, =0 {} =1 {, 已跳过1个重复项} other {, 已跳过#个重复项}}",
+        "descriptionWithDuplicates": "找到{count}个联系人, 其中{duplicates}个已存在于Nametag中"
       },
       "notifications": {
         "newContactsFound": "{count} 个新联系人已找到",

--- a/tests/components/ImportSuccessToast.test.tsx
+++ b/tests/components/ImportSuccessToast.test.tsx
@@ -25,11 +25,14 @@ vi.mock('sonner', () => ({
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) => {
-    if (key === 'importSuccessToast') {
-      return `${params?.imported} imported, ${params?.skipped} skipped`;
+    if (key === 'importSuccessWithUpdatesToast') {
+      return `${params?.imported} imported, ${params?.updated} updated, ${params?.skipped} skipped`;
     }
     if (key === 'importCompleteWithErrors') {
       return `${params?.imported} imported, ${params?.errors} errors`;
+    }
+    if (key === 'allSkippedToast') {
+      return `${params?.skipped} skipped`;
     }
     return key;
   },
@@ -54,7 +57,7 @@ describe('ImportSuccessToast', () => {
     // Mock window.location for URL construction
     Object.defineProperty(window, 'location', {
       writable: true,
-      value: new URL('http://localhost/people?importSuccess=true&imported=5&skipped=2&errors=0'),
+      value: new URL('http://localhost/people?importSuccess=true&imported=5&updated=0&skipped=2&errors=0'),
     });
   });
 
@@ -67,7 +70,7 @@ describe('ImportSuccessToast', () => {
 
       render(<ImportSuccessToast />);
 
-      expect(toast.success).toHaveBeenCalledWith('5 imported, 2 skipped');
+      expect(toast.success).toHaveBeenCalledWith('5 imported, 0 updated, 2 skipped');
     });
 
     it('should handle zero skipped contacts', () => {
@@ -78,7 +81,19 @@ describe('ImportSuccessToast', () => {
 
       render(<ImportSuccessToast />);
 
-      expect(toast.success).toHaveBeenCalledWith('3 imported, 0 skipped');
+      expect(toast.success).toHaveBeenCalledWith('3 imported, 0 updated, 0 skipped');
+    });
+
+    it('should show success toast with updated count', () => {
+      mockSearchParams.set('importSuccess', 'true');
+      mockSearchParams.set('imported', '2');
+      mockSearchParams.set('updated', '3');
+      mockSearchParams.set('skipped', '0');
+      mockSearchParams.set('errors', '0');
+
+      render(<ImportSuccessToast />);
+
+      expect(toast.success).toHaveBeenCalledWith('2 imported, 3 updated, 0 skipped');
     });
 
     it('should handle single contact import', () => {
@@ -133,6 +148,7 @@ describe('ImportSuccessToast', () => {
       const callArg = mockReplace.mock.calls[0][0];
       expect(callArg).not.toContain('importSuccess');
       expect(callArg).not.toContain('imported');
+      expect(callArg).not.toContain('updated');
       expect(callArg).not.toContain('skipped');
       expect(callArg).not.toContain('errors');
     });
@@ -235,7 +251,7 @@ describe('ImportSuccessToast', () => {
       expect(toast.error).not.toHaveBeenCalled();
     });
 
-    it('should not show toast when zero imported with no errors', () => {
+    it('should show warning toast when all contacts were skipped', () => {
       mockSearchParams.set('importSuccess', 'true');
       mockSearchParams.set('imported', '0');
       mockSearchParams.set('skipped', '5');
@@ -243,7 +259,7 @@ describe('ImportSuccessToast', () => {
 
       render(<ImportSuccessToast />);
 
-      // No toast shown if importedCount is 0 and no errors
+      expect(toast.warning).toHaveBeenCalledWith('5 skipped');
       expect(toast.success).not.toHaveBeenCalled();
       expect(toast.error).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Summary

- When re-importing a VCF file with contacts that already exist (matched by vCard UID), the import was silently skipping them with no user feedback
- The import page now detects duplicates upfront and shows an "Already in Nametag" badge on matching contacts
- Users can check "Update existing contact" to overwrite the existing record with data from the import file
- The toast always shows results: a warning when all contacts were skipped, and an updated count when contacts were updated
- API, OpenAPI spec, docs, and all 9 locale files updated

Closes #359

## Test plan

- [ ] Import a VCF file with a new contact - should import normally
- [ ] Re-import the same VCF file - contacts should show "Already in Nametag" badge
- [ ] Select an existing contact without checking "Update existing" - should show warning toast with skip count
- [ ] Select an existing contact with "Update existing" checked - should update the person and show updated count in toast
- [ ] Modify the VCF file (e.g. add phone number), re-import with "Update existing" - verify the person is updated with new data
- [ ] Import a mix of new and existing contacts - toast should show correct counts for imported, updated, and skipped
- [ ] Verify translations appear correctly in at least 2 languages