### PR TITLE
chore: stop ESLint from scanning nested build artifacts

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,11 +7,19 @@ const eslintConfig = defineConfig([
   ...nextTs,
   // Override default ignores of eslint-config-next.
   globalIgnores([
-    // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    // Default ignores of eslint-config-next. The `**/` prefix matters: build
+    // output also appears inside nested checkouts (git worktrees under
+    // .claude/, sibling clones), and a bare ".next/**" only matches the root.
+    "**/.next/**",
+    "**/out/**",
+    "**/build/**",
+    "**/next-env.d.ts",
+    // Agent and editor scratch directories, including their build artifacts.
+    ".claude/**",
+    // Playwright and coverage output.
+    "**/playwright-report/**",
+    "**/test-results/**",
+    "**/coverage/**",
   ]),
   // Global rules
   {


### PR DESCRIPTION
ESLint was reporting 10 errors from generated JavaScript inside `.claude/worktrees/*/.next/`, which meant `npm run verify` could never pass on a checkout that had ever hosted a git worktree. A red verify gate teaches people to ignore it, so this goes first.

## The cause

`globalIgnores` used bare patterns:

```js
".next/**", "out/**", "build/**", "next-env.d.ts"
```

Those only match at the repo root. Build output also lands in nested checkouts (worktrees under `.claude/`, sibling clones), so ESLint happily linted minified chunks and generated `routes.d.ts` files.

## The fix

- `**/` prefix on the build-output patterns so they match at any depth
- ignore `.claude/` outright
- ignore `playwright-report/`, `test-results/`, and `coverage/`

## Verification

`npm run verify` (lint, typecheck, 2525 tests, build) passes end to end.

Confirmed the ignores are not too broad by dropping a file with an unused variable into `lib/` and checking ESLint still flagged it:

```
lib/__lint-canary.ts
  1:7  warning  'unusedVar' is assigned a value but never used
```
