### PR TITLE
fix(carddav): accept null addressBook fields when saving connection

### DIFF
--- a/app/api/carddav/connection/route.ts
+++ b/app/api/carddav/connection/route.ts
@@ -18,8 +18,8 @@ const connectionSchema = z.object({
   autoExportNew: z.boolean().optional(),
   autoSyncInterval: z.number().int().min(60).max(86400).optional(), // 1 min to 24 hours
   importMode: z.enum(['manual', 'notify', 'auto']).optional(),
-  addressBookUrl: z.string().url().optional(),
-  addressBookName: z.string().optional(),
+  addressBookUrl: z.string().url().nullish(),
+  addressBookName: z.string().nullish(),
   cardDavNameFormat: z.enum(['FULL', 'FIRST_LAST', 'NICKNAME_PREFERRED', 'SHORT']).optional(),
 });
 

--- a/lib/openapi/carddav.ts
+++ b/lib/openapi/carddav.ts
@@ -19,6 +19,8 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
             autoExportNew: { type: 'boolean' },
             autoSyncInterval: { type: 'integer', minimum: 60, maximum: 86400, description: 'Sync interval in seconds' },
             importMode: { type: 'string', enum: ['manual', 'notify', 'auto'] },
+            addressBookUrl: { type: ['string', 'null'], format: 'uri', description: 'URL of the selected address book' },
+            addressBookName: { type: ['string', 'null'], description: 'Display name of the selected address book' },
             cardDavNameFormat: { type: 'string', enum: ['FULL', 'FIRST_LAST', 'NICKNAME_PREFERRED', 'SHORT'], description: 'Name format used for the vCard FN field when syncing' },
           },
           required: ['serverUrl', 'username', 'password'],


### PR DESCRIPTION
## Summary

- The connection wizard sends `addressBookUrl` and `addressBookName` as JSON `null`, but the Zod validation schema used `.optional()` which only accepts `undefined`. Changed to `.nullish()` so both `null` and `undefined` pass validation.
- Added the missing `addressBookUrl` and `addressBookName` fields to the OpenAPI spec for the POST endpoint.

The connection test passes because its schema only validates `serverUrl`, `username`, and `password`. The save fails because it also validates the address book fields, which arrive as `null` from the wizard when the address book selection step is skipped (single address book) or the display name is empty.

Closes #332

## Test plan

- [ ] Set up an iCloud CardDAV connection using the wizard
- [ ] Verify the connection test passes
- [ ] Verify the connection saves successfully (no "Invalid input" error)
- [ ] Run `npx vitest run tests/app/api/carddav/connection-put.test.ts`
- [ ] Run `npx vitest run tests/api/openapi-spec.test.ts`