### PR TITLE
fix: close CSRF gap on 12 routes and harden three open endpoints

### DIFF
--- a/app/api/carddav/backup/route.ts
+++ b/app/api/carddav/backup/route.ts
@@ -1,23 +1,19 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createDAVClient } from 'tsdav';
 import { validateServerUrl } from '@/lib/carddav/url-validation';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { decryptPassword } from '@/lib/carddav/encryption';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 
 const log = createModuleLogger('carddav');
 
-export const POST = withLogging(async function POST(request: Request) {
+// Accepts arbitrary server credentials in the body and dials the given host, so
+// it stays session-only: an API token must not be able to drive outbound
+// requests to a server of the caller's choosing.
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     const rateLimitResponse = checkRateLimit(request, 'carddavBackup', session.user.id);
     if (rateLimitResponse) return rateLimitResponse;
 
@@ -129,4 +125,4 @@ export const POST = withLogging(async function POST(request: Request) {
       { status: 500 }
     );
   }
-});
+}, { allowApiToken: false });

--- a/app/api/carddav/conflicts/[id]/resolve/route.ts
+++ b/app/api/carddav/conflicts/[id]/resolve/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { syncToServer } from '@/lib/carddav/sync';
 import { updatePersonFromVCardInTransaction, savePhotoForPerson } from '@/lib/carddav/vcard-import';
 import type { ParsedVCardData } from '@/lib/carddav/types';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging, type RouteContext } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { z } from 'zod';
 import { customFieldValuesInclude } from '@/lib/prisma-queries';
 
@@ -15,14 +14,8 @@ const resolveSchema = z.object({
   resolution: z.enum(['keep_local', 'keep_remote', 'merged']),
 });
 
-export const POST = withLogging(async function POST(request: Request, context: RouteContext) {
+export const POST = withAuth(async (request, session, context) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     const { id } = await context.params;
     const validationResult = resolveSchema.safeParse(await request.json());
 

--- a/app/api/carddav/connection/route.ts
+++ b/app/api/carddav/connection/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { encryptPassword } from '@/lib/carddav/encryption';
 import { validateServerUrl } from '@/lib/carddav/url-validation';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { z } from 'zod';
 
 const log = createModuleLogger('carddav');
@@ -35,13 +34,11 @@ const updateConnectionSchema = z.object({
   cardDavNameFormat: z.enum(['FULL', 'FIRST_LAST', 'NICKNAME_PREFERRED', 'SHORT']).optional(),
 });
 
-export const POST = withLogging(async function POST(request: Request) {
+// Connection management stores and rotates CardDAV credentials, so all three
+// handlers stay session-only: an API token must not be able to read, replace,
+// or delete the stored server credentials.
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = await request.json();
     const validationResult = connectionSchema.safeParse(body);
@@ -128,15 +125,10 @@ export const POST = withLogging(async function POST(request: Request) {
       { status: 500 }
     );
   }
-});
+}, { allowApiToken: false });
 
-export const PUT = withLogging(async function PUT(request: Request) {
+export const PUT = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = await request.json();
     const validationResult = updateConnectionSchema.safeParse(body);
@@ -260,15 +252,10 @@ export const PUT = withLogging(async function PUT(request: Request) {
       { status: 500 }
     );
   }
-});
+}, { allowApiToken: false });
 
-export const DELETE = withLogging(async function DELETE(_request: Request) {
+export const DELETE = withAuth(async (_request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Check if connection exists
     const existingConnection = await prisma.cardDavConnection.findUnique({
@@ -306,4 +293,4 @@ export const DELETE = withLogging(async function DELETE(_request: Request) {
       { status: 500 }
     );
   }
-});
+}, { allowApiToken: false });

--- a/app/api/carddav/connection/test/route.ts
+++ b/app/api/carddav/connection/test/route.ts
@@ -1,10 +1,9 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { createDAVClient } from 'tsdav';
 import { validateServerUrl } from '@/lib/carddav/url-validation';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { z } from 'zod';
 
 const log = createModuleLogger('carddav');
@@ -15,14 +14,10 @@ const connectionTestSchema = z.object({
   password: z.string().min(1),
 });
 
-export const POST = withLogging(async function POST(request: Request) {
+// Dials whatever host the caller supplies, so it stays session-only: an API
+// token must not be able to drive outbound requests to an arbitrary server.
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     const rateLimitResponse = checkRateLimit(request, 'carddavTest', session.user.id);
     if (rateLimitResponse) return rateLimitResponse;
 
@@ -145,4 +140,4 @@ export const POST = withLogging(async function POST(request: Request) {
       { status: 500 }
     );
   }
-});
+}, { allowApiToken: false });

--- a/app/api/carddav/discover/route.ts
+++ b/app/api/carddav/discover/route.ts
@@ -1,23 +1,15 @@
-import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { discoverNewContacts } from '@/lib/carddav/discover';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { apiResponse, withAuth } from '@/lib/api-utils';
 
 const log = createModuleLogger('carddav');
 
-export const POST = withLogging(async function POST(_request: Request) {
+export const POST = withAuth(async (_request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Discover new contacts
     const result = await discoverNewContacts(session.user.id);
 
-    return NextResponse.json({
+    return apiResponse.ok({
       success: true,
       discovered: result.discovered,
       errors: result.errors,
@@ -26,12 +18,12 @@ export const POST = withLogging(async function POST(_request: Request) {
   } catch (error) {
     log.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Discovery failed');
 
-    return NextResponse.json(
+    return apiResponse.ok(
       {
         success: false,
         error: error instanceof Error ? error.message : 'Discovery failed',
       },
-      { status: 500 }
+      500
     );
   }
 });

--- a/app/api/carddav/export-bulk/route.ts
+++ b/app/api/carddav/export-bulk/route.ts
@@ -1,5 +1,4 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { createCardDavClient } from '@/lib/carddav/client';
 import { getAddressBook } from '@/lib/carddav/address-book';
@@ -7,7 +6,7 @@ import { personToVCard } from '@/lib/carddav/vcard-export';
 import { v4 as uuidv4 } from 'uuid';
 import { buildLocalHash } from '@/lib/carddav/hash';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { z } from 'zod';
 import { customFieldValuesInclude } from '@/lib/prisma-queries';
 
@@ -17,13 +16,8 @@ const exportBulkSchema = z.object({
   personIds: z.array(z.string()).min(1, 'No contacts selected for export'),
 });
 
-export const POST = withLogging(async function POST(request: Request) {
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = await request.json();
     const validationResult = exportBulkSchema.safeParse(body);

--- a/app/api/carddav/import/route.ts
+++ b/app/api/carddav/import/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma, withDeleted } from '@/lib/prisma';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { parseVCard } from '@/lib/carddav/vcard-parser';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
 import { createPersonFromVCardData, restorePersonFromVCardData, updatePersonFromVCard } from '@/lib/carddav/vcard-import';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { isSaasMode } from '@/lib/features';
 import { canCreateResource, getUserUsage } from '@/lib/billing';
 import { z } from 'zod';
@@ -23,13 +22,8 @@ const importSchema = z.object({
   updateExistingIds: z.array(z.string()).optional(),
 });
 
-export const POST = withLogging(async function POST(request: Request) {
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = await request.json();
     const validationResult = importSchema.safeParse(body);

--- a/app/api/carddav/pending-count/route.ts
+++ b/app/api/carddav/pending-count/route.ts
@@ -1,27 +1,16 @@
-import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getAlreadyMappedPersonUids } from '@/lib/carddav/mapped-uids';
-import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
-const log = createModuleLogger('carddav');
-
-export const GET = withLogging(async function GET(_request: Request) {
+export const GET = withAuth(async (_request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
     // Get connection
     const connection = await prisma.cardDavConnection.findUnique({
       where: { userId: session.user.id },
     });
 
     if (!connection) {
-      return NextResponse.json({ count: 0 });
+      return apiResponse.ok({ count: 0 });
     }
 
     // Exclude pending imports whose person is already mapped (under any UID)
@@ -36,12 +25,8 @@ export const GET = withLogging(async function GET(_request: Request) {
       },
     });
 
-    return NextResponse.json({ count });
+    return apiResponse.ok({ count });
   } catch (error) {
-    log.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Error getting pending count');
-    return NextResponse.json(
-      { error: 'Internal server error' },
-      { status: 500 }
-    );
+    return handleApiError(error, 'carddav-pending-count');
   }
 });

--- a/app/api/carddav/sync/route.ts
+++ b/app/api/carddav/sync/route.ts
@@ -1,22 +1,12 @@
-import { auth } from '@/lib/auth';
 import { bidirectionalSync } from '@/lib/carddav/sync';
 import type { SyncProgressEvent } from '@/lib/carddav/sync';
 import { checkRateLimit } from '@/lib/rate-limit';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 
 const log = createModuleLogger('carddav');
 
-export const POST = withLogging(async function POST(request: Request) {
-  const session = await auth();
-
-  if (!session?.user) {
-    return new Response(JSON.stringify({ error: 'Unauthorized' }), {
-      status: 401,
-      headers: { 'Content-Type': 'application/json' },
-    });
-  }
-
+export const POST = withAuth(async (request, session) => {
   const rateLimitResponse = checkRateLimit(request, 'carddavSync', session.user.id);
   if (rateLimitResponse) return rateLimitResponse;
 

--- a/app/api/cron/carddav-sync/route.ts
+++ b/app/api/cron/carddav-sync/route.ts
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { bidirectionalSync } from '@/lib/carddav/sync';
 import { env } from '@/lib/env';
 import { handleApiError, withLogging, getClientIp } from '@/lib/api-utils';
+import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { runWithContext, updateContext } from '@/lib/logging/context';
 
@@ -17,8 +18,7 @@ export const GET = withLogging(async function GET(request: Request) {
   let cronLogId: string | null = null;
 
   try {
-    const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
       securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', { endpoint: 'carddav-sync' });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/cron/geocode/route.ts
+++ b/app/api/cron/geocode/route.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { env } from '@/lib/env';
 import { handleApiError, withLogging, getClientIp } from '@/lib/api-utils';
+import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { updateContext } from '@/lib/logging/context';
 import { geocodeSingleAddress } from '@/lib/geocoding/geocode-person';
@@ -27,8 +28,7 @@ export const GET = withLogging(async function GET(request: Request) {
   let acquiredRunLock = false;
 
   try {
-    const authHeader = request.headers.get('authorization');
-    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
       securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', { endpoint: 'geocode' });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }

--- a/app/api/cron/purge-deleted/route.ts
+++ b/app/api/cron/purge-deleted/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { withDeleted, prisma } from '@/lib/prisma';
 import { env } from '@/lib/env';
 import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
+import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { logger, securityLogger } from '@/lib/logger';
 import { deletePersonPhotos } from '@/lib/photo-storage';
 
@@ -16,9 +17,7 @@ export const GET = withLogging(async function GET(request: Request) {
 
   try {
     // Verify the cron secret
-    const authHeader = request.headers.get('authorization');
-
-    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
       securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
         endpoint: 'purge-deleted',
       });

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -5,6 +5,7 @@ import type { SendBatchEmailItem } from '@/lib/email';
 import { formatGraphName } from '@/lib/nameUtils';
 import { env, getAppUrl } from '@/lib/env';
 import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
+import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
 import { parseAsLocalDate } from '@/lib/date-format';
@@ -20,9 +21,7 @@ export const GET = withLogging(async function GET(request: Request) {
 
   try {
     // Verify the cron secret
-    const authHeader = request.headers.get('authorization');
-
-    if (authHeader !== `Bearer ${env.CRON_SECRET}`) {
+    if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
       securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
         endpoint: 'send-reminders',
       });

--- a/app/api/dev/clear-rate-limits/route.ts
+++ b/app/api/dev/clear-rate-limits/route.ts
@@ -1,29 +1,29 @@
 import { NextResponse } from 'next/server';
 import { getRedis } from '@/lib/redis';
-import { logger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { logger, securityLogger } from '@/lib/logger';
+import { getClientIp, withLogging } from '@/lib/api-utils';
+import { hasValidBearerSecret } from '@/lib/shared-secret';
 
 /**
- * Development-only endpoint to clear rate limits
+ * Maintenance endpoint to clear rate limits, used during development and when
+ * an operator needs to unblock a locked-out account.
+ *
+ * Requires `Authorization: Bearer $CRON_SECRET` in every environment. The
+ * previous guard also accepted any request when `NODE_ENV !== 'production'`,
+ * which fails open: the standalone server is started with `node server.js`,
+ * which does not set NODE_ENV, so a self-hosted deployment that did not set it
+ * explicitly exposed unauthenticated rate-limit clearing.
  *
  * Usage:
  *   DELETE /api/dev/clear-rate-limits?type=register
  *   DELETE /api/dev/clear-rate-limits?all=true
  */
 export const DELETE = withLogging(async function DELETE(request: Request) {
-  // Only allow in development/test or with CRON_SECRET
-  const authHeader = request.headers.get('authorization');
-  const cronSecret = process.env.CRON_SECRET;
-  
-  const isAuthorized = 
-    process.env.NODE_ENV !== 'production' ||
-    (authHeader && cronSecret && authHeader === `Bearer ${cronSecret}`);
-
-  if (!isAuthorized) {
-    return NextResponse.json(
-      { error: 'Unauthorized' },
-      { status: 401 }
-    );
+  if (!hasValidBearerSecret(request, process.env.CRON_SECRET)) {
+    securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
+      endpoint: 'clear-rate-limits',
+    });
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const redis = getRedis();
@@ -65,18 +65,19 @@ export const DELETE = withLogging(async function DELETE(request: Request) {
     // Delete all matching keys
     await redis.del(...keys);
 
+    // The keys themselves are deliberately not returned: a rate-limit key
+    // embeds the client IP and, for login and password reset, the email
+    // address that was attempted.
     return NextResponse.json({
       message: 'Rate limits cleared successfully',
       pattern,
       count: keys.length,
-      keys: keys.slice(0, 10), // Show first 10 keys
     });
   } catch (error) {
     logger.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Error clearing rate limits');
     return NextResponse.json(
-      { error: 'Failed to clear rate limits', details: error instanceof Error ? error.message : 'Unknown error' },
+      { error: 'Failed to clear rate limits' },
       { status: 500 }
     );
   }
 });
-

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,22 +1,31 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { createModuleLogger } from '@/lib/logger';
+
+const log = createModuleLogger('health');
 
 /**
  * Health check endpoint for monitoring and orchestration
  * GET /api/health
- * 
+ *
  * Returns:
  * - 200: Service is healthy
  * - 503: Service is unhealthy (e.g., database connection failed)
+ *
+ * This endpoint is unauthenticated so that container orchestrators and uptime
+ * monitors can reach it, which means the response body must stay free of
+ * internal detail. Prisma connection errors quote the host, port, and
+ * sometimes the database user, so the error goes to the log and the caller
+ * only learns that the check failed.
  */
 export async function GET() {
   const startTime = Date.now();
-  
+
   try {
     // Check database connection
     await prisma.$queryRaw`SELECT 1`;
     const dbLatency = Date.now() - startTime;
-    
+
     return NextResponse.json({
       status: 'healthy',
       timestamp: new Date().toISOString(),
@@ -30,7 +39,12 @@ export async function GET() {
     });
   } catch (error) {
     const dbLatency = Date.now() - startTime;
-    
+
+    log.error(
+      { err: error instanceof Error ? error : new Error(String(error)) },
+      'Health check failed: database unreachable'
+    );
+
     return NextResponse.json(
       {
         status: 'unhealthy',
@@ -40,7 +54,6 @@ export async function GET() {
           database: {
             status: 'disconnected',
             latency: `${dbLatency}ms`,
-            error: error instanceof Error ? error.message : 'Unknown error',
           },
         },
       },
@@ -48,4 +61,3 @@ export async function GET() {
     );
   }
 }
-

--- a/app/api/log-error/route.ts
+++ b/app/api/log-error/route.ts
@@ -1,34 +1,80 @@
 import { NextResponse } from 'next/server';
 import { logger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { handleApiError, parseRequestBody, withLogging } from '@/lib/api-utils';
+import { checkRateLimit } from '@/lib/rate-limit';
 
 /**
  * Client-side error logging endpoint
  * Allows the browser to send errors to the server for logging
+ *
+ * Unauthenticated by necessity: an error that breaks the session still needs to
+ * be reportable. Everything written to the log is therefore treated as
+ * untrusted input. Reports are rate limited per IP, the body is capped, and
+ * each field is accepted only if it is a string and then truncated, so a caller
+ * cannot flood the log or shape it with arbitrary structures.
  */
+
+/** Reports are small; anything larger is not a genuine error report. */
+const MAX_REPORT_SIZE = 64 * 1024;
+
+const FIELD_LIMITS = {
+  message: 1024,
+  stack: 8192,
+  digest: 256,
+  url: 2048,
+  userAgent: 512,
+} as const;
+
+interface ErrorReport {
+  message?: unknown;
+  stack?: unknown;
+  digest?: unknown;
+  url?: unknown;
+  userAgent?: unknown;
+}
+
+/**
+ * Accept a field only if the client sent a string, and cap its length.
+ * Non-string values (objects, arrays, numbers) are dropped rather than
+ * coerced, so the log keeps a predictable shape.
+ */
+function takeString(
+  value: unknown,
+  maxLength: number
+): string | undefined {
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  return value.length > maxLength ? value.slice(0, maxLength) : value;
+}
+
 export const POST = withLogging(async function POST(request: Request) {
+  const rateLimitResponse = checkRateLimit(request, 'clientErrorLog');
+  if (rateLimitResponse) return rateLimitResponse;
+
+  let report: ErrorReport;
   try {
-    const body = await request.json();
-    const { message, stack, digest, url, userAgent } = body;
-
-    const ip = request.headers.get('x-forwarded-for') || 
-               request.headers.get('x-real-ip') || 
-               'unknown';
-
-    logger.error({
-      message,
-      stack,
-      digest,
-      url,
-      userAgent: userAgent || request.headers.get('user-agent'),
-      ip,
-    }, 'Client-side error');
-
-    return NextResponse.json({ success: true });
+    report = await parseRequestBody<ErrorReport>(request, MAX_REPORT_SIZE);
   } catch (error) {
-    // If error logging fails, still return success to avoid infinite loops
-    logger.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Failed to log client error');
-    return NextResponse.json({ success: false }, { status: 500 });
+    return handleApiError(error, 'log-error');
   }
-});
 
+  const ip =
+    request.headers.get('x-forwarded-for') ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+
+  logger.error(
+    {
+      message: takeString(report.message, FIELD_LIMITS.message),
+      stack: takeString(report.stack, FIELD_LIMITS.stack),
+      digest: takeString(report.digest, FIELD_LIMITS.digest),
+      url: takeString(report.url, FIELD_LIMITS.url),
+      userAgent:
+        takeString(report.userAgent, FIELD_LIMITS.userAgent) ??
+        takeString(request.headers.get('user-agent'), FIELD_LIMITS.userAgent),
+      ip,
+    },
+    'Client-side error'
+  );
+
+  return NextResponse.json({ success: true });
+});

--- a/app/api/user/language/route.ts
+++ b/app/api/user/language/route.ts
@@ -1,33 +1,23 @@
-import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { isSupportedLocale, setLocaleCookie } from '@/lib/locale';
-import { logger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import {
+  isSupportedLocale,
+  setLocaleCookie,
+  SUPPORTED_LOCALES,
+} from '@/lib/locale';
+import { apiResponse, handleApiError, parseRequestBody, withAuth } from '@/lib/api-utils';
 
 /**
  * PUT /api/user/language
  * Update user's language preference
  */
-export const PUT = withLogging(async function PUT(request: Request) {
+export const PUT = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user?.id) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
-      );
-    }
-
-    const body = await request.json();
+    const body = await parseRequestBody<{ language?: unknown }>(request);
     const { language } = body;
 
-    // Validate language
-    if (!language || !isSupportedLocale(language)) {
-      return NextResponse.json(
-        { error: 'Invalid language. Supported languages: en, es-ES, ja-JP, nb-NO, de-DE, zh-CN, it-IT, ru-RU, nl-NL'},
-        { status: 400 }
+    if (typeof language !== 'string' || !isSupportedLocale(language)) {
+      return apiResponse.error(
+        `Invalid language. Supported languages: ${SUPPORTED_LOCALES.join(', ')}`
       );
     }
 
@@ -40,15 +30,8 @@ export const PUT = withLogging(async function PUT(request: Request) {
     // Set cookie for immediate effect
     await setLocaleCookie(language);
 
-    return NextResponse.json({
-      success: true,
-      language,
-    });
+    return apiResponse.ok({ success: true, language });
   } catch (error) {
-    logger.error({ err: error instanceof Error ? error : new Error(String(error)) }, 'Error updating language');
-    return NextResponse.json(
-      { error: 'Failed to update language' },
-      { status: 500 }
-    );
+    return handleApiError(error, 'user-language');
   }
 });

--- a/app/api/vcard/import/route.ts
+++ b/app/api/vcard/import/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
 import { createPersonFromVCardData } from '@/lib/carddav/vcard-import';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 import { isSaasMode } from '@/lib/features';
 import { canCreateResource, getUserUsage } from '@/lib/billing';
 
@@ -15,13 +14,8 @@ const log = createModuleLogger('vcard');
  * POST /api/vcard/import
  * Import contacts from raw vCard file content
  */
-export const POST = withLogging(async function POST(request: Request) {
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Read raw vCard text
     const vcardText = await request.text();

--- a/app/api/vcard/upload/route.ts
+++ b/app/api/vcard/upload/route.ts
@@ -1,9 +1,8 @@
 import { NextResponse } from 'next/server';
-import { auth } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { createModuleLogger } from '@/lib/logger';
-import { withLogging } from '@/lib/api-utils';
+import { withAuth } from '@/lib/api-utils';
 
 const log = createModuleLogger('vcard');
 
@@ -11,13 +10,8 @@ const log = createModuleLogger('vcard');
  * POST /api/vcard/upload
  * Upload vCard file and prepare for import (creates temporary pending imports)
  */
-export const POST = withLogging(async function POST(request: Request) {
+export const POST = withAuth(async (request, session) => {
   try {
-    const session = await auth();
-
-    if (!session?.user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     // Read raw vCard text
     const vcardText = await request.text();

--- a/docs/src/content/docs/api/tokens.md
+++ b/docs/src/content/docs/api/tokens.md
@@ -24,6 +24,18 @@ API tokens let you script against Nametag without a browser session. Create one 
 
 Use `READ` scope for anything that only needs to pull data, such as a read-only dashboard or export script, so a leaked token can't modify or delete your contacts.
 
+### Endpoints that require a session
+
+A few endpoints reject bearer tokens regardless of scope and accept only a browser session. They fall into three groups:
+
+| Endpoints | Why |
+| --- | --- |
+| `/api/user/api-tokens*` | A token must never be able to mint or revoke other tokens. |
+| `/api/billing/*` | Subscription and payment changes stay tied to an interactive session. |
+| `/api/carddav/connection`, `/api/carddav/connection/test`, `/api/carddav/backup` | These read or replace stored CardDAV credentials, and the last two dial whatever host the caller supplies. |
+
+Requests to these with a bearer token return `401`.
+
 ### Token format
 
 | Property | Detail |

--- a/docs/src/content/docs/self-hosting/cron-jobs.md
+++ b/docs/src/content/docs/self-hosting/cron-jobs.md
@@ -92,3 +92,19 @@ If you're not using Docker's `alpine` cron container, any scheduler capable of m
 | `send-reminders` | All eligible reminders | None |
 
 `geocode` and `carddav-sync` are throttled because they call external services (your geocoder, and each user's CardDAV server) and shouldn't hammer them. `purge-deleted` and `send-reminders` only touch your own database and don't need batching or a rate limit; they process everything eligible in a single run.
+
+## Clearing rate limits
+
+`CRON_SECRET` also authenticates one maintenance endpoint, useful when someone has locked themselves out by failing login too many times:
+
+```bash
+# Clear one category of rate limit
+curl -X DELETE "https://your-instance.example.com/api/dev/clear-rate-limits?type=login" \
+  -H "Authorization: Bearer $CRON_SECRET"
+
+# Clear all of them
+curl -X DELETE "https://your-instance.example.com/api/dev/clear-rate-limits?all=true" \
+  -H "Authorization: Bearer $CRON_SECRET"
+```
+
+It requires Redis, and it requires the bearer token in every environment, including development. Earlier versions accepted any request when `NODE_ENV` was not exactly `production`, which meant a deployment that did not set `NODE_ENV` left it open; the standalone server is started with `node server.js`, which does not set that variable on its own. The official Docker image always sets it, so image-based deployments were unaffected.

--- a/lib/openapi/user.ts
+++ b/lib/openapi/user.ts
@@ -5,6 +5,7 @@ import {
   updateGeocodingSchema,
   importDataSchema,
 } from '../validations';
+import { SUPPORTED_LOCALES } from '../locale';
 import { zodBody, jsonBody, jsonResponse, ref400, ref401, refMessage, resp } from './helpers';
 
 export function userPaths(): Record<string, Record<string, unknown>> {
@@ -167,7 +168,9 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         requestBody: jsonBody({
           type: 'object',
           properties: {
-            language: { type: 'string', enum: ['en', 'es-ES', 'ja-JP', 'nb-NO', 'de-DE'] },
+            // Derived from the canonical locale list so the spec cannot drift
+            // when a new language is added.
+            language: { type: 'string', enum: [...SUPPORTED_LOCALES] },
           },
           required: ['language'],
         }),
@@ -176,6 +179,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
             type: 'object',
             properties: { success: { type: 'boolean' }, language: { type: 'string' } },
           }),
+          '400': ref400(),
           '401': ref401(),
         },
       },

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -74,6 +74,13 @@ export const rateLimitConfigs = {
     maxAttempts: 10,
     windowMs: 15 * 60 * 1000,
   },
+  // Client-side error reports: 60 per 5 minutes. The endpoint is
+  // unauthenticated, so this caps how much a single client can write to the
+  // log while still allowing a genuinely broken page to report itself.
+  clientErrorLog: {
+    maxAttempts: 60,
+    windowMs: 5 * 60 * 1000,
+  },
 } as const;
 
 export type RateLimitType = keyof typeof rateLimitConfigs;

--- a/lib/shared-secret.ts
+++ b/lib/shared-secret.ts
@@ -1,0 +1,47 @@
+import { timingSafeEqual } from 'node:crypto';
+
+/**
+ * Compare two secrets without leaking their contents through timing.
+ *
+ * `timingSafeEqual` throws when the buffers differ in length, which would
+ * itself reveal the expected length, so the lengths are compared first and a
+ * mismatch short-circuits to false.
+ */
+export function secretsMatch(provided: string, expected: string): boolean {
+  const a = Buffer.from(provided, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Verify an `Authorization: Bearer <secret>` header against a shared secret.
+ *
+ * Returns false when the header is missing or malformed, or when the configured
+ * secret is empty, so a deployment that forgot to set the secret fails closed
+ * instead of accepting `Bearer undefined`.
+ */
+export function hasValidBearerSecret(
+  request: Request,
+  expected: string | undefined
+): boolean {
+  if (!expected) {
+    return false;
+  }
+
+  const header = request.headers.get('authorization');
+  if (!header) {
+    return false;
+  }
+
+  const match = /^Bearer\s+(.+)$/i.exec(header.trim());
+  if (!match) {
+    return false;
+  }
+
+  return secretsMatch(match[1].trim(), expected);
+}

--- a/tests/api/carddav-import-limits.test.ts
+++ b/tests/api/carddav-import-limits.test.ts
@@ -118,6 +118,16 @@ vi.mock('@/lib/carddav/vcard-import', () => ({
 
 // Mock logger
 vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+  securityLogger: {
+    authFailure: vi.fn(),
+    rateLimitExceeded: vi.fn(),
+  },
   createModuleLogger: () => ({
     info: vi.fn(),
     error: vi.fn(),
@@ -126,10 +136,8 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
-// Mock api-utils (withLogging is a pass-through wrapper)
-vi.mock('@/lib/api-utils', () => ({
-  withLogging: (fn: (...args: unknown[]) => unknown) => fn,
-}));
+// api-utils is deliberately NOT mocked: the route is wrapped in the real
+// withAuth, so these tests also cover its session and same-origin handling.
 
 // Import after mocking
 import { POST } from '@/app/api/carddav/import/route';

--- a/tests/api/dev-clear-rate-limits.test.ts
+++ b/tests/api/dev-clear-rate-limits.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockRedis = vi.hoisted(() => ({
+  keys: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock('@/lib/redis', () => ({
+  getRedis: vi.fn(() => mockRedis),
+  isRedisConnected: vi.fn(() => true),
+}));
+
+const mockLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLog,
+  securityLogger: {
+    authFailure: vi.fn(),
+    rateLimitExceeded: vi.fn(),
+  },
+  createModuleLogger: vi.fn(() => mockLog),
+}));
+
+import { DELETE } from '@/app/api/dev/clear-rate-limits/route';
+
+const SECRET = 'test-cron-secret-value';
+
+function request(opts: { auth?: string; query?: string } = {}) {
+  return new Request(
+    `http://localhost:3000/api/dev/clear-rate-limits?${opts.query ?? 'all=true'}`,
+    {
+      method: 'DELETE',
+      headers: opts.auth ? { authorization: opts.auth } : {},
+    }
+  );
+}
+
+describe('DELETE /api/dev/clear-rate-limits', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.CRON_SECRET = SECRET;
+    mockRedis.keys.mockResolvedValue(['ratelimit:login:1.2.3.4']);
+    mockRedis.del.mockResolvedValue(1);
+  });
+
+  it('requires the shared secret even outside production', async () => {
+    // The old guard was `NODE_ENV !== 'production' || bearer === CRON_SECRET`,
+    // which left the endpoint wide open whenever NODE_ENV was unset. The
+    // standalone server started with `node server.js` does not set it.
+    const previous = process.env.NODE_ENV;
+    (process.env as { NODE_ENV?: string }).NODE_ENV = undefined;
+
+    try {
+      const res = await DELETE(request());
+
+      expect(res.status).toBe(401);
+      expect(mockRedis.del).not.toHaveBeenCalled();
+    } finally {
+      (process.env as { NODE_ENV?: string }).NODE_ENV = previous;
+    }
+  });
+
+  it('rejects a wrong secret', async () => {
+    const res = await DELETE(request({ auth: 'Bearer not-the-secret' }));
+
+    expect(res.status).toBe(401);
+    expect(mockRedis.del).not.toHaveBeenCalled();
+  });
+
+  it('clears matching keys when the secret is correct', async () => {
+    const res = await DELETE(request({ auth: `Bearer ${SECRET}` }));
+
+    expect(res.status).toBe(200);
+    expect(mockRedis.del).toHaveBeenCalledWith('ratelimit:login:1.2.3.4');
+  });
+
+  it('does not echo the rate-limit keys back to the caller', async () => {
+    mockRedis.keys.mockResolvedValue([
+      'ratelimit:login:203.0.113.9:victim@example.com',
+    ]);
+
+    const res = await DELETE(request({ auth: `Bearer ${SECRET}` }));
+    const raw = await res.text();
+
+    expect(raw).not.toContain('victim@example.com');
+    expect(raw).not.toContain('203.0.113.9');
+  });
+
+  it('does not leak internal error details when Redis fails', async () => {
+    mockRedis.keys.mockRejectedValue(
+      new Error('READONLY replica at redis.internal:6379')
+    );
+
+    const res = await DELETE(request({ auth: `Bearer ${SECRET}` }));
+    const raw = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(raw).not.toContain('redis.internal');
+  });
+});

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GET } from '@/app/api/health/route';
+import { prisma } from '@/lib/prisma';
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: { $queryRaw: vi.fn() },
+}));
+
+const mockLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLog,
+  createModuleLogger: vi.fn(() => mockLog),
+}));
+
+describe('GET /api/health', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reports healthy when the database responds', async () => {
+    vi.mocked(prisma.$queryRaw).mockResolvedValue([{ '?column?': 1 }]);
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe('healthy');
+    expect(body.checks.database.status).toBe('connected');
+  });
+
+  it('reports unhealthy with 503 when the database is unreachable', async () => {
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(
+      new Error('connect ECONNREFUSED 10.0.0.5:5432')
+    );
+
+    const res = await GET();
+    const body = await res.json();
+
+    expect(res.status).toBe(503);
+    expect(body.status).toBe('unhealthy');
+    expect(body.checks.database.status).toBe('disconnected');
+  });
+
+  it('does not leak database error details to an unauthenticated caller', async () => {
+    // A real Prisma connection error carries the host, port, and sometimes the
+    // user from the connection string. /api/health is unauthenticated, so the
+    // response must not echo it back.
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(
+      new Error(
+        "Can't reach database server at `db.internal.example:5432`. " +
+          'Credentials: nametag_admin / hunter2'
+      )
+    );
+
+    const res = await GET();
+    const raw = await res.text();
+
+    expect(res.status).toBe(503);
+    expect(raw).not.toContain('db.internal.example');
+    expect(raw).not.toContain('hunter2');
+    expect(raw).not.toContain('nametag_admin');
+  });
+
+  it('logs the underlying error so operators can still diagnose it', async () => {
+    const dbError = new Error("Can't reach database server at `db.internal:5432`");
+    vi.mocked(prisma.$queryRaw).mockRejectedValue(dbError);
+
+    await GET();
+
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.objectContaining({ err: dbError }),
+      expect.any(String)
+    );
+  });
+});

--- a/tests/api/log-error.test.ts
+++ b/tests/api/log-error.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLog,
+  securityLogger: { rateLimitExceeded: vi.fn() },
+  createModuleLogger: vi.fn(() => mockLog),
+}));
+
+import { POST } from '@/app/api/log-error/route';
+import { resetRateLimit } from '@/lib/rate-limit';
+
+function post(body: unknown, ip = '203.0.113.10') {
+  return new Request('http://localhost:3000/api/log-error', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-forwarded-for': ip },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
+describe('POST /api/log-error', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetRateLimit(post({}, '203.0.113.10'), 'clientErrorLog');
+  });
+
+  it('records a client error report', async () => {
+    const res = await POST(post({ message: 'boom', url: '/people' }));
+
+    expect(res.status).toBe(200);
+    expect(mockLog.error).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'boom', url: '/people' }),
+      'Client-side error'
+    );
+  });
+
+  it('rejects a payload that is too large instead of logging it', async () => {
+    const res = await POST(post({ message: 'x'.repeat(200 * 1024) }));
+
+    expect(res.status).toBe(413);
+    expect(mockLog.error).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.any(String) }),
+      'Client-side error'
+    );
+  });
+
+  it('truncates oversized fields so one report cannot flood the log', async () => {
+    await POST(post({ message: 'y'.repeat(5000), stack: 'z'.repeat(20000) }));
+
+    const [logged] = mockLog.error.mock.calls[0];
+    expect((logged.message as string).length).toBeLessThanOrEqual(1024);
+    expect((logged.stack as string).length).toBeLessThanOrEqual(8192);
+  });
+
+  it('ignores non-string fields rather than logging arbitrary structures', async () => {
+    await POST(post({ message: { nested: { deep: [1, 2, 3] } }, stack: 42 }));
+
+    const [logged] = mockLog.error.mock.calls[0];
+    expect(logged.message).toBeUndefined();
+    expect(logged.stack).toBeUndefined();
+  });
+
+  it('rate limits a client that floods the endpoint', async () => {
+    const ip = '198.51.100.7';
+    resetRateLimit(post({}, ip), 'clientErrorLog');
+
+    let limited: Response | undefined;
+    for (let i = 0; i < 80; i++) {
+      const res = await POST(post({ message: `err ${i}` }, ip));
+      if (res.status === 429) {
+        limited = res;
+        break;
+      }
+    }
+
+    expect(limited, 'endpoint accepted 80 reports without rate limiting').toBeDefined();
+    expect(limited!.status).toBe(429);
+  });
+});

--- a/tests/api/route-auth-invariants.test.ts
+++ b/tests/api/route-auth-invariants.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+/**
+ * Structural guard for the API surface.
+ *
+ * `withAuth` (lib/api-utils.ts) is the only place that runs the same-origin
+ * CSRF check for cookie-authenticated requests. A route that resolves the
+ * session itself with a bare `await auth()` gets authentication but skips that
+ * check, so a cross-site request carrying the victim's cookie is accepted.
+ *
+ * Routes that are intentionally unauthenticated (NextAuth handlers, cron jobs
+ * guarded by CRON_SECRET, the Stripe webhook, health, version) never call
+ * `auth()` at all, so the invariant needs no allowlist: if a route file calls
+ * `auth()`, it is doing authorization by hand and is missing the CSRF check.
+ */
+
+const API_ROOT = join(process.cwd(), 'app', 'api');
+
+function collectRouteFiles(dir: string): string[] {
+  const found: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      found.push(...collectRouteFiles(full));
+    } else if (entry === 'route.ts') {
+      found.push(full);
+    }
+  }
+
+  return found;
+}
+
+describe('API route auth invariants', () => {
+  const routeFiles = collectRouteFiles(API_ROOT);
+
+  it('finds the API routes to check', () => {
+    expect(routeFiles.length).toBeGreaterThan(50);
+  });
+
+  it('no route resolves the session with a bare auth() call', () => {
+    const offenders = routeFiles.filter((file) => {
+      const source = readFileSync(file, 'utf8');
+      // Strip comments so prose mentioning auth() does not trip the check.
+      const code = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/^\s*\/\/.*$/gm, '');
+      return /\bawait\s+auth\s*\(\s*\)/.test(code);
+    });
+
+    expect(
+      offenders.map((f) => relative(process.cwd(), f)),
+      'These routes call auth() directly and therefore skip the same-origin ' +
+        'CSRF check in withAuth. Wrap the handler in withAuth instead.'
+    ).toEqual([]);
+  });
+
+  it('no route imports auth from lib/auth', () => {
+    const offenders = routeFiles.filter((file) => {
+      const source = readFileSync(file, 'utf8');
+      // `handlers` is the NextAuth request handler export, not session lookup.
+      return /import\s*\{[^}]*\bauth\b[^}]*\}\s*from\s*['"]@\/lib\/auth['"]/.test(
+        source
+      );
+    });
+
+    expect(
+      offenders.map((f) => relative(process.cwd(), f)),
+      'Route files should get the session from withAuth, not by importing auth.'
+    ).toEqual([]);
+  });
+});

--- a/tests/api/user-language.test.ts
+++ b/tests/api/user-language.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/prisma', () => ({
   },
 }));
 vi.mock('@/lib/locale', () => ({
+  SUPPORTED_LOCALES: ['en', 'es-ES'],
   isSupportedLocale: (locale: string) => ['en', 'es-ES'].includes(locale),
   setLocaleCookie: vi.fn(),
 }));
@@ -122,7 +123,10 @@ describe('Language API Endpoint', () => {
       expect(prisma.user.update).not.toHaveBeenCalled();
     });
 
-    it('should return 500 for invalid JSON', async () => {
+    it('should return 400 for invalid JSON', async () => {
+      // A malformed body is the client's mistake, not a server fault. The route
+      // used to surface it as a 500 because it called request.json() directly;
+      // parseRequestBody classifies it as InvalidJsonError instead.
       vi.mocked(auth).mockResolvedValue({
         user: { id: 'user1', email: 'test@example.com' },
       } as any);
@@ -133,8 +137,10 @@ describe('Language API Endpoint', () => {
       });
 
       const response = await PUT(request);
+      const data = await response.json();
 
-      expect(response.status).toBe(500);
+      expect(response.status).toBe(400);
+      expect(data.error).toContain('Invalid JSON');
       expect(prisma.user.update).not.toHaveBeenCalled();
     });
 

--- a/tests/api/vcard-import-limits.test.ts
+++ b/tests/api/vcard-import-limits.test.ts
@@ -79,6 +79,16 @@ vi.mock('@/lib/carddav/vcard-import', () => ({
 
 // Mock logger
 vi.mock('@/lib/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  },
+  securityLogger: {
+    authFailure: vi.fn(),
+    rateLimitExceeded: vi.fn(),
+  },
   createModuleLogger: () => ({
     info: vi.fn(),
     error: vi.fn(),
@@ -87,10 +97,8 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
-// Mock api-utils (withLogging is a pass-through wrapper)
-vi.mock('@/lib/api-utils', () => ({
-  withLogging: (fn: (...args: unknown[]) => unknown) => fn,
-}));
+// api-utils is deliberately NOT mocked: the route is wrapped in the real
+// withAuth, so these tests also cover its session and same-origin handling.
 
 // Import after mocking
 import { POST } from '@/app/api/vcard/import/route';

--- a/tests/lib/api-utils.csrf.test.ts
+++ b/tests/lib/api-utils.csrf.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { withAuth, apiResponse } from '@/lib/api-utils';
+import { auth } from '@/lib/auth';
+
+vi.mock('@/lib/auth', () => ({ auth: vi.fn() }));
+
+vi.mock('@/lib/api-tokens', () => ({ resolveApiToken: vi.fn() }));
+
+const mockLog = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: mockLog,
+  securityLogger: mockLog,
+  createModuleLogger: vi.fn(() => mockLog),
+}));
+
+vi.mock('@/lib/env', () => ({
+  getAppUrl: () => 'http://localhost:3000',
+  env: { NEXTAUTH_URL: 'http://localhost:3000' },
+  getEnv: () => ({ NEXTAUTH_URL: 'http://localhost:3000' }),
+}));
+
+const handler = vi.fn(async () => apiResponse.ok({ ok: true }));
+
+function request(method: string, headers: Record<string, string> = {}) {
+  return new Request('http://localhost:3000/api/test', {
+    method,
+    headers,
+    ...(method === 'GET' || method === 'HEAD' ? {} : { body: '{}' }),
+  });
+}
+
+describe('withAuth same-origin enforcement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(auth).mockResolvedValue({
+      user: { id: 'user1' },
+    } as unknown as Awaited<ReturnType<typeof auth>>);
+  });
+
+  it.each(['POST', 'PUT', 'PATCH', 'DELETE'])(
+    'rejects a cross-origin %s request with 403',
+    async (method) => {
+      const res = await withAuth(handler)(
+        request(method, { origin: 'https://evil.example' })
+      );
+
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'Invalid request origin' });
+      expect(handler).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a cross-origin request identified only by Referer', async () => {
+    const res = await withAuth(handler)(
+      request('POST', { referer: 'https://evil.example/attack.html' })
+    );
+
+    expect(res.status).toBe(403);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('allows a same-origin state-changing request', async () => {
+    const res = await withAuth(handler)(
+      request('POST', { origin: 'http://localhost:3000' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalled();
+  });
+
+  it('allows a cross-origin GET, which cannot change state', async () => {
+    const res = await withAuth(handler)(
+      request('GET', { origin: 'https://evil.example' })
+    );
+
+    expect(res.status).toBe(200);
+    expect(handler).toHaveBeenCalled();
+  });
+});

--- a/tests/lib/shared-secret.test.ts
+++ b/tests/lib/shared-secret.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { hasValidBearerSecret, secretsMatch } from '@/lib/shared-secret';
+
+function req(authorization?: string) {
+  return new Request('http://localhost:3000/api/cron/example', {
+    headers: authorization ? { authorization } : {},
+  });
+}
+
+describe('secretsMatch', () => {
+  it('accepts identical secrets', () => {
+    expect(secretsMatch('a-long-shared-secret', 'a-long-shared-secret')).toBe(true);
+  });
+
+  it('rejects different secrets of the same length', () => {
+    expect(secretsMatch('aaaaaaaaaaaaaaaa', 'bbbbbbbbbbbbbbbb')).toBe(false);
+  });
+
+  it('rejects secrets of different lengths without throwing', () => {
+    expect(secretsMatch('short', 'a-much-longer-secret')).toBe(false);
+  });
+
+  it('handles multi-byte characters', () => {
+    expect(secretsMatch('sécret-ñ', 'sécret-ñ')).toBe(true);
+    expect(secretsMatch('sécret-ñ', 'secret-n')).toBe(false);
+  });
+});
+
+describe('hasValidBearerSecret', () => {
+  const secret = 'cron-secret-at-least-16';
+
+  it('accepts a matching bearer token', () => {
+    expect(hasValidBearerSecret(req(`Bearer ${secret}`), secret)).toBe(true);
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(hasValidBearerSecret(req(`bearer ${secret}`), secret)).toBe(true);
+  });
+
+  it('rejects a wrong token', () => {
+    expect(hasValidBearerSecret(req('Bearer nope'), secret)).toBe(false);
+  });
+
+  it('rejects a missing header', () => {
+    expect(hasValidBearerSecret(req(), secret)).toBe(false);
+  });
+
+  it('rejects a malformed header', () => {
+    expect(hasValidBearerSecret(req(secret), secret)).toBe(false);
+    expect(hasValidBearerSecret(req('Basic dXNlcjpwYXNz'), secret)).toBe(false);
+  });
+
+  it('fails closed when no secret is configured', () => {
+    // Without this guard a template literal would compare against the string
+    // "Bearer undefined", which a caller could simply send.
+    expect(hasValidBearerSecret(req('Bearer undefined'), undefined)).toBe(false);
+    expect(hasValidBearerSecret(req('Bearer '), '')).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes a CSRF gap across the authenticated API surface, plus three unauthenticated endpoints that were leaking or unbounded.

## The CSRF gap

`withAuth` is the only place that runs the same-origin check (`validateOrigin`). Twelve routes resolved the session themselves with a bare `await auth()`, so they were authenticated but unprotected: a cross-site request carrying the victim's session cookie was accepted.

| Route | Methods |
| --- | --- |
| `carddav/connection` | POST, PUT, DELETE |
| `carddav/connection/test` | POST |
| `carddav/sync`, `import`, `export-bulk`, `discover`, `backup` | POST |
| `carddav/pending-count` | GET |
| `carddav/conflicts/[id]/resolve` | POST |
| `vcard/upload`, `vcard/import` | POST |
| `user/language` | PUT |

`carddav/connection/test` and `carddav/backup` were the sharpest of these: both accept a server URL plus credentials in the request body and dial that host.

All twelve now go through `withAuth`. Connection management, connection test, and backup are additionally marked `allowApiToken: false`, matching the precedent already set for token management and billing: an API token should not be able to read or replace stored CardDAV credentials, nor aim an outbound request at a host of its choosing.

### Keeping it closed

`tests/api/route-auth-invariants.test.ts` fails if any route under `app/api` calls `auth()` or imports it from `lib/auth`. Routes that are intentionally unauthenticated (NextAuth handlers, cron, the Stripe webhook, health, version) never call `auth()` at all, so the rule needs no allowlist and cannot rot into one.

`tests/lib/api-utils.csrf.test.ts` covers the mechanism itself: cross-origin POST/PUT/PATCH/DELETE rejected, Referer-only cross-origin rejected, same-origin allowed, cross-origin GET allowed. Worth noting that this file passed on the first run before any route was touched, which confirmed the check was working and the problem was purely non-adoption.

## Three open endpoints

**`/api/health`** returned the raw Prisma error on its 503 path. Those messages quote the database host and port, and sometimes the user. The endpoint is unauthenticated so orchestrators can reach it, so the error now goes to the log and the caller only learns the check failed.

**`/api/log-error`** was unauthenticated, unrate-limited, and unbounded. It read `request.json()` directly and logged whatever fields arrived, so anyone could write arbitrary structures into the error log indefinitely. It now caps the body at 64KB, accepts each field only if it is a string, truncates per field, and rate limits reports per IP (60 per 5 minutes, enough for a genuinely broken page to report itself).

**`/api/dev/clear-rate-limits`** was authorized by:

```js
process.env.NODE_ENV !== 'production' || authHeader === `Bearer ${cronSecret}`
```

That fails open. The standalone build is started with `node server.js`, which does not set `NODE_ENV`, so a self-hosted deployment that did not set it explicitly exposed unauthenticated rate-limit clearing. The bearer secret is now required in every environment. The response also no longer echoes the matched keys (they embed client IPs and, for login and password reset, the attempted email address) or the raw Redis error. The official Docker image sets `NODE_ENV=production`, so image-based deployments were never affected.

## Incidental

- The four cron routes each compared the secret with `!==` against a template literal. They now share `lib/shared-secret.ts`, which compares in constant time and fails closed when no secret is configured instead of accepting the literal string `Bearer undefined`.
- `/api/user/language` hardcoded the locale list in its error message and had drifted; it now derives from `SUPPORTED_LOCALES`. The OpenAPI spec for that route had drifted the same way (missing four locales) and gained its missing `400`.

## Test changes worth a look

- `carddav-import-limits` and `vcard-import-limits` stubbed out all of `lib/api-utils` with a pass-through `withLogging`. They now leave it real, so they exercise the actual `withAuth`.
- `user-language.test.ts` asserted `500` for malformed JSON. That was documenting a bug: `parseRequestBody` correctly classifies it as `400`. The test now asserts `400` and says why.

## Verification

`npm run lint`, `npm run typecheck`, `npx vitest run` (2559 passed, 16 skipped), `npm run build` (exit 0), and `cd docs && npm run build` all pass.

No behavior change for the browser UI: every converted route is already called same-origin from the app.
