### PR TITLE
fix(photos): never upscale images smaller than PHOTO_SIZE

### DIFF
--- a/components/PhotoCropModal.tsx
+++ b/components/PhotoCropModal.tsx
@@ -30,8 +30,9 @@ async function getCroppedBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> 
     const image = new Image();
     image.onload = () => {
       const canvas = document.createElement('canvas');
-      canvas.width = OUTPUT_SIZE;
-      canvas.height = OUTPUT_SIZE;
+      const outSize = Math.min(OUTPUT_SIZE, pixelCrop.width, pixelCrop.height);
+      canvas.width = outSize;
+      canvas.height = outSize;
       const ctx = canvas.getContext('2d');
       if (!ctx) {
         reject(new Error('Could not get canvas context'));
@@ -46,12 +47,12 @@ async function getCroppedBlob(imageSrc: string, pixelCrop: Area): Promise<Blob> 
         pixelCrop.height,
         0,
         0,
-        OUTPUT_SIZE,
-        OUTPUT_SIZE
+        outSize,
+        outSize
       );
       // Output JPEG by default for compact uploads; only fall back to PNG when
       // the source actually has transparency (server does not need to convert).
-      const hasAlpha = canvasHasAlpha(ctx, OUTPUT_SIZE, OUTPUT_SIZE);
+      const hasAlpha = canvasHasAlpha(ctx, outSize, outSize);
       const mimeType = hasAlpha ? 'image/png' : 'image/jpeg';
       const quality = hasAlpha ? undefined : JPEG_QUALITY;
       canvas.toBlob(

--- a/docs/src/content/docs/features/photos.md
+++ b/docs/src/content/docs/features/photos.md
@@ -41,7 +41,7 @@ Photos are stored on disk, not in the database, at the path configured by the `P
 | Max upload size | 50 MB |
 | Accepted input formats | JPEG, PNG, GIF, WebP (native); HEIC/HEIF (auto-converted to JPEG before crop) |
 | Output format | JPEG for opaque images, PNG for images with transparency |
-| Output dimensions | Square, default 256x256px (configurable via the `PHOTO_SIZE` environment variable, range 64-4096) |
+| Output dimensions | Square, at most 256x256px by default (configurable via the `PHOTO_SIZE` environment variable, range 64-4096). Images smaller than the configured size are kept at their original dimensions and never upscaled. |
 | JPEG quality | Default 80 (configurable via the `PHOTO_QUALITY` environment variable, range 1-100) |
 | Crop aspect ratio | 1:1 (square), shown with a round crop shape in the UI |
 | EXIF data | Auto-rotated, then stripped |

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -68,7 +68,7 @@ If `DATABASE_URL` is set, it takes precedence over the individual `DB_*` variabl
 | `SMTP_REQUIRE_TLS` | Require STARTTLS | `true` |
 | `SMTP_FROM` | Override the "from" address if your server rejects custom ones | Not set |
 | `PHOTO_STORAGE_PATH` | Custom path for photo storage | `/app/data/photos` |
-| `PHOTO_SIZE` | Photo dimensions in pixels, square, 64 to 4096 | `256` |
+| `PHOTO_SIZE` | Max photo dimensions in pixels (square, 64 to 4096). Smaller images keep their original size. | `256` |
 | `PHOTO_QUALITY` | JPEG quality for opaque photos, 1 to 100 | `80` |
 | `OIDC_ISSUER_URL` | OIDC provider issuer URL, enables SSO login | Not set |
 | `OIDC_CLIENT_ID` | OIDC client ID registered with your provider | Not set |
@@ -89,7 +89,7 @@ Some variables are validated against a specific range or format at startup. If a
 
 | Variable | Constraint | Default |
 | --- | --- | --- |
-| `PHOTO_SIZE` | Integer, 64 to 4096 (output photo dimensions in pixels, square) | `256` |
+| `PHOTO_SIZE` | Integer, 64 to 4096 (max output dimensions in pixels, square; images smaller than this are not upscaled) | `256` |
 | `PHOTO_QUALITY` | Integer, 1 to 100 (JPEG compression quality) | `80` |
 | `DB_PORT` | Integer, 1 to 65535 | None, required |
 | `LOG_LEVEL` | One of `debug`, `info`, `warn`, `error` | `info` |

--- a/lib/photo-storage.ts
+++ b/lib/photo-storage.ts
@@ -207,9 +207,10 @@ export function isHeicBuffer(buffer: Buffer): boolean {
 
 /**
  * Process a photo buffer: validate format, enforce size limit,
- * resize to PHOTO_SIZE x PHOTO_SIZE (cover), convert to JPEG at PHOTO_QUALITY, strip EXIF.
- * PHOTO_SIZE and PHOTO_QUALITY are read from the environment (see lib/env.ts), with
- * defaults of 256 and 80 respectively.
+ * resize to at most PHOTO_SIZE x PHOTO_SIZE (cover), convert to JPEG at PHOTO_QUALITY,
+ * strip EXIF.  Images smaller than PHOTO_SIZE are kept at their original dimensions
+ * (never upscaled).  PHOTO_SIZE and PHOTO_QUALITY are read from the environment
+ * (see lib/env.ts), with defaults of 256 and 80 respectively.
  * Throws on invalid input.
  */
 export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasAlpha: boolean }> {
@@ -223,7 +224,7 @@ export async function processPhoto(buffer: Buffer): Promise<{ data: Buffer; hasA
 
   const photoSize = getPhotoSize();
   const image = sharp(buffer, { limitInputPixels: SHARP_MAX_INPUT_PIXELS })
-    .resize(photoSize, photoSize, { fit: 'cover' })
+    .resize(photoSize, photoSize, { fit: 'cover', withoutEnlargement: true })
     .rotate(); // auto-rotate based on EXIF before stripping
 
   // Check if the source format has an alpha channel

--- a/tests/lib/photo-storage.test.ts
+++ b/tests/lib/photo-storage.test.ts
@@ -214,12 +214,21 @@ describe('processPhoto', () => {
   });
 
   it('should convert WebP to JPEG', async () => {
-    const input = await createTestImage(100, 100, 'webp');
+    const input = await createTestImage(300, 300, 'webp');
     const output = await processPhoto(input);
 
     const metadata = await sharp(output.data).metadata();
     expect(metadata.format).toBe('jpeg');
     expect(metadata.width).toBe(256);
+  });
+
+  it('should not upscale images smaller than PHOTO_SIZE', async () => {
+    const input = await createTestImage(100, 100, 'png');
+    const output = await processPhoto(input);
+
+    const metadata = await sharp(output.data).metadata();
+    expect(metadata.width).toBe(100);
+    expect(metadata.height).toBe(100);
   });
 
   it('should convert JPEG input and resize', async () => {


### PR DESCRIPTION
## Summary

- Photos smaller than the configured `PHOTO_SIZE` are now kept at their original dimensions instead of being upscaled (which caused pixelation)
- Fix applied at both layers: the client-side crop canvas and the server-side sharp resize
- Docs updated to reflect the new behavior

Closes #320

## Test plan

- [x] Existing photo-storage tests pass (46/46)
- [x] New test verifies a 100x100 image stays 100x100 when `PHOTO_SIZE` is 256
- [x] TypeScript type-check passes
- [x] Docs build successfully
- [ ] Manual: upload a small photo (e.g. 100x100) and verify it is not pixelated
- [ ] Manual: upload a large photo (e.g. 2000x2000) and verify it is downscaled normally