### PR TITLE
refactor: share one deleted-aware Prisma client, page GET /api/people

### DIFF
--- a/app/api/carddav/import/route.ts
+++ b/app/api/carddav/import/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { prisma, withDeleted } from '@/lib/prisma';
+import { prisma, prismaIncludingDeleted } from '@/lib/prisma';
 import { vCardToPerson } from '@/lib/carddav/vcard-import';
 import { parseVCard } from '@/lib/carddav/vcard-parser';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
@@ -132,22 +132,17 @@ export const POST = withAuth(async (request, session) => {
         : []
     );
 
-    // Use withDeleted() to bypass soft-delete filtering and find soft-deleted records
-    const rawClient = withDeleted();
-    let softDeletedPersons: Awaited<ReturnType<typeof rawClient.person.findMany>> = [];
-    try {
-      softDeletedPersons = allUIDs.length > 0
-        ? await rawClient.person.findMany({
-            where: {
-              uid: { in: allUIDs },
-              userId: session.user.id,
-              deletedAt: { not: null },
-            },
-          })
-        : [];
-    } finally {
-      await rawClient.$disconnect();
-    }
+    // Bypass soft-delete filtering so a previously deleted contact can be
+    // matched by UID and restored instead of duplicated.
+    const softDeletedPersons = allUIDs.length > 0
+      ? await prismaIncludingDeleted.person.findMany({
+          where: {
+            uid: { in: allUIDs },
+            userId: session.user.id,
+            deletedAt: { not: null },
+          },
+        })
+      : [];
 
     // Create a Map for O(1) lookup during import
     const softDeletedMap = new Map(

--- a/app/api/cron/purge-deleted/route.ts
+++ b/app/api/cron/purge-deleted/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { withDeleted, prisma } from '@/lib/prisma';
+import { prismaIncludingDeleted, prisma } from '@/lib/prisma';
 import { env } from '@/lib/env';
 import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
@@ -11,7 +11,6 @@ const RETENTION_DAYS = 30;
 // GET /api/cron/purge-deleted - Permanently delete records older than retention period
 // This endpoint should be called by a cron job daily
 export const GET = withLogging(async function GET(request: Request) {
-  const prismaWithDeleted = withDeleted();
   const startTime = Date.now();
   let cronLogId: string | null = null;
 
@@ -48,7 +47,7 @@ export const GET = withLogging(async function GET(request: Request) {
     };
 
     // 1. Purge ImportantDates that are soft-deleted past retention
-    const importantDatesResult = await prismaWithDeleted.importantDate.deleteMany({
+    const importantDatesResult = await prismaIncludingDeleted.importantDate.deleteMany({
       where: {
         deletedAt: { not: null, lt: cutoffDate },
       },
@@ -56,7 +55,7 @@ export const GET = withLogging(async function GET(request: Request) {
     purged.importantDates = importantDatesResult.count;
 
     // 2. Get IDs of persons to be purged (for cleaning up related data)
-    const personsToDelete = await prismaWithDeleted.person.findMany({
+    const personsToDelete = await prismaIncludingDeleted.person.findMany({
       where: { deletedAt: { not: null, lt: cutoffDate } },
       select: { id: true, userId: true },
     });
@@ -69,20 +68,20 @@ export const GET = withLogging(async function GET(request: Request) {
 
     // 3. Delete PersonGroups for persons being purged
     if (personIds.length > 0) {
-      const personGroupsResult = await prismaWithDeleted.personGroup.deleteMany({
+      const personGroupsResult = await prismaIncludingDeleted.personGroup.deleteMany({
         where: { personId: { in: personIds } },
       });
       purged.personGroups += personGroupsResult.count;
 
       // Also delete ImportantDates for persons being purged (even if not soft-deleted)
-      const orphanedDatesResult = await prismaWithDeleted.importantDate.deleteMany({
+      const orphanedDatesResult = await prismaIncludingDeleted.importantDate.deleteMany({
         where: { personId: { in: personIds } },
       });
       purged.importantDates += orphanedDatesResult.count;
     }
 
     // 4. Purge Relationships that are soft-deleted past retention
-    const relationshipsResult = await prismaWithDeleted.relationship.deleteMany({
+    const relationshipsResult = await prismaIncludingDeleted.relationship.deleteMany({
       where: {
         deletedAt: { not: null, lt: cutoffDate },
       },
@@ -91,7 +90,7 @@ export const GET = withLogging(async function GET(request: Request) {
 
     // Also delete relationships where either person is being purged
     if (personIds.length > 0) {
-      const orphanedRelationshipsResult = await prismaWithDeleted.relationship.deleteMany({
+      const orphanedRelationshipsResult = await prismaIncludingDeleted.relationship.deleteMany({
         where: {
           OR: [
             { personId: { in: personIds } },
@@ -103,7 +102,7 @@ export const GET = withLogging(async function GET(request: Request) {
     }
 
     // 5. Get IDs of groups to be purged
-    const groupsToDelete = await prismaWithDeleted.group.findMany({
+    const groupsToDelete = await prismaIncludingDeleted.group.findMany({
       where: { deletedAt: { not: null, lt: cutoffDate } },
       select: { id: true },
     });
@@ -111,14 +110,14 @@ export const GET = withLogging(async function GET(request: Request) {
 
     // Delete PersonGroups for groups being purged
     if (groupIds.length > 0) {
-      const groupPersonGroupsResult = await prismaWithDeleted.personGroup.deleteMany({
+      const groupPersonGroupsResult = await prismaIncludingDeleted.personGroup.deleteMany({
         where: { groupId: { in: groupIds } },
       });
       purged.personGroups += groupPersonGroupsResult.count;
     }
 
     // 6. Purge Groups that are soft-deleted past retention
-    const groupsResult = await prismaWithDeleted.group.deleteMany({
+    const groupsResult = await prismaIncludingDeleted.group.deleteMany({
       where: {
         deletedAt: { not: null, lt: cutoffDate },
       },
@@ -126,7 +125,7 @@ export const GET = withLogging(async function GET(request: Request) {
     purged.groups = groupsResult.count;
 
     // 7. Get IDs of relationship types to be purged
-    const relationshipTypesToDelete = await prismaWithDeleted.relationshipType.findMany({
+    const relationshipTypesToDelete = await prismaIncludingDeleted.relationshipType.findMany({
       where: { deletedAt: { not: null, lt: cutoffDate } },
       select: { id: true },
     });
@@ -134,26 +133,26 @@ export const GET = withLogging(async function GET(request: Request) {
 
     if (relationshipTypeIds.length > 0) {
       // Clear relationshipToUserId references to deleted types
-      await prismaWithDeleted.person.updateMany({
+      await prismaIncludingDeleted.person.updateMany({
         where: { relationshipToUserId: { in: relationshipTypeIds } },
         data: { relationshipToUserId: null },
       });
 
       // Clear relationship references to deleted types
-      await prismaWithDeleted.relationship.updateMany({
+      await prismaIncludingDeleted.relationship.updateMany({
         where: { relationshipTypeId: { in: relationshipTypeIds } },
         data: { relationshipTypeId: null },
       });
 
       // Clear inverse references
-      await prismaWithDeleted.relationshipType.updateMany({
+      await prismaIncludingDeleted.relationshipType.updateMany({
         where: { inverseId: { in: relationshipTypeIds } },
         data: { inverseId: null },
       });
     }
 
     // 8. Purge RelationshipTypes that are soft-deleted past retention
-    const relationshipTypesResult = await prismaWithDeleted.relationshipType.deleteMany({
+    const relationshipTypesResult = await prismaIncludingDeleted.relationshipType.deleteMany({
       where: {
         deletedAt: { not: null, lt: cutoffDate },
       },
@@ -161,7 +160,7 @@ export const GET = withLogging(async function GET(request: Request) {
     purged.relationshipTypes = relationshipTypesResult.count;
 
     // 9. Finally purge Persons that are soft-deleted past retention
-    const peopleResult = await prismaWithDeleted.person.deleteMany({
+    const peopleResult = await prismaIncludingDeleted.person.deleteMany({
       where: {
         deletedAt: { not: null, lt: cutoffDate },
       },
@@ -206,7 +205,5 @@ export const GET = withLogging(async function GET(request: Request) {
       });
     }
     return handleApiError(error, 'cron-purge-deleted');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/deleted/route.ts
+++ b/app/api/deleted/route.ts
@@ -1,12 +1,10 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 const RETENTION_DAYS = 30;
 
 // GET /api/deleted - List soft-deleted items by type
 export const GET = withAuth(async (request, session) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { searchParams } = new URL(request.url);
     const type = searchParams.get('type');
@@ -19,7 +17,7 @@ export const GET = withAuth(async (request, session) => {
 
     switch (type) {
       case 'people':
-        deleted = await prismaWithDeleted.person.findMany({
+        deleted = await prismaIncludingDeleted.person.findMany({
           where: {
             userId: session.user.id,
             deletedAt: { not: null, gte: cutoffDate },
@@ -37,7 +35,7 @@ export const GET = withAuth(async (request, session) => {
         break;
 
       case 'groups':
-        deleted = await prismaWithDeleted.group.findMany({
+        deleted = await prismaIncludingDeleted.group.findMany({
           where: {
             userId: session.user.id,
             deletedAt: { not: null, gte: cutoffDate },
@@ -54,7 +52,7 @@ export const GET = withAuth(async (request, session) => {
         break;
 
       case 'relationships':
-        deleted = await prismaWithDeleted.relationship.findMany({
+        deleted = await prismaIncludingDeleted.relationship.findMany({
           where: {
             person: { userId: session.user.id },
             deletedAt: { not: null, gte: cutoffDate },
@@ -77,7 +75,7 @@ export const GET = withAuth(async (request, session) => {
         break;
 
       case 'relationshipTypes':
-        deleted = await prismaWithDeleted.relationshipType.findMany({
+        deleted = await prismaIncludingDeleted.relationshipType.findMany({
           where: {
             userId: session.user.id,
             deletedAt: { not: null, gte: cutoffDate },
@@ -94,7 +92,7 @@ export const GET = withAuth(async (request, session) => {
         break;
 
       case 'importantDates':
-        deleted = await prismaWithDeleted.importantDate.findMany({
+        deleted = await prismaIncludingDeleted.importantDate.findMany({
           where: {
             person: { userId: session.user.id },
             deletedAt: { not: null, gte: cutoffDate },
@@ -125,7 +123,5 @@ export const GET = withAuth(async (request, session) => {
     });
   } catch (error) {
     return handleApiError(error, 'deleted-list');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/groups/[id]/permanent/route.ts
+++ b/app/api/groups/[id]/permanent/route.ts
@@ -1,14 +1,12 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // DELETE /api/groups/[id]/permanent - Permanently delete a trashed group
 export const DELETE = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
-    const group = await prismaWithDeleted.group.findUnique({
+    const group = await prismaIncludingDeleted.group.findUnique({
       where: { id, userId: session.user.id },
     });
 
@@ -21,15 +19,13 @@ export const DELETE = withAuth(async (_request, session, context) => {
     }
 
     // Delete memberships first
-    await prismaWithDeleted.personGroup.deleteMany({ where: { groupId: id } });
+    await prismaIncludingDeleted.personGroup.deleteMany({ where: { groupId: id } });
 
     // Delete the group
-    await prismaWithDeleted.group.delete({ where: { id } });
+    await prismaIncludingDeleted.group.delete({ where: { id } });
 
     return apiResponse.ok({ success: true });
   } catch (error) {
     return handleApiError(error, 'groups-permanent-delete');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/groups/[id]/restore/route.ts
+++ b/app/api/groups/[id]/restore/route.ts
@@ -1,4 +1,4 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 import { syncGroupMembersToCardDav } from '@/lib/carddav/group-sync';
 import { createModuleLogger } from '@/lib/logger';
@@ -7,13 +7,11 @@ const log = createModuleLogger('groups');
 
 // POST /api/groups/[id]/restore - Restore a soft-deleted group
 export const POST = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
     // Find the soft-deleted group (using raw client to bypass soft-delete filter)
-    const group = await prismaWithDeleted.group.findUnique({
+    const group = await prismaIncludingDeleted.group.findUnique({
       where: {
         id,
         userId: session.user.id,
@@ -29,7 +27,7 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Restore the group by clearing deletedAt
-    const restored = await prismaWithDeleted.group.update({
+    const restored = await prismaIncludingDeleted.group.update({
       where: { id },
       data: { deletedAt: null },
     });
@@ -42,7 +40,5 @@ export const POST = withAuth(async (_request, session, context) => {
     return apiResponse.ok({ group: restored });
   } catch (error) {
     return handleApiError(error, 'groups-restore');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/people/[id]/important-dates/[dateId]/permanent/route.ts
+++ b/app/api/people/[id]/important-dates/[dateId]/permanent/route.ts
@@ -1,14 +1,12 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // DELETE /api/people/[id]/important-dates/[dateId]/permanent - Permanently delete a trashed important date
 export const DELETE = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id, dateId } = await context.params;
 
-    const person = await prismaWithDeleted.person.findUnique({
+    const person = await prismaIncludingDeleted.person.findUnique({
       where: { id, userId: session.user.id },
     });
 
@@ -16,7 +14,7 @@ export const DELETE = withAuth(async (_request, session, context) => {
       return apiResponse.notFound('Person not found');
     }
 
-    const importantDate = await prismaWithDeleted.importantDate.findUnique({
+    const importantDate = await prismaIncludingDeleted.importantDate.findUnique({
       where: { id: dateId, personId: id },
     });
 
@@ -28,12 +26,10 @@ export const DELETE = withAuth(async (_request, session, context) => {
       return apiResponse.error('Important date is not deleted');
     }
 
-    await prismaWithDeleted.importantDate.delete({ where: { id: dateId } });
+    await prismaIncludingDeleted.importantDate.delete({ where: { id: dateId } });
 
     return apiResponse.ok({ success: true });
   } catch (error) {
     return handleApiError(error, 'important-dates-permanent-delete');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/people/[id]/important-dates/[dateId]/restore/route.ts
+++ b/app/api/people/[id]/important-dates/[dateId]/restore/route.ts
@@ -1,15 +1,13 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // POST /api/people/[id]/important-dates/[dateId]/restore - Restore a soft-deleted important date
 export const POST = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id, dateId } = await context.params;
 
     // Check if person exists and belongs to user
-    const person = await prismaWithDeleted.person.findUnique({
+    const person = await prismaIncludingDeleted.person.findUnique({
       where: {
         id,
         userId: session.user.id,
@@ -21,7 +19,7 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Find the soft-deleted important date (using raw client to bypass soft-delete filter)
-    const importantDate = await prismaWithDeleted.importantDate.findUnique({
+    const importantDate = await prismaIncludingDeleted.importantDate.findUnique({
       where: {
         id: dateId,
         personId: id,
@@ -38,7 +36,7 @@ export const POST = withAuth(async (_request, session, context) => {
 
     // Check for uniqueness conflict with predefined types
     if (importantDate.type) {
-      const existing = await prismaWithDeleted.importantDate.findFirst({
+      const existing = await prismaIncludingDeleted.importantDate.findFirst({
         where: {
           personId: id,
           type: importantDate.type,
@@ -53,7 +51,7 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Restore the important date by clearing deletedAt
-    const restored = await prismaWithDeleted.importantDate.update({
+    const restored = await prismaIncludingDeleted.importantDate.update({
       where: { id: dateId },
       data: { deletedAt: null },
     });
@@ -61,7 +59,5 @@ export const POST = withAuth(async (_request, session, context) => {
     return apiResponse.ok({ importantDate: restored });
   } catch (error) {
     return handleApiError(error, 'important-date-restore');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/people/[id]/permanent/route.ts
+++ b/app/api/people/[id]/permanent/route.ts
@@ -1,15 +1,13 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 import { deletePersonPhotos } from '@/lib/photo-storage';
 
 // DELETE /api/people/[id]/permanent - Permanently delete a trashed person
 export const DELETE = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
-    const person = await prismaWithDeleted.person.findUnique({
+    const person = await prismaIncludingDeleted.person.findUnique({
       where: { id, userId: session.user.id },
     });
 
@@ -25,32 +23,30 @@ export const DELETE = withAuth(async (_request, session, context) => {
     await deletePersonPhotos(session.user.id, id);
 
     // Delete child records in FK order
-    await prismaWithDeleted.journalEntryPerson.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.duplicateDismissal.deleteMany({
+    await prismaIncludingDeleted.journalEntryPerson.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.duplicateDismissal.deleteMany({
       where: { OR: [{ personAId: id }, { personBId: id }] },
     });
-    await prismaWithDeleted.cardDavMapping.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personCustomFieldValue.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personCustomField.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personLocation.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personIM.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personUrl.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personAddress.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personEmail.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.personPhone.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.importantDate.deleteMany({ where: { personId: id } });
-    await prismaWithDeleted.relationship.deleteMany({
+    await prismaIncludingDeleted.cardDavMapping.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personCustomFieldValue.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personCustomField.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personLocation.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personIM.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personUrl.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personAddress.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personEmail.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personPhone.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.importantDate.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.relationship.deleteMany({
       where: { OR: [{ personId: id }, { relatedPersonId: id }] },
     });
-    await prismaWithDeleted.personGroup.deleteMany({ where: { personId: id } });
+    await prismaIncludingDeleted.personGroup.deleteMany({ where: { personId: id } });
 
     // Delete the person
-    await prismaWithDeleted.person.delete({ where: { id } });
+    await prismaIncludingDeleted.person.delete({ where: { id } });
 
     return apiResponse.ok({ success: true });
   } catch (error) {
     return handleApiError(error, 'people-permanent-delete');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/people/[id]/restore/route.ts
+++ b/app/api/people/[id]/restore/route.ts
@@ -1,15 +1,13 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // POST /api/people/[id]/restore - Restore a soft-deleted person
 export const POST = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
     // Find the soft-deleted person (using raw client to bypass soft-delete filter)
-    const person = await prismaWithDeleted.person.findUnique({
+    const person = await prismaIncludingDeleted.person.findUnique({
       where: {
         id,
         userId: session.user.id,
@@ -25,7 +23,7 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Restore the person by clearing deletedAt
-    const restored = await prismaWithDeleted.person.update({
+    const restored = await prismaIncludingDeleted.person.update({
       where: { id },
       data: { deletedAt: null },
     });
@@ -33,7 +31,5 @@ export const POST = withAuth(async (_request, session, context) => {
     return apiResponse.ok({ person: restored });
   } catch (error) {
     return handleApiError(error, 'people-restore');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/people/route.ts
+++ b/app/api/people/route.ts
@@ -5,8 +5,20 @@ import { canCreateResource, canEnableReminder } from '@/lib/billing';
 import { savePhoto } from '@/lib/photo-storage';
 import { createPerson } from '@/lib/services/person';
 import { applyCustomFieldValues, validateCustomFieldValues, CustomFieldValidationError } from '@/lib/customFields/persistence';
+import { DEFAULT_PEOPLE_PAGE_SIZE, MAX_PEOPLE_PAGE_SIZE } from '@/lib/constants';
 
-// GET /api/people - List all people for the current user
+/**
+ * Parse a non-negative integer query param. Returns `undefined` when absent and
+ * `null` when present but not a valid non-negative integer, so the caller can
+ * tell "not asked for" from "asked for nonsense".
+ */
+function parseNonNegativeInt(raw: string | null): number | null | undefined {
+  if (raw === null) return undefined;
+  if (!/^\d+$/.test(raw)) return null;
+  return Number.parseInt(raw, 10);
+}
+
+// GET /api/people - List people for the current user, one page at a time
 export const GET = withAuth(async (request, session) => {
   try {
     const { searchParams } = new URL(request.url);
@@ -15,6 +27,26 @@ export const GET = withAuth(async (request, session) => {
     // When includeDetails=false, skip multi-value relations (phones, emails, etc.)
     // for lighter list-view responses. Defaults to true for backward compatibility.
     const includeDetails = searchParams.get('includeDetails') !== 'false';
+
+    const requestedLimit = parseNonNegativeInt(searchParams.get('limit'));
+    if (requestedLimit === null || requestedLimit === 0) {
+      return apiResponse.error('limit must be a positive integer');
+    }
+
+    const requestedOffset = parseNonNegativeInt(searchParams.get('offset'));
+    if (requestedOffset === null) {
+      return apiResponse.error('offset must be a non-negative integer');
+    }
+
+    // An export must be complete, so includeAll opts out of the default page
+    // size. An explicit limit still applies, and the cap always applies.
+    const limit =
+      requestedLimit !== undefined
+        ? Math.min(requestedLimit, MAX_PEOPLE_PAGE_SIZE)
+        : includeAll
+          ? undefined
+          : DEFAULT_PEOPLE_PAGE_SIZE;
+    const offset = requestedOffset ?? 0;
 
     // Build where clause
     const where: { userId: string; deletedAt: null; groups?: { some: { groupId: { in: string[] } } } } = {
@@ -84,9 +116,26 @@ export const GET = withAuth(async (request, session) => {
       orderBy: {
         name: 'asc',
       },
+      ...(limit !== undefined && { take: limit, skip: offset }),
     });
 
-    return apiResponse.ok({ people });
+    if (limit === undefined) {
+      return apiResponse.ok({ people });
+    }
+
+    // Counted over the same `where` as the page, so the total and hasMore
+    // describe the set the caller is actually walking.
+    const total = await prisma.person.count({ where });
+
+    return apiResponse.ok({
+      people,
+      pagination: {
+        total,
+        limit,
+        offset,
+        hasMore: offset + people.length < total,
+      },
+    });
   } catch (error) {
     return handleApiError(error, 'people-list');
   }

--- a/app/api/relationship-types/[id]/permanent/route.ts
+++ b/app/api/relationship-types/[id]/permanent/route.ts
@@ -1,14 +1,12 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // DELETE /api/relationship-types/[id]/permanent - Permanently delete a trashed relationship type
 export const DELETE = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
-    const relationshipType = await prismaWithDeleted.relationshipType.findFirst({
+    const relationshipType = await prismaIncludingDeleted.relationshipType.findFirst({
       where: { id, userId: session.user.id },
     });
 
@@ -21,25 +19,23 @@ export const DELETE = withAuth(async (_request, session, context) => {
     }
 
     // Clear references before deleting
-    await prismaWithDeleted.person.updateMany({
+    await prismaIncludingDeleted.person.updateMany({
       where: { relationshipToUserId: id },
       data: { relationshipToUserId: null },
     });
-    await prismaWithDeleted.relationship.updateMany({
+    await prismaIncludingDeleted.relationship.updateMany({
       where: { relationshipTypeId: id },
       data: { relationshipTypeId: null },
     });
-    await prismaWithDeleted.relationshipType.updateMany({
+    await prismaIncludingDeleted.relationshipType.updateMany({
       where: { inverseId: id },
       data: { inverseId: null },
     });
 
-    await prismaWithDeleted.relationshipType.delete({ where: { id } });
+    await prismaIncludingDeleted.relationshipType.delete({ where: { id } });
 
     return apiResponse.ok({ success: true });
   } catch (error) {
     return handleApiError(error, 'relationship-types-permanent-delete');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/relationship-types/[id]/restore/route.ts
+++ b/app/api/relationship-types/[id]/restore/route.ts
@@ -1,15 +1,13 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // POST /api/relationship-types/[id]/restore - Restore a soft-deleted relationship type
 export const POST = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
     // Find the soft-deleted relationship type (using raw client to bypass soft-delete filter)
-    const relationshipType = await prismaWithDeleted.relationshipType.findFirst({
+    const relationshipType = await prismaIncludingDeleted.relationshipType.findFirst({
       where: {
         id,
         userId: session.user.id,
@@ -25,7 +23,7 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Restore the relationship type by clearing deletedAt
-    const restored = await prismaWithDeleted.relationshipType.update({
+    const restored = await prismaIncludingDeleted.relationshipType.update({
       where: { id },
       data: { deletedAt: null },
     });
@@ -33,7 +31,5 @@ export const POST = withAuth(async (_request, session, context) => {
     return apiResponse.ok({ relationshipType: restored });
   } catch (error) {
     return handleApiError(error, 'relationship-types-restore');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/relationships/[id]/permanent/route.ts
+++ b/app/api/relationships/[id]/permanent/route.ts
@@ -1,14 +1,12 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // DELETE /api/relationships/[id]/permanent - Permanently delete a trashed relationship
 export const DELETE = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
-    const relationship = await prismaWithDeleted.relationship.findUnique({
+    const relationship = await prismaIncludingDeleted.relationship.findUnique({
       where: { id },
       include: { person: true },
     });
@@ -26,7 +24,7 @@ export const DELETE = withAuth(async (_request, session, context) => {
     }
 
     // Delete the inverse relationship if it's also trashed
-    const inverse = await prismaWithDeleted.relationship.findFirst({
+    const inverse = await prismaIncludingDeleted.relationship.findFirst({
       where: {
         personId: relationship.relatedPersonId,
         relatedPersonId: relationship.personId,
@@ -35,15 +33,13 @@ export const DELETE = withAuth(async (_request, session, context) => {
     });
 
     if (inverse) {
-      await prismaWithDeleted.relationship.delete({ where: { id: inverse.id } });
+      await prismaIncludingDeleted.relationship.delete({ where: { id: inverse.id } });
     }
 
-    await prismaWithDeleted.relationship.delete({ where: { id } });
+    await prismaIncludingDeleted.relationship.delete({ where: { id } });
 
     return apiResponse.ok({ success: true });
   } catch (error) {
     return handleApiError(error, 'relationships-permanent-delete');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/app/api/relationships/[id]/restore/route.ts
+++ b/app/api/relationships/[id]/restore/route.ts
@@ -1,15 +1,13 @@
-import { withDeleted } from '@/lib/prisma';
+import { prismaIncludingDeleted } from '@/lib/prisma';
 import { apiResponse, handleApiError, withAuth } from '@/lib/api-utils';
 
 // POST /api/relationships/[id]/restore - Restore a soft-deleted relationship
 export const POST = withAuth(async (_request, session, context) => {
-  const prismaWithDeleted = withDeleted();
-
   try {
     const { id } = await context.params;
 
     // Find the soft-deleted relationship (using raw client to bypass soft-delete filter)
-    const relationship = await prismaWithDeleted.relationship.findUnique({
+    const relationship = await prismaIncludingDeleted.relationship.findUnique({
       where: { id },
       include: {
         person: true,
@@ -30,13 +28,13 @@ export const POST = withAuth(async (_request, session, context) => {
     }
 
     // Restore the relationship by clearing deletedAt
-    const restored = await prismaWithDeleted.relationship.update({
+    const restored = await prismaIncludingDeleted.relationship.update({
       where: { id },
       data: { deletedAt: null },
     });
 
     // Also restore the inverse relationship if it exists and was deleted at the same time
-    const inverse = await prismaWithDeleted.relationship.findFirst({
+    const inverse = await prismaIncludingDeleted.relationship.findFirst({
       where: {
         personId: relationship.relatedPersonId,
         relatedPersonId: relationship.personId,
@@ -45,7 +43,7 @@ export const POST = withAuth(async (_request, session, context) => {
     });
 
     if (inverse) {
-      await prismaWithDeleted.relationship.update({
+      await prismaIncludingDeleted.relationship.update({
         where: { id: inverse.id },
         data: { deletedAt: null },
       });
@@ -54,7 +52,5 @@ export const POST = withAuth(async (_request, session, context) => {
     return apiResponse.ok({ relationship: restored });
   } catch (error) {
     return handleApiError(error, 'relationships-restore');
-  } finally {
-    await prismaWithDeleted.$disconnect();
   }
 });

--- a/docs/src/content/docs/api/people.md
+++ b/docs/src/content/docs/api/people.md
@@ -15,24 +15,55 @@ All endpoints on this page require authentication (session cookie or API token) 
 GET /api/people
 ```
 
-Returns all people for the authenticated user, sorted alphabetically by name.
+Returns a page of people for the authenticated user, sorted alphabetically by name.
 
 **Query parameters**
 
 | Parameter | Type | Description |
 | --- | --- | --- |
+| `limit` | integer | Page size. Defaults to `100`, capped at `500`. Must be a positive integer. |
+| `offset` | integer | People to skip before the page starts. Defaults to `0`. |
 | `groupIds` | string | Comma-separated group IDs. Only people belonging to at least one of these groups are returned. |
 | `includeDetails` | boolean | Defaults to `true`. Set to `false` to skip multi-value fields (phones, emails, addresses, URLs, IM handles, locations, custom fields) for a lighter list-view payload. |
-| `includeAll` | boolean | Set to `true` to also include important dates, person-to-person relationships, and typed custom field values. Used by data export. |
+| `includeAll` | boolean | Set to `true` to also include important dates, person-to-person relationships, and typed custom field values. Used by data export. Also returns every person rather than a page, so an export is never truncated. |
 
 ```bash
-curl https://your-instance.example.com/api/people?includeDetails=false \
+curl "https://your-instance.example.com/api/people?limit=50&offset=0" \
   -H "Authorization: Bearer ntag_xxx"
 ```
 
 ```json
-{ "people": [ { "id": "clx1", "name": "Ada", "surname": "Lovelace" } ] }
+{
+  "people": [ { "id": "clx1", "name": "Ada", "surname": "Lovelace" } ],
+  "pagination": { "total": 214, "limit": 50, "offset": 0, "hasMore": true }
+}
 ```
+
+### Paging through everyone
+
+`total` counts the people matching your filter, ignoring the page. Keep requesting while `hasMore` is `true`, advancing `offset` by your `limit`:
+
+```bash
+offset=0
+while :; do
+  page=$(curl -s "https://your-instance.example.com/api/people?limit=100&offset=$offset" \
+    -H "Authorization: Bearer ntag_xxx")
+  echo "$page" | jq -r '.people[].name'
+  [ "$(echo "$page" | jq -r '.pagination.hasMore')" = "true" ] || break
+  offset=$((offset + 100))
+done
+```
+
+Because the sort is by name, adding or renaming a person between requests can shift rows across page boundaries. For a consistent snapshot of everything at once, use `includeAll=true`, which returns the full set and omits `pagination`.
+
+### Technical details
+
+| Limit | Value |
+| --- | --- |
+| Default page size | 100 |
+| Maximum page size | 500 |
+| Response without `limit` | First 100 people, plus a `pagination` object |
+| Response with `includeAll=true` | Every person, no `pagination` object |
 
 ## Create a person
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -4,6 +4,16 @@
  */
 
 /**
+ * Page size applied to GET /api/people when the caller does not pass `limit`.
+ * The endpoint joins every multi-value relation per person, so an unbounded
+ * response grows quickly for a large address book.
+ */
+export const DEFAULT_PEOPLE_PAGE_SIZE = 100;
+
+/** Upper bound on `limit` for GET /api/people, whatever the caller asks for. */
+export const MAX_PEOPLE_PAGE_SIZE = 500;
+
+/**
  * Security-related constants
  */
 export const SECURITY = {

--- a/lib/openapi/people.ts
+++ b/lib/openapi/people.ts
@@ -4,22 +4,72 @@ import {
   mergePersonSchema,
 } from '../validations';
 import { zodBody, jsonBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refGraph, refSuccess, resp } from './helpers';
+import { DEFAULT_PEOPLE_PAGE_SIZE, MAX_PEOPLE_PAGE_SIZE } from '../constants';
 
 export function peoplePaths(): Record<string, Record<string, unknown>> {
   return {
     '/api/people': {
       get: {
         tags: ['People'],
-        summary: 'List all people',
-        description: 'Returns all people belonging to the authenticated user, sorted alphabetically by name. Includes relationship-to-user info and group memberships.',
+        summary: 'List people',
+        description:
+          'Returns a page of people belonging to the authenticated user, sorted alphabetically by name. ' +
+          `Defaults to ${DEFAULT_PEOPLE_PAGE_SIZE} per page; pass \`limit\` and \`offset\` to walk the rest. ` +
+          'Includes relationship-to-user info and group memberships.',
         security: [{ session: [] }],
+        parameters: [
+          {
+            name: 'limit',
+            in: 'query',
+            schema: { type: 'integer', minimum: 1, maximum: MAX_PEOPLE_PAGE_SIZE, default: DEFAULT_PEOPLE_PAGE_SIZE },
+            description: `Page size. Values above ${MAX_PEOPLE_PAGE_SIZE} are capped.`,
+          },
+          {
+            name: 'offset',
+            in: 'query',
+            schema: { type: 'integer', minimum: 0, default: 0 },
+            description: 'Number of people to skip before the page starts.',
+          },
+          {
+            name: 'groupIds',
+            in: 'query',
+            schema: { type: 'string' },
+            description: 'Comma-separated group IDs. Only people in at least one of them are returned.',
+          },
+          {
+            name: 'includeDetails',
+            in: 'query',
+            schema: { type: 'boolean', default: true },
+            description: 'Set to false to omit multi-value fields (phones, emails, addresses) for a lighter response.',
+          },
+          {
+            name: 'includeAll',
+            in: 'query',
+            schema: { type: 'boolean', default: false },
+            description:
+              'Export mode: adds important dates, relationships, and custom field values, and returns every person ' +
+              'rather than a page (so an export is never silently truncated). The `pagination` object is omitted. ' +
+              'An explicit `limit` still applies.',
+          },
+        ],
         responses: {
-          '200': jsonResponse('List of people', {
+          '200': jsonResponse('Page of people', {
             type: 'object',
             properties: {
               people: { type: 'array', items: { $ref: '#/components/schemas/Person' } },
+              pagination: {
+                type: 'object',
+                description: 'Omitted when includeAll=true is used without an explicit limit.',
+                properties: {
+                  total: { type: 'integer', description: 'People matching the filter, ignoring the page.' },
+                  limit: { type: 'integer' },
+                  offset: { type: 'integer' },
+                  hasMore: { type: 'boolean' },
+                },
+              },
             },
           }),
+          '400': ref400(),
           '401': ref401(),
         },
       },

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -92,6 +92,7 @@ type ExtendedPrismaClient = ReturnType<typeof createExtendedClient>;
 
 const globalForPrisma = globalThis as unknown as {
   prisma: ExtendedPrismaClient | undefined;
+  prismaIncludingDeleted: PrismaClient | undefined;
 };
 
 export const prisma = globalForPrisma.prisma ?? createExtendedClient();
@@ -99,16 +100,23 @@ export const prisma = globalForPrisma.prisma ?? createExtendedClient();
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
 
 /**
- * Returns a raw Prisma client without soft-delete filtering.
- * Use this for:
+ * Prisma client without the soft-delete filter, so queries see soft-deleted
+ * rows. Use it for:
  * - Restore operations (need to find soft-deleted records)
  * - Purge operations (need to permanently delete old records)
- * - Admin/debugging queries
+ * - Trash listings
  *
- * IMPORTANT: Always call .$disconnect() when done to avoid connection leaks.
+ * A shared singleton with its own connection pool, like `prisma`. Callers must
+ * NOT disconnect it: it outlives any single request.
+ *
+ * Every read through this client is unfiltered, so scope it deliberately. Reach
+ * for `prisma` unless the query is specifically about deleted rows.
  */
-export function withDeleted(): PrismaClient {
-  return createBaseClient();
+export const prismaIncludingDeleted: PrismaClient =
+  globalForPrisma.prismaIncludingDeleted ?? createBaseClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prismaIncludingDeleted = prismaIncludingDeleted;
 }
 
 // Graceful shutdown handlers - guarded to prevent duplicate registration during hot reload
@@ -116,7 +124,10 @@ const globalForShutdown = globalThis as unknown as { __prismaShutdownRegistered?
 if (!globalForShutdown.__prismaShutdownRegistered) {
   globalForShutdown.__prismaShutdownRegistered = true;
   const gracefulShutdown = async () => {
-    await prisma.$disconnect();
+    await Promise.allSettled([
+      prisma.$disconnect(),
+      prismaIncludingDeleted.$disconnect(),
+    ]);
     process.exit(0);
   };
   process.on('SIGINT', gracefulShutdown);

--- a/lib/services/person.ts
+++ b/lib/services/person.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 import type { Prisma } from '@prisma/client';
-import { prisma, withDeleted } from '@/lib/prisma';
+import { prisma, prismaIncludingDeleted } from '@/lib/prisma';
 import { createPersonSchema, updatePersonSchema } from '@/lib/validations';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
 import { autoExportPerson, autoUpdatePerson } from '@/lib/carddav/auto-export';
@@ -548,26 +548,20 @@ export async function deletePerson(id: string, userId: string): Promise<string |
  * Returns the restored person's id, or null if not found / not owned.
  */
 export async function restorePerson(id: string, userId: string): Promise<string | null> {
-  const rawPrisma = withDeleted();
+  const existingPerson = await prismaIncludingDeleted.person.findUnique({
+    where: { id, userId },
+  });
 
-  try {
-    const existingPerson = await rawPrisma.person.findUnique({
-      where: { id, userId },
-    });
-
-    if (!existingPerson || existingPerson.deletedAt === null) {
-      return null;
-    }
-
-    await rawPrisma.person.update({
-      where: { id },
-      data: { deletedAt: null },
-    });
-
-    return id;
-  } finally {
-    await rawPrisma.$disconnect();
+  if (!existingPerson || existingPerson.deletedAt === null) {
+    return null;
   }
+
+  await prismaIncludingDeleted.person.update({
+    where: { id },
+    data: { deletedAt: null },
+  });
+
+  return id;
 }
 
 // ---------------------------------------------------------------------------

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -6,9 +6,9 @@ config();
 import * as bcrypt from 'bcryptjs';
 
 async function main() {
-  // Dynamically import prisma after env is loaded
-  const { withDeleted } = await import('../lib/prisma');
-  const prisma = withDeleted();
+  // Dynamically import prisma after env is loaded. The seed wipes and rebuilds
+  // the database, so it uses the client that sees soft-deleted rows too.
+  const { prismaIncludingDeleted: prisma } = await import('../lib/prisma');
   console.log('🌱 Starting database seed...');
 
   // Clear existing data

--- a/tests/api/carddav-import-limits.test.ts
+++ b/tests/api/carddav-import-limits.test.ts
@@ -30,9 +30,8 @@ const mocks = vi.hoisted(() => ({
   personGroupCreateMany: vi.fn(),
   groupFindMany: vi.fn(),
   relationshipTypeFindMany: vi.fn(),
-  // withDeleted mock
-  withDeletedPersonFindMany: vi.fn(),
-  withDeletedDisconnect: vi.fn(),
+  // Client that sees soft-deleted rows
+  deletedAwarePersonFindMany: vi.fn(),
   // Billing mocks
   canCreateResource: vi.fn(),
   getUserUsage: vi.fn(),
@@ -72,12 +71,11 @@ vi.mock('@/lib/prisma', () => ({
       findMany: mocks.relationshipTypeFindMany,
     },
   },
-  withDeleted: () => ({
+  prismaIncludingDeleted: {
     person: {
-      findMany: mocks.withDeletedPersonFindMany,
+      findMany: mocks.deletedAwarePersonFindMany,
     },
-    $disconnect: mocks.withDeletedDisconnect,
-  }),
+  },
 }));
 
 // Mock billing module
@@ -167,8 +165,7 @@ describe('CardDAV Import Tier Limits', () => {
     mocks.personFindMany.mockResolvedValue([]);
 
     // Default: no soft-deleted persons
-    mocks.withDeletedPersonFindMany.mockResolvedValue([]);
-    mocks.withDeletedDisconnect.mockResolvedValue(undefined);
+    mocks.deletedAwarePersonFindMany.mockResolvedValue([]);
 
     // Default: no relationship types
     mocks.relationshipTypeFindMany.mockResolvedValue([]);

--- a/tests/api/people-pagination.test.ts
+++ b/tests/api/people-pagination.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * GET /api/people returned every person the user owns, with every multi-value
+ * relation joined and no upper bound. These tests pin the paging contract.
+ */
+
+const mocks = vi.hoisted(() => ({
+  personFindMany: vi.fn(),
+  personCount: vi.fn(),
+}));
+
+vi.mock('../../lib/prisma', () => ({
+  prisma: {
+    person: {
+      findMany: mocks.personFindMany,
+      count: mocks.personCount,
+    },
+  },
+}));
+
+vi.mock('../../lib/auth', () => ({
+  auth: vi.fn(() =>
+    Promise.resolve({ user: { id: 'user-123', email: 'test@example.com' } })
+  ),
+}));
+
+vi.mock('../../lib/billing', () => ({
+  canCreateResource: vi.fn(),
+  canEnableReminder: vi.fn(),
+}));
+
+vi.mock('../../lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  securityLogger: { authFailure: vi.fn(), rateLimitExceeded: vi.fn() },
+  createModuleLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+import { GET } from '../../app/api/people/route';
+import { DEFAULT_PEOPLE_PAGE_SIZE, MAX_PEOPLE_PAGE_SIZE } from '@/lib/constants';
+
+function get(query = '') {
+  return new Request(`http://localhost/api/people${query}`);
+}
+
+/** The findMany args from the most recent call. */
+function lastFindManyArgs() {
+  return mocks.personFindMany.mock.calls.at(-1)![0];
+}
+
+describe('GET /api/people paging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.personFindMany.mockResolvedValue([]);
+    mocks.personCount.mockResolvedValue(0);
+  });
+
+  it('applies a default page size when the caller does not ask for one', async () => {
+    await GET(get());
+
+    expect(lastFindManyArgs().take).toBe(DEFAULT_PEOPLE_PAGE_SIZE);
+    expect(lastFindManyArgs().skip).toBe(0);
+  });
+
+  it('honours an explicit limit and offset', async () => {
+    await GET(get('?limit=25&offset=50'));
+
+    expect(lastFindManyArgs().take).toBe(25);
+    expect(lastFindManyArgs().skip).toBe(50);
+  });
+
+  it('caps limit at the maximum instead of trusting the caller', async () => {
+    await GET(get(`?limit=${MAX_PEOPLE_PAGE_SIZE * 10}`));
+
+    expect(lastFindManyArgs().take).toBe(MAX_PEOPLE_PAGE_SIZE);
+  });
+
+  it('rejects a limit that is not a positive integer', async () => {
+    for (const bad of ['0', '-5', 'abc', '1.5', '']) {
+      const res = await GET(get(`?limit=${bad}`));
+      expect(res.status, `limit=${bad} should be rejected`).toBe(400);
+    }
+  });
+
+  it('rejects a negative offset', async () => {
+    const res = await GET(get('?offset=-1'));
+    expect(res.status).toBe(400);
+  });
+
+  it('reports total, limit, offset, and hasMore', async () => {
+    mocks.personFindMany.mockResolvedValue([{ id: 'p1' }, { id: 'p2' }]);
+    mocks.personCount.mockResolvedValue(120);
+
+    const res = await GET(get('?limit=2&offset=0'));
+    const body = await res.json();
+
+    expect(body.pagination).toEqual({
+      total: 120,
+      limit: 2,
+      offset: 0,
+      hasMore: true,
+    });
+  });
+
+  it('reports hasMore false on the last page', async () => {
+    mocks.personFindMany.mockResolvedValue([{ id: 'p1' }]);
+    mocks.personCount.mockResolvedValue(101);
+
+    const res = await GET(get('?limit=100&offset=100'));
+    const body = await res.json();
+
+    expect(body.pagination.hasMore).toBe(false);
+  });
+
+  it('counts with the same filter as the query it pages', async () => {
+    await GET(get('?groupIds=g1,g2&limit=10'));
+
+    const findWhere = lastFindManyArgs().where;
+    const countWhere = mocks.personCount.mock.calls.at(-1)![0].where;
+
+    // A count over a different filter would produce a wrong total and a
+    // hasMore that lies.
+    expect(countWhere).toEqual(findWhere);
+  });
+
+  it('still returns every person for an export', async () => {
+    // A truncated export is silent data loss, so includeAll opts out of paging.
+    mocks.personFindMany.mockResolvedValue([]);
+
+    const res = await GET(get('?includeAll=true'));
+    const body = await res.json();
+
+    expect(lastFindManyArgs().take).toBeUndefined();
+    expect(lastFindManyArgs().skip).toBeUndefined();
+    expect(body.pagination).toBeUndefined();
+  });
+
+  it('honours an explicit limit even with includeAll', async () => {
+    await GET(get('?includeAll=true&limit=10'));
+
+    expect(lastFindManyArgs().take).toBe(10);
+  });
+});

--- a/tests/api/people.test.ts
+++ b/tests/api/people.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   personFindUnique: vi.fn(),
   personFindMany: vi.fn(),
   personFindFirst: vi.fn(),
+  personCount: vi.fn(),
   personCreate: vi.fn(),
   personUpdate: vi.fn(),
   personUpdateMany: vi.fn(),
@@ -23,6 +24,7 @@ vi.mock('../../lib/prisma', () => ({
       findUnique: mocks.personFindUnique,
       findMany: mocks.personFindMany,
       findFirst: mocks.personFindFirst,
+      count: mocks.personCount,
       create: mocks.personCreate,
       update: mocks.personUpdate,
       updateMany: mocks.personUpdateMany,
@@ -77,6 +79,7 @@ describe('People API', () => {
       ];
 
       mocks.personFindMany.mockResolvedValue(mockPeople);
+      mocks.personCount.mockResolvedValue(mockPeople.length);
 
       const request = new Request('http://localhost/api/people');
       const response = await GET(request);
@@ -84,6 +87,12 @@ describe('People API', () => {
 
       expect(response.status).toBe(200);
       expect(body.people).toEqual(mockPeople);
+      expect(body.pagination).toEqual({
+        total: 2,
+        limit: 100,
+        offset: 0,
+        hasMore: false,
+      });
       expect(mocks.personFindMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { userId: 'user-123', deletedAt: null },
@@ -93,6 +102,7 @@ describe('People API', () => {
 
     it('should order people by name ascending', async () => {
       mocks.personFindMany.mockResolvedValue([]);
+      mocks.personCount.mockResolvedValue(0);
 
       const request = new Request('http://localhost/api/people');
       await GET(request);
@@ -106,6 +116,7 @@ describe('People API', () => {
 
     it('should include relationships and groups', async () => {
       mocks.personFindMany.mockResolvedValue([]);
+      mocks.personCount.mockResolvedValue(0);
 
       const request = new Request('http://localhost/api/people');
       await GET(request);

--- a/tests/api/permanent-delete.test.ts
+++ b/tests/api/permanent-delete.test.ts
@@ -17,7 +17,6 @@ const mocks = vi.hoisted(() => ({
   cardDavMappingDeleteMany: vi.fn(),
   duplicateDismissalDeleteMany: vi.fn(),
   journalEntryPersonDeleteMany: vi.fn(),
-  disconnect: vi.fn(),
   deletePersonPhotos: vi.fn(),
   // Group mocks
   groupFindUnique: vi.fn(),
@@ -40,7 +39,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../lib/prisma', () => ({
-  withDeleted: () => ({
+  prismaIncludingDeleted: {
     person: {
       findUnique: mocks.personFindUnique,
       findFirst: mocks.personFindFirst,
@@ -80,8 +79,7 @@ vi.mock('../../lib/prisma', () => ({
     cardDavMapping: { deleteMany: mocks.cardDavMappingDeleteMany },
     duplicateDismissal: { deleteMany: mocks.duplicateDismissalDeleteMany },
     journalEntryPerson: { deleteMany: mocks.journalEntryPersonDeleteMany },
-    $disconnect: mocks.disconnect,
-  }),
+  },
 }));
 
 vi.mock('../../lib/photo-storage', () => ({

--- a/tests/app/api/carddav/import-duplicate-uid.test.ts
+++ b/tests/app/api/carddav/import-duplicate-uid.test.ts
@@ -25,7 +25,6 @@ const mocks = vi.hoisted(() => ({
   createPersonFromVCardData: vi.fn(),
   restorePersonFromVCardData: vi.fn(),
   rawFindMany: vi.fn(),
-  rawDisconnect: vi.fn(),
 }));
 
 vi.mock('@/lib/auth');
@@ -48,10 +47,9 @@ vi.mock('@/lib/prisma', () => ({
       createMany: mocks.createManyPersonGroup,
     },
   },
-  withDeleted: () => ({
+  prismaIncludingDeleted: {
     person: { findMany: mocks.rawFindMany },
-    $disconnect: mocks.rawDisconnect,
-  }),
+  },
 }));
 
 vi.mock('@/lib/carddav/vcard-import', () => ({
@@ -112,7 +110,6 @@ describe('POST /api/carddav/import — duplicate UID handling', () => {
     mocks.findManyMapping.mockResolvedValue([]);
     mocks.findManyPerson.mockResolvedValue([]);
     mocks.rawFindMany.mockResolvedValue([]);
-    mocks.rawDisconnect.mockResolvedValue(undefined);
     // Default: no groups
     mocks.findManyGroup.mockResolvedValue([]);
     mocks.findManyPersonGroup.mockResolvedValue([]);

--- a/tests/app/api/carddav/import-relationship.test.ts
+++ b/tests/app/api/carddav/import-relationship.test.ts
@@ -30,7 +30,6 @@ const mocks = vi.hoisted(() => ({
   createPersonFromVCardData: vi.fn(),
   restorePersonFromVCardData: vi.fn(),
   rawFindMany: vi.fn(),
-  rawDisconnect: vi.fn(),
 }));
 
 vi.mock('@/lib/auth');
@@ -57,10 +56,9 @@ vi.mock('@/lib/prisma', () => ({
     },
     relationshipType: { findMany: mocks.findManyRelationshipType },
   },
-  withDeleted: () => ({
+  prismaIncludingDeleted: {
     person: { findMany: mocks.rawFindMany },
-    $disconnect: mocks.rawDisconnect,
-  }),
+  },
 }));
 
 vi.mock('@/lib/carddav/vcard-import', () => ({
@@ -116,7 +114,6 @@ describe('POST /api/carddav/import — relationship assignment', () => {
     mocks.findManyMapping.mockResolvedValue([]);
     mocks.findManyPerson.mockResolvedValue([]);
     mocks.rawFindMany.mockResolvedValue([]);
-    mocks.rawDisconnect.mockResolvedValue(undefined);
     // Default: no groups
     mocks.findManyGroup.mockResolvedValue([]);
     mocks.findManyPersonGroup.mockResolvedValue([]);

--- a/tests/integration/soft-delete.test.ts
+++ b/tests/integration/soft-delete.test.ts
@@ -72,9 +72,6 @@ const mockEnv = vi.hoisted(() => ({
   NEXTAUTH_URL: 'http://localhost:3000',
 }));
 
-// Track if withDeleted was used
-let withDeletedClient: any = null;
-
 // Mock Prisma
 vi.mock('../../lib/prisma', () => ({
   prisma: {
@@ -123,53 +120,50 @@ vi.mock('../../lib/prisma', () => ({
       deleteMany: mocks.cardDavMappingDeleteMany,
     },
   },
-  withDeleted: vi.fn(() => {
-    withDeletedClient = {
-      person: {
-        findUnique: mocks.personFindUnique,
-        findMany: mocks.personFindMany,
-        update: mocks.personUpdate,
-        updateMany: mocks.personUpdateMany,
-        deleteMany: mocks.personDeleteMany,
-      },
-      group: {
-        findUnique: mocks.groupFindUnique,
-        findMany: mocks.groupFindMany,
-        update: mocks.groupUpdate,
-        deleteMany: mocks.groupDeleteMany,
-      },
-      relationship: {
-        findUnique: mocks.relationshipFindUnique,
-        findFirst: mocks.relationshipFindFirst,
-        findMany: mocks.relationshipFindMany,
-        update: mocks.relationshipUpdate,
-        updateMany: mocks.relationshipUpdateMany,
-        deleteMany: mocks.relationshipDeleteMany,
-      },
-      relationshipType: {
-        findFirst: mocks.relationshipTypeFindFirst,
-        findMany: mocks.relationshipTypeFindMany,
-        update: mocks.relationshipTypeUpdate,
-        updateMany: mocks.relationshipTypeUpdateMany,
-        deleteMany: mocks.relationshipTypeDeleteMany,
-      },
-      importantDate: {
-        findUnique: mocks.importantDateFindUnique,
-        findMany: mocks.importantDateFindMany,
-        update: mocks.importantDateUpdate,
-        deleteMany: mocks.importantDateDeleteMany,
-      },
-      personGroup: {
-        deleteMany: mocks.personGroupDeleteMany,
-      },
-      cronJobLog: {
-        create: mocks.cronJobLogCreate,
-        update: mocks.cronJobLogUpdate,
-      },
-      $disconnect: vi.fn(),
-    };
-    return withDeletedClient;
-  }),
+  prismaIncludingDeleted: {
+    person: {
+      findUnique: mocks.personFindUnique,
+      findMany: mocks.personFindMany,
+      update: mocks.personUpdate,
+      updateMany: mocks.personUpdateMany,
+      deleteMany: mocks.personDeleteMany,
+    },
+    group: {
+      findUnique: mocks.groupFindUnique,
+      findMany: mocks.groupFindMany,
+      update: mocks.groupUpdate,
+      deleteMany: mocks.groupDeleteMany,
+    },
+    relationship: {
+      findUnique: mocks.relationshipFindUnique,
+      findFirst: mocks.relationshipFindFirst,
+      findMany: mocks.relationshipFindMany,
+      update: mocks.relationshipUpdate,
+      updateMany: mocks.relationshipUpdateMany,
+      deleteMany: mocks.relationshipDeleteMany,
+    },
+    relationshipType: {
+      findFirst: mocks.relationshipTypeFindFirst,
+      findMany: mocks.relationshipTypeFindMany,
+      update: mocks.relationshipTypeUpdate,
+      updateMany: mocks.relationshipTypeUpdateMany,
+      deleteMany: mocks.relationshipTypeDeleteMany,
+    },
+    importantDate: {
+      findUnique: mocks.importantDateFindUnique,
+      findMany: mocks.importantDateFindMany,
+      update: mocks.importantDateUpdate,
+      deleteMany: mocks.importantDateDeleteMany,
+    },
+    personGroup: {
+      deleteMany: mocks.personGroupDeleteMany,
+    },
+    cronJobLog: {
+      create: mocks.cronJobLogCreate,
+      update: mocks.cronJobLogUpdate,
+    },
+    $disconnect: vi.fn(),
+  },
 }));
 
 // Mock auth
@@ -220,7 +214,6 @@ describe('Soft Delete Integration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetStore();
-    withDeletedClient = null;
 
     // Setup cronJobLog mocks
     mocks.cronJobLogCreate.mockResolvedValue({ id: 'cron-1' });

--- a/tests/lib/prisma-clients.test.ts
+++ b/tests/lib/prisma-clients.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * The soft-delete-bypassing client used by the trash, restore, and purge paths
+ * must be a shared singleton, like `prisma` itself.
+ *
+ * It used to be produced by a `withDeleted()` factory that constructed a fresh
+ * PrismaClient (and therefore a fresh pg Pool) on every call, which every
+ * caller then had to tear down in a `finally` block. That meant a TCP connect
+ * and auth handshake on each trash listing, restore, and permanent delete, and
+ * one forgotten `finally` would have leaked a pool.
+ */
+
+const constructed = vi.hoisted(() => ({ prismaClient: 0, adapter: 0 }));
+
+vi.mock('@prisma/client', () => {
+  class FakePrismaClient {
+    constructor() {
+      constructed.prismaClient++;
+    }
+    $extends() {
+      return this;
+    }
+    $disconnect() {
+      return Promise.resolve();
+    }
+    $on() {}
+  }
+  return { PrismaClient: FakePrismaClient, Prisma: {} };
+});
+
+vi.mock('@prisma/adapter-pg', () => ({
+  PrismaPg: class {
+    constructor() {
+      constructed.adapter++;
+    }
+  },
+}));
+
+describe('Prisma client singletons', () => {
+  beforeEach(() => {
+    constructed.prismaClient = 0;
+    constructed.adapter = 0;
+    vi.resetModules();
+  });
+
+  it('constructs each client once per module load, not once per use', async () => {
+    const mod = await import('@/lib/prisma');
+
+    const afterLoad = constructed.prismaClient;
+
+    // Touch the unfiltered client repeatedly: no further clients may appear.
+    for (let i = 0; i < 25; i++) {
+      expect(mod.prismaIncludingDeleted).toBeDefined();
+    }
+
+    expect(constructed.prismaClient).toBe(afterLoad);
+    expect(afterLoad).toBeLessThanOrEqual(2);
+  });
+
+  it('hands out the same unfiltered client every time', async () => {
+    const mod = await import('@/lib/prisma');
+
+    expect(mod.prismaIncludingDeleted).toBe(mod.prismaIncludingDeleted);
+
+    const again = await import('@/lib/prisma');
+    expect(again.prismaIncludingDeleted).toBe(mod.prismaIncludingDeleted);
+  });
+
+  it('no longer exports a per-call factory', async () => {
+    const mod = (await import('@/lib/prisma')) as Record<string, unknown>;
+
+    // A factory invites the caller to own a lifecycle it should not own.
+    expect(mod.withDeleted).toBeUndefined();
+  });
+});

--- a/tests/lib/services/person.test.ts
+++ b/tests/lib/services/person.test.ts
@@ -36,9 +36,9 @@ const mocks = vi.hoisted(() => {
   const journalEntryPersonFindMany = vi.fn();
   const journalEntryPersonUpdateMany = vi.fn();
   const journalEntryPersonDeleteMany = vi.fn();
-  const withDeletedPersonFindUnique = vi.fn();
-  const withDeletedPersonUpdate = vi.fn();
-  const withDeletedDisconnect = vi.fn();
+  const deletedAwarePersonFindUnique = vi.fn();
+  const deletedAwarePersonUpdate = vi.fn();
+  const deletedAwareDisconnect = vi.fn();
   const autoExportPerson = vi.fn();
   const autoUpdatePerson = vi.fn();
 
@@ -94,9 +94,9 @@ const mocks = vi.hoisted(() => {
     journalEntryPersonFindMany,
     journalEntryPersonUpdateMany,
     journalEntryPersonDeleteMany,
-    withDeletedPersonFindUnique,
-    withDeletedPersonUpdate,
-    withDeletedDisconnect,
+    deletedAwarePersonFindUnique,
+    deletedAwarePersonUpdate,
+    deletedAwareDisconnect,
     autoExportPerson,
     autoUpdatePerson,
     mockTxClient,
@@ -131,13 +131,13 @@ vi.mock('../../../lib/prisma', () => ({
       deleteMany: mocks.journalEntryPersonDeleteMany,
     },
   },
-  withDeleted: vi.fn(() => ({
+  prismaIncludingDeleted: {
     person: {
-      findUnique: mocks.withDeletedPersonFindUnique,
-      update: mocks.withDeletedPersonUpdate,
+      findUnique: mocks.deletedAwarePersonFindUnique,
+      update: mocks.deletedAwarePersonUpdate,
     },
-    $disconnect: mocks.withDeletedDisconnect,
-  })),
+    $disconnect: mocks.deletedAwareDisconnect,
+  },
 }));
 
 vi.mock('../../../lib/carddav/auto-export', () => ({
@@ -237,7 +237,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.autoExportPerson.mockResolvedValue(undefined);
   mocks.autoUpdatePerson.mockResolvedValue(undefined);
-  mocks.withDeletedDisconnect.mockResolvedValue(undefined);
+  mocks.deletedAwareDisconnect.mockResolvedValue(undefined);
   mocks.importantDateFindMany.mockResolvedValue([]);
 });
 
@@ -671,35 +671,35 @@ describe('deletePerson', () => {
 
 describe('restorePerson', () => {
   beforeEach(() => {
-    mocks.withDeletedPersonFindUnique.mockResolvedValue({
+    mocks.deletedAwarePersonFindUnique.mockResolvedValue({
       id: PERSON_ID,
       userId: USER_ID,
       deletedAt: new Date('2024-01-01'),
     });
-    mocks.withDeletedPersonUpdate.mockResolvedValue({ id: PERSON_ID });
+    mocks.deletedAwarePersonUpdate.mockResolvedValue({ id: PERSON_ID });
   });
 
   it('returns null when person not found', async () => {
-    mocks.withDeletedPersonFindUnique.mockResolvedValue(null);
+    mocks.deletedAwarePersonFindUnique.mockResolvedValue(null);
     const result = await restorePerson(PERSON_ID, USER_ID);
     expect(result).toBeNull();
-    expect(mocks.withDeletedPersonUpdate).not.toHaveBeenCalled();
+    expect(mocks.deletedAwarePersonUpdate).not.toHaveBeenCalled();
   });
 
   it('returns null when person is not soft-deleted', async () => {
-    mocks.withDeletedPersonFindUnique.mockResolvedValue({
+    mocks.deletedAwarePersonFindUnique.mockResolvedValue({
       id: PERSON_ID,
       userId: USER_ID,
       deletedAt: null,
     });
     const result = await restorePerson(PERSON_ID, USER_ID);
     expect(result).toBeNull();
-    expect(mocks.withDeletedPersonUpdate).not.toHaveBeenCalled();
+    expect(mocks.deletedAwarePersonUpdate).not.toHaveBeenCalled();
   });
 
   it('clears deletedAt on restore', async () => {
     await restorePerson(PERSON_ID, USER_ID);
-    const call = mocks.withDeletedPersonUpdate.mock.calls[0][0];
+    const call = mocks.deletedAwarePersonUpdate.mock.calls[0][0];
     expect(call.where).toEqual({ id: PERSON_ID });
     expect(call.data).toEqual({ deletedAt: null });
   });
@@ -709,15 +709,24 @@ describe('restorePerson', () => {
     expect(result).toBe(PERSON_ID);
   });
 
-  it('always calls disconnect on the raw client', async () => {
+  it('looks the person up scoped to the owning user', async () => {
     await restorePerson(PERSON_ID, USER_ID);
-    expect(mocks.withDeletedDisconnect).toHaveBeenCalled();
+    expect(mocks.deletedAwarePersonFindUnique).toHaveBeenCalledWith({
+      where: { id: PERSON_ID, userId: USER_ID },
+    });
   });
 
-  it('calls disconnect even if findUnique throws', async () => {
-    mocks.withDeletedPersonFindUnique.mockRejectedValue(new Error('db error'));
+  it('never disconnects the shared client', async () => {
+    // prismaIncludingDeleted is a process-wide singleton with its own pool.
+    // Disconnecting it here would tear the pool out from under other requests.
+    await restorePerson(PERSON_ID, USER_ID);
+    expect(mocks.deletedAwareDisconnect).not.toHaveBeenCalled();
+  });
+
+  it('propagates a lookup failure and still does not disconnect', async () => {
+    mocks.deletedAwarePersonFindUnique.mockRejectedValue(new Error('db error'));
     await expect(restorePerson(PERSON_ID, USER_ID)).rejects.toThrow('db error');
-    expect(mocks.withDeletedDisconnect).toHaveBeenCalled();
+    expect(mocks.deletedAwareDisconnect).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
> [!WARNING]
> **Breaking API change for external scripts**
>
> `GET /api/people` now returns the first 100 people by default instead of all of them. Any script that reads `people` without checking `pagination.hasMore` will silently see only the first page.
>
> - To page: advance `offset` by `limit` while `pagination.hasMore` is `true`
> - To keep getting everything in one response: pass `includeAll=true`
>
> This needs a release-note warning when it ships. No in-app behavior changes: the only caller inside Nametag is the data export, which uses `includeAll=true`.

Two things from the audit: a Prisma client that was built per request, and an endpoint with no upper bound.

## One shared deleted-aware client

`withDeleted()` looked like a cheap accessor but constructed a whole `PrismaClient`, and therefore a fresh `pg` Pool, on every call:

```js
export function withDeleted(): PrismaClient {
  return createBaseClient();   // new PrismaClient + new PrismaPg adapter
}
```

Fifteen call sites paid a TCP connect and auth handshake per trash listing, restore, and permanent delete, and every one of them carried this:

```js
const prismaWithDeleted = withDeleted();
try {
  ...
} finally {
  await prismaWithDeleted.$disconnect();
}
```

All fifteen did remember the `finally` (I checked each), so there was no live leak. But the design put a process-level resource lifecycle in the hands of a request handler, and one omission would have leaked a pool for the lifetime of the process.

It is now `prismaIncludingDeleted`, a shared singleton alongside `prisma`: same `globalThis` caching outside production so `next dev` does not accumulate pools across reloads, and disconnected only on `SIGINT`/`SIGTERM`. The fifteen call sites lose the factory call and the `finally`. Naming it as a client rather than a factory also stops it reading like something the caller owns.

I considered collapsing the two clients into one by having the soft-delete extension skip injection when the caller passes an explicit `deletedAt`, which would remove the second pool entirely. I did not: `findUnique` post-filters its result rather than filtering in the query, so restore paths would have needed rewriting to `findFirst`, and "explicit `deletedAt` wins" is a subtle rule that silently disables the filter if someone writes `deletedAt: undefined`. Two named clients are easier to audit.

## Paging GET /api/people

The endpoint fetched every person the user owns with `phoneNumbers`, `emails`, `addresses`, `urls`, `imHandles`, `locations`, and `customFields` all joined, with no `take`. Fine at 50 contacts, not at 5000, and Pro tiers allow that.

Now: `limit` (default 100, capped 500) and `offset`, plus a `pagination` object.

```json
{
  "people": [ ... ],
  "pagination": { "total": 214, "limit": 50, "offset": 0, "hasMore": true }
}
```

`total` is counted over the same `where` as the page, so `hasMore` cannot disagree with the rows returned. A test asserts that specifically, since a count over a different filter is the easy way to get this wrong.

`includeAll=true` still returns everyone. A truncated export is silent data loss, and export is the only in-app caller. An explicit `limit` still applies there for anyone who wants to page the richer shape.

Invalid input is rejected rather than coerced: `limit=0`, `limit=-5`, `limit=abc`, `limit=1.5`, and `offset=-1` all return `400`.

## Test changes worth review

**`tests/lib/prisma-clients.test.ts`** (new) pins the singleton contract by stubbing `@prisma/client` and counting constructions across repeated use of the export.

**`tests/lib/services/person.test.ts`** had two tests asserting `$disconnect` was called on the raw client. Under the new contract that assertion is backwards, and deleting them outright would have quietly dropped coverage. They now assert the shared client is *never* disconnected, plus that the lookup stays scoped to the owning user. I confirmed the new assertion actually bites by reintroducing a `$disconnect()` call in `restorePerson`:

```
FAIL tests/lib/services/person.test.ts > restorePerson > never disconnects the shared client
```

Six test files mocked `withDeleted` as a factory returning a fresh object; they now mock the client directly, which is also a closer match to what the code does.

## Verification

`npm run lint`, `npm run typecheck`, `npx vitest run` (2539 passed, 16 skipped), `npm run build` (exit 0), `cd docs && npm run build`.

Docs updated: `api/people.md` gains the two parameters, a worked paging loop, a note that a name-ordered page can shift rows if the data changes mid-walk, and a Technical details table. OpenAPI spec updated to match, with the limits derived from the constants so they cannot drift.
