### PR TITLE
fix: stop duplicate date entries in CardDAV vCards

### DIFF
--- a/app/api/carddav/export-bulk/route.ts
+++ b/app/api/carddav/export-bulk/route.ts
@@ -91,7 +91,7 @@ export const POST = withLogging(async function POST(request: Request) {
         locations: true,
         customFields: true,
         customFieldValues: customFieldValuesInclude(),
-        importantDates: true,
+        importantDates: { where: { deletedAt: null } },
         relationshipsFrom: {
           include: {
             relatedPerson: true,

--- a/lib/carddav/auto-export.ts
+++ b/lib/carddav/auto-export.ts
@@ -44,7 +44,7 @@ export async function autoExportPerson(
       locations: true,
       customFields: true,
       customFieldValues: customFieldValuesInclude(),
-      importantDates: true,
+      importantDates: { where: { deletedAt: null } },
       relationshipsFrom: {
         where: { deletedAt: null },
         include: {
@@ -253,7 +253,7 @@ export async function autoUpdatePerson(personId: string): Promise<void> {
       locations: true,
       customFields: true,
       customFieldValues: customFieldValuesInclude(),
-      importantDates: true,
+      importantDates: { where: { deletedAt: null } },
       relationshipsFrom: {
         where: { deletedAt: null },
         include: {

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -627,7 +627,7 @@ export async function syncToServer(
             locations: true,
             customFields: true,
             customFieldValues: customFieldValuesInclude(),
-            importantDates: true,
+            importantDates: { where: { deletedAt: null } },
             groups: {
               where: { group: { deletedAt: null } },
               include: { group: true },
@@ -850,7 +850,7 @@ export async function syncToServer(
         locations: true,
         customFields: true,
         customFieldValues: customFieldValuesInclude(),
-        importantDates: true,
+        importantDates: { where: { deletedAt: null } },
         relationshipsFrom: {
           include: { relatedPerson: true },
         },

--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -8,7 +8,7 @@
  * vCard 3.0 format details:
  * - Date format: YYYYMMDD (not YYYY-MM-DD)
  * - Photo encoding: ENCODING=b parameter (not data URI)
- * - Special dates: Both X-ABDATE (Apple) and X-ANNIVERSARY (Android) for compatibility
+ * - Special dates: X-ABDATE with X-ABLabel (Apple format, widely supported)
  * - Line folding: 75 character limit with CRLF + SPACE continuation
  */
 
@@ -162,7 +162,6 @@ export function personToVCard(
     const dateValue = formatVCardV3Date(anniversary.date);
     lines.push(`item${itemCounter}.X-ABDATE;VALUE=date-and-or-time:${dateValue}`);
     lines.push(`item${itemCounter}.X-ABLabel:Anniversary`);
-    lines.push(`X-ANNIVERSARY:${dateValue}`);
     itemCounter++;
   }
 
@@ -185,12 +184,8 @@ export function personToVCard(
     );
     const dateValue = formatVCardV3Date(date.date);
 
-    // X-ABDATE format (Apple)
     lines.push(`item${itemCounter}.X-ABDATE;VALUE=date-and-or-time:${dateValue}`);
     lines.push(`item${itemCounter}.X-ABLabel:${label}`);
-
-    // X-ANNIVERSARY format (Android)
-    lines.push(`X-ANNIVERSARY;TYPE=${label.toUpperCase()}:${dateValue}`);
 
     itemCounter++;
   });

--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -150,18 +150,32 @@ export function personToVCard(
 
   let itemCounter = 1;
 
+  // Only live dates are exported. Soft-deleted rows can still reach this
+  // function from callers that load dates without a deletedAt filter, and
+  // exporting them resurrects dates the user removed (issue #373).
+  const activeDates = person.importantDates.filter((d) => !d.deletedAt);
+
+  // Deduplicate by calendar day + label so databases polluted by the sync
+  // loop from issue #373 push a single entry per date instead of every
+  // duplicate row.
+  const seenDates = new Set<string>();
+  const dateKey = (date: Date, label: string) =>
+    `${formatVCardV3Date(date)}:${label.toLowerCase()}`;
+
   // BDAY (Birthday) - get from ImportantDates by type
-  const birthday = person.importantDates.find((d) => d.type === 'birthday');
+  const birthday = activeDates.find((d) => d.type === 'birthday');
   if (birthday) {
     lines.push(`BDAY:${formatVCardV3Date(birthday.date)}`);
+    seenDates.add(dateKey(birthday.date, 'birthday'));
   }
 
   // ANNIVERSARY - get from ImportantDates by type
-  const anniversary = person.importantDates.find((d) => d.type === 'anniversary');
+  const anniversary = activeDates.find((d) => d.type === 'anniversary');
   if (anniversary) {
     const dateValue = formatVCardV3Date(anniversary.date);
     lines.push(`item${itemCounter}.X-ABDATE;VALUE=date-and-or-time:${dateValue}`);
     lines.push(`item${itemCounter}.X-ABLabel:Anniversary`);
+    seenDates.add(dateKey(anniversary.date, 'anniversary'));
     itemCounter++;
   }
 
@@ -172,16 +186,19 @@ export function personToVCard(
   };
 
   // Other dates - everything except birthday and anniversary
-  const otherDates = person.importantDates.filter(
+  const otherDates = activeDates.filter(
     (d) => d.type !== 'birthday' && d.type !== 'anniversary'
   );
 
   otherDates.forEach((date) => {
     // For predefined types: use English display name from EXPORT_LABELS
     // For custom dates: use the title field
-    const label = escapeVCardText(
-      (date.type && EXPORT_LABELS[date.type]) || date.title
-    );
+    const rawLabel = (date.type && EXPORT_LABELS[date.type]) || date.title;
+    const key = dateKey(date.date, rawLabel);
+    if (seenDates.has(key)) return;
+    seenDates.add(key);
+
+    const label = escapeVCardText(rawLabel);
     const dateValue = formatVCardV3Date(date.date);
 
     lines.push(`item${itemCounter}.X-ABDATE;VALUE=date-and-or-time:${dateValue}`);
@@ -382,6 +399,9 @@ export function personToVCard(
     );
     filteredFreeForm.forEach((field) => {
       const key = field.key.startsWith('X-') ? field.key : `X-${field.key}`;
+      // The parser maps X-ANNIVERSARY to important dates now. Rows stored as
+      // custom fields by older versions would re-emit a duplicate date line.
+      if (key.toUpperCase() === 'X-ANNIVERSARY') return;
       const dedupKey = `${key}:${field.value}`;
       if (seenCustomFields.has(dedupKey)) return;
       // Also drop any free-form entry whose normalised key still collides with a template key

--- a/lib/carddav/vcard-parser.ts
+++ b/lib/carddav/vcard-parser.ts
@@ -80,6 +80,19 @@ export function parseVCard(vCardText: string): ParsedVCardDataEnhanced {
   // Collect unknown properties
   data.unknownProperties = collectUnknownProperties(properties, handledProperties);
 
+  // Deduplicate importantDates: X-ABDATE and X-ANNIVERSARY (or BDAY and
+  // Apple-added X-ABDATE) can describe the same date. Key on the calendar
+  // day + type so genuinely different dates on the same day are preserved.
+  const seenDates = new Set<string>();
+  data.importantDates = data.importantDates.filter((d) => {
+    const dayKey = d.date.toISOString().slice(0, 10);
+    const typeKey = d.type || d.title.toLowerCase();
+    const key = `${dayKey}:${typeKey}`;
+    if (seenDates.has(key)) return false;
+    seenDates.add(key);
+    return true;
+  });
+
   return data;
 }
 
@@ -506,11 +519,45 @@ function processProperty(
 
     // Vendor-specific properties
     case 'X-ABDATE': {
-      // Apple custom date with label in item group
+      // Apple custom date with label in item group.
+      // Map well-known labels to predefined types so they survive round-trips.
       const date = parseVCardDate(prop.value);
       if (date && prop.group) {
         const label = getItemGroupLabel(prop.group, itemGroups) || 'Important Date';
-        data.importantDates.push({ type: null, title: label, date });
+        const normalised = label.toLowerCase();
+        if (normalised === 'birthday') {
+          data.importantDates.push({ type: 'birthday', title: '', date });
+        } else if (normalised === 'anniversary') {
+          data.importantDates.push({ type: 'anniversary', title: '', date });
+        } else {
+          data.importantDates.push({ type: null, title: label, date });
+        }
+      }
+      return true;
+    }
+
+    case 'X-ANNIVERSARY': {
+      // Android/generic date extension. Parse like ANNIVERSARY to avoid it
+      // falling through to custom fields and creating persistent duplicates.
+      const date = parseVCardDate(prop.value);
+      if (date) {
+        const typeParam = prop.params.TYPE;
+        const type = Array.isArray(typeParam) ? typeParam[0] : typeParam;
+
+        if (type && type.toUpperCase() === 'LAST-CONTACT') {
+          data.lastContact = date;
+        } else if (!type) {
+          data.importantDates.push({ type: 'anniversary', title: '', date });
+        } else {
+          const normalised = type.toLowerCase();
+          if (normalised === 'anniversary') {
+            data.importantDates.push({ type: 'anniversary', title: '', date });
+          } else if (normalised === 'birthday') {
+            data.importantDates.push({ type: 'birthday', title: '', date });
+          } else {
+            data.importantDates.push({ type: null, title: type, date });
+          }
+        }
       }
       return true;
     }

--- a/tests/lib/carddav/auto-export.test.ts
+++ b/tests/lib/carddav/auto-export.test.ts
@@ -255,6 +255,18 @@ describe('CardDAV Auto-Export', () => {
       });
     });
 
+    it('should exclude soft-deleted important dates from the person query', async () => {
+      await autoExportPerson(PERSON_ID);
+
+      expect(mocks.personFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            importantDates: { where: { deletedAt: null } },
+          }),
+        })
+      );
+    });
+
     it('should match server-rewritten vCard by FN when person has a displayNameOverride', async () => {
       mocks.personFindUnique.mockResolvedValue(
         makePerson({ displayNameOverride: 'Dad' })
@@ -446,6 +458,20 @@ describe('CardDAV Auto-Export', () => {
   });
 
   describe('autoUpdatePerson', () => {
+    it('should exclude soft-deleted important dates from the person query', async () => {
+      mocks.cardDavMappingFindUnique.mockResolvedValue(makeMapping());
+
+      await autoUpdatePerson(PERSON_ID);
+
+      expect(mocks.personFindUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          include: expect.objectContaining({
+            importantDates: { where: { deletedAt: null } },
+          }),
+        })
+      );
+    });
+
     it('should update vCard on server when mapping exists and sync enabled', async () => {
       mocks.cardDavMappingFindUnique.mockResolvedValue(makeMapping());
 

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -959,6 +959,35 @@ describe('CardDAV Sync Engine', () => {
         );
       });
 
+      it('should exclude soft-deleted important dates from export queries', async () => {
+        mocks.cardDavMappingFindMany.mockResolvedValue([]);
+        mocks.personFindMany.mockResolvedValue([]);
+
+        await syncToServer(USER_ID);
+
+        // Pending mappings query (mapped contacts push)
+        expect(mocks.cardDavMappingFindMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            include: {
+              person: {
+                include: expect.objectContaining({
+                  importantDates: { where: { deletedAt: null } },
+                }),
+              },
+            },
+          })
+        );
+
+        // Unmapped persons query
+        expect(mocks.personFindMany).toHaveBeenCalledWith(
+          expect.objectContaining({
+            include: expect.objectContaining({
+              importantDates: { where: { deletedAt: null } },
+            }),
+          })
+        );
+      });
+
       it('should use existing UID when person already has one', async () => {
         mocks.cardDavMappingFindMany.mockResolvedValue([]);
 

--- a/tests/lib/carddav/vcard-parser.test.ts
+++ b/tests/lib/carddav/vcard-parser.test.ts
@@ -560,14 +560,102 @@ END:VCARD`;
 VERSION:3.0
 FN:Test
 item1.X-ABDATE:20230615
+item1.X-ABLabel:Custom Date
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBeNull();
+      expect(parsed.importantDates[0].title).toBe('Custom Date');
+      expect(parsed.importantDates[0].date.getFullYear()).toBe(2023);
+    });
+
+    it('should map X-ABDATE with Anniversary label to predefined type', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.X-ABDATE:20230615
 item1.X-ABLabel:Anniversary
 END:VCARD`;
 
       const parsed = parseVCard(vCard);
 
       expect(parsed.importantDates).toHaveLength(1);
-      expect(parsed.importantDates[0].title).toBe('Anniversary');
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(2023);
+      expect(parsed.importantDates[0].type).toBe('anniversary');
+      expect(parsed.importantDates[0].title).toBe('');
+    });
+
+    it('should map X-ABDATE with Birthday label to predefined type', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.X-ABDATE:19900515
+item1.X-ABLabel:Birthday
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBe('birthday');
+    });
+
+    it('should parse X-ANNIVERSARY as importantDate, not custom field', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+X-ANNIVERSARY:20200101
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBe('anniversary');
+      expect(parsed.customFields.find(f => f.key === 'X-ANNIVERSARY')).toBeUndefined();
+    });
+
+    it('should parse X-ANNIVERSARY with TYPE as importantDate', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+X-ANNIVERSARY;TYPE=Name day:20200301
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBeNull();
+      expect(parsed.importantDates[0].title).toBe('name day');
+    });
+
+    it('should dedup importantDates from X-ABDATE and X-ANNIVERSARY', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+item1.X-ABDATE:20200615
+item1.X-ABLabel:Anniversary
+X-ANNIVERSARY:20200615
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBe('anniversary');
+    });
+
+    it('should dedup BDAY and X-ABDATE with Birthday label', () => {
+      const vCard = `BEGIN:VCARD
+VERSION:3.0
+FN:Test
+BDAY:19900515
+item1.X-ABDATE:19900515
+item1.X-ABLabel:Birthday
+END:VCARD`;
+
+      const parsed = parseVCard(vCard);
+
+      expect(parsed.importantDates).toHaveLength(1);
+      expect(parsed.importantDates[0].type).toBe('birthday');
     });
 
     it('should parse X-SOCIALPROFILE as IM handle', () => {

--- a/tests/lib/vcard-v3-compliance.test.ts
+++ b/tests/lib/vcard-v3-compliance.test.ts
@@ -235,6 +235,185 @@ describe('vCard v3.0 Compliance (RFC 2426)', () => {
       expect(vcard).toContain('item2.X-ABDATE');
     });
 
+    it('should deduplicate identical important dates on export', () => {
+      const person = createTestPerson({
+        importantDates: [
+          {
+            id: 'date-1',
+            personId: 'test-1',
+            type: null,
+            title: 'Anniversary',
+            date: new Date('2020-06-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+          {
+            id: 'date-2',
+            personId: 'test-1',
+            type: null,
+            title: 'Anniversary',
+            date: new Date('2020-06-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      expect(vcard).toContain('item1.X-ABDATE;VALUE=date-and-or-time:20200615');
+      expect(vcard).not.toContain('item2.X-ABDATE');
+    });
+
+    it('should not emit a generic date duplicating the typed anniversary', () => {
+      const person = createTestPerson({
+        importantDates: [
+          {
+            id: 'date-1',
+            personId: 'test-1',
+            type: 'anniversary',
+            title: '',
+            date: new Date('2020-06-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+          {
+            id: 'date-2',
+            personId: 'test-1',
+            type: null,
+            title: 'Anniversary',
+            date: new Date('2020-06-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      const abdateCount = (vcard.match(/X-ABDATE/g) || []).length;
+      expect(abdateCount).toBe(1);
+    });
+
+    it('should not emit an X-ABDATE duplicating BDAY', () => {
+      const person = createTestPerson({
+        importantDates: [
+          {
+            id: 'date-1',
+            personId: 'test-1',
+            type: 'birthday',
+            title: '',
+            date: new Date('1990-05-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+          {
+            id: 'date-2',
+            personId: 'test-1',
+            type: null,
+            title: 'Birthday',
+            date: new Date('1990-05-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      expect(vcard).toContain('BDAY:19900515');
+      expect(vcard).not.toContain('X-ABDATE');
+    });
+
+    it('should keep dates with the same label on different days', () => {
+      const person = createTestPerson({
+        importantDates: [
+          {
+            id: 'date-1',
+            personId: 'test-1',
+            type: null,
+            title: 'Moved',
+            date: new Date('2019-01-20'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+          {
+            id: 'date-2',
+            personId: 'test-1',
+            type: null,
+            title: 'Moved',
+            date: new Date('2021-03-05'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: null,
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      expect(vcard).toContain('item1.X-ABDATE');
+      expect(vcard).toContain('item2.X-ABDATE');
+    });
+
+    it('should not export soft-deleted important dates', () => {
+      const person = createTestPerson({
+        importantDates: [
+          {
+            id: 'date-1',
+            personId: 'test-1',
+            type: 'birthday',
+            title: '',
+            date: new Date('1990-05-15'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: new Date('2025-01-01'),
+          },
+          {
+            id: 'date-2',
+            personId: 'test-1',
+            type: null,
+            title: 'Moved',
+            date: new Date('2019-01-20'),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: new Date('2025-01-01'),
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      expect(vcard).not.toContain('BDAY');
+      expect(vcard).not.toContain('X-ABDATE');
+    });
+
+    it('should not export legacy X-ANNIVERSARY custom fields', () => {
+      const person = createTestPerson({
+        customFields: [
+          {
+            id: 'cf-1',
+            personId: 'test-1',
+            key: 'X-ANNIVERSARY',
+            value: '20200615',
+            type: null,
+            createdAt: new Date(),
+          },
+        ],
+      });
+
+      const vcard = personToVCard(person);
+
+      expect(vcard).not.toContain('X-ANNIVERSARY');
+    });
+
     it('should not export Birthday as special date (uses BDAY instead)', () => {
       const person = createTestPerson({
         importantDates: [

--- a/tests/lib/vcard-v3-compliance.test.ts
+++ b/tests/lib/vcard-v3-compliance.test.ts
@@ -178,8 +178,8 @@ describe('vCard v3.0 Compliance (RFC 2426)', () => {
     });
   });
 
-  describe('Special dates (X-ABDATE and X-ANNIVERSARY)', () => {
-    it('should export both X-ABDATE and X-ANNIVERSARY for important dates', () => {
+  describe('Special dates (X-ABDATE)', () => {
+    it('should export X-ABDATE for important dates without X-ANNIVERSARY duplicates', () => {
       const person = createTestPerson({
         importantDates: [
           {
@@ -196,12 +196,12 @@ describe('vCard v3.0 Compliance (RFC 2426)', () => {
 
       const vcard = personToVCard(person);
 
-      // Apple format
+      // Apple format only
       expect(vcard).toContain('item1.X-ABDATE;VALUE=date-and-or-time:20200615');
       expect(vcard).toContain('item1.X-ABLabel:Anniversary');
 
-      // Android format
-      expect(vcard).toContain('X-ANNIVERSARY;TYPE=ANNIVERSARY:20200615');
+      // No duplicate X-ANNIVERSARY line
+      expect(vcard).not.toContain('X-ANNIVERSARY');
     });
 
     it('should use item grouping for multiple important dates', () => {


### PR DESCRIPTION
## Summary

Fixes #373 - CardDAV-synced contacts contained duplicate date entries that caused Apple Contacts/Calendar to balloon in memory usage (40+ GB), locking up macOS.

- **Remove dual date emission**: each non-birthday date was exported in both Apple (`X-ABDATE`) and Android (`X-ANNIVERSARY`) formats. Apple clients parsed both as separate dates, immediately doubling every non-birthday date. Now only `X-ABDATE` with `X-ABLabel` is emitted (widely supported by Apple, Google, and most CardDAV clients).
- **Parse X-ANNIVERSARY as a date**: previously fell through to the custom field handler, where it persisted and re-exported as an additional `X-ANNIVERSARY` line each sync cycle. Now parsed as an `importantDate` with proper type mapping.
- **Map well-known labels to predefined types**: `X-ABDATE` entries with "Birthday" or "Anniversary" labels now map to their predefined types (`birthday`/`anniversary`) instead of becoming generic dates with a title. This prevents type degradation across round-trips (e.g., `anniversary` becoming `{type: null, title: "Anniversary"}`).
- **Deduplicate importantDates on import**: after parsing, dates are deduped by calendar day + type to handle vCards from Apple or other clients that emit both `BDAY` and `X-ABDATE:Birthday` (or `X-ABDATE:Anniversary` and `X-ANNIVERSARY`) for the same date.
- **Deduplicate importantDates on export**: `personToVCard` now dedupes by calendar day + label (mirroring the existing location dedup), so a database that already accumulated duplicate rows pushes a single entry per date instead of every duplicate. It also collapses a generic titled date (e.g. `{type: null, title: "Anniversary"}`) that shadows a typed one on the same day.
- **Stop exporting soft-deleted dates**: the Prisma soft-delete extension only filters top-level queries, not nested includes, so all export paths (sync push, auto-export, bulk export) were loading soft-deleted `ImportantDate` rows and exporting them. Deleting a duplicate date in Nametag did not stick: it was still pushed to the server and came back on the next import. The five `importantDates` includes now filter `deletedAt: null`, and `personToVCard` skips soft-deleted rows as a safety net.
- **Stop exporting legacy X-ANNIVERSARY custom fields**: rows persisted as custom fields by older versions no longer re-emit an `X-ANNIVERSARY` line that would duplicate the `X-ABDATE` entry.

## Cleaning up existing duplicates

For users already affected (like the reporter of #373), the duplicates live in three places: the Nametag database, the vCards on the CardDAV server, and the Apple Contacts/Calendar caches. No migration is needed; after upgrading:

1. **In Nametag**: open each affected person and delete the duplicate dates, keeping one of each. Before this fix, deleted dates were resurrected by the next sync; now they stay deleted. Each save also triggers an export that overwrites the server vCard with a clean, deduplicated version.
2. **Contacts that you do not edit** heal on their next change from either side: any local edit pushes a deduplicated card, and any remote change imports through the new dedup logic.
3. **On the Mac**: once the server copies are clean, Contacts picks them up on its next sync. If stale duplicates linger, remove and re-add the CardDAV account under System Settings > Internet Accounts to force a full re-download. Calendar derives its birthday/anniversary series from Contacts, so it cleans up once Contacts is correct.

## Test plan

- [x] All CardDAV tests pass (370, including 16 new test cases)
- [x] New tests cover: label-to-type mapping, X-ANNIVERSARY parsing, import dedup, export dedup, soft-deleted date filtering (behavior + query shape), and legacy X-ANNIVERSARY custom field suppression
- [ ] Manual test: connect to a CardDAV server, sync contacts with dates, verify no duplicate entries in Apple Contacts/Calendar
- [ ] Manual test: verify Android CardDAV clients can still read dates from the `X-ABDATE` format
- [ ] Manual test: delete a duplicate date in Nametag and verify it does not come back after a sync cycle
