### PR TITLE
fix: make OpenAPI security match the code, and enforce spec coverage

### DIFF
--- a/docs/src/content/docs/api/carddav.md
+++ b/docs/src/content/docs/api/carddav.md
@@ -31,7 +31,7 @@ POST /api/carddav/connection
 
 ```bash
 curl -X POST https://your-instance.example.com/api/carddav/connection \
-  -H "Authorization: Bearer ntag_xxx" \
+  --cookie "authjs.session-token=..." \
   -H "Content-Type: application/json" \
   -d '{
     "serverUrl": "https://contacts.icloud.com/",
@@ -58,7 +58,7 @@ Same fields as create, except `password` is optional (only changed if provided).
 
 ```bash
 curl -X PUT https://your-instance.example.com/api/carddav/connection \
-  -H "Authorization: Bearer ntag_xxx" \
+  --cookie "authjs.session-token=..." \
   -H "Content-Type: application/json" \
   -d '{ "serverUrl": "https://contacts.icloud.com/", "username": "ada@example.com", "autoSyncInterval": 900 }'
 ```
@@ -77,7 +77,7 @@ Disconnects and deletes the connection along with all sync mappings and pending 
 
 ```bash
 curl -X DELETE https://your-instance.example.com/api/carddav/connection \
-  -H "Authorization: Bearer ntag_xxx"
+  --cookie "authjs.session-token=..."
 ```
 
 ```json
@@ -94,7 +94,7 @@ Tests connectivity without saving credentials.
 
 ```bash
 curl -X POST https://your-instance.example.com/api/carddav/connection/test \
-  -H "Authorization: Bearer ntag_xxx" \
+  --cookie "authjs.session-token=..." \
   -H "Content-Type: application/json" \
   -d '{ "serverUrl": "https://contacts.icloud.com/", "username": "ada@example.com", "password": "app-specific-password" }'
 ```
@@ -220,7 +220,7 @@ Downloads every contact from the connected server as a single `.vcf` file.
 
 ```bash
 curl -X POST https://your-instance.example.com/api/carddav/backup \
-  -H "Authorization: Bearer ntag_xxx" \
+  --cookie "authjs.session-token=..." \
   -o nametag-backup.vcf
 ```
 

--- a/docs/src/content/docs/api/overview.md
+++ b/docs/src/content/docs/api/overview.md
@@ -34,7 +34,13 @@ curl https://your-instance.example.com/api/people \
   -H "Authorization: Bearer ntag_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
-API tokens work on nearly every endpoint that accepts a session cookie. The token management endpoints themselves (`/api/user/api-tokens`) are the one exception: creating and revoking tokens always requires a session, since letting a token manage other tokens would be a security hole. See [API Tokens](/api/tokens/) for scopes, expiry, and full examples.
+API tokens work on nearly every endpoint that accepts a session cookie. A few reject them and require a browser session:
+
+- `/api/user/api-tokens*`, so a token can never mint or revoke other tokens
+- `/api/billing/*`, so subscription and payment changes stay tied to an interactive session
+- `/api/carddav/connection`, `/api/carddav/connection/test`, and `/api/carddav/backup`, which read or replace stored CardDAV credentials, and where the last two dial whatever host the caller supplies
+
+Requests to those with a bearer token return `401`. Each endpoint's accepted schemes are listed in the [OpenAPI spec](/api/openapi.json), and see [API Tokens](/api/tokens/) for scopes, expiry, and full examples.
 
 ## Response format
 

--- a/lib/openapi/apiTokens.ts
+++ b/lib/openapi/apiTokens.ts
@@ -1,13 +1,5 @@
 import { createApiTokenSchema } from '../validations';
-import {
-  zodBody,
-  jsonResponse,
-  ref400,
-  ref401,
-  ref404,
-  refSuccess,
-  pathParam,
-} from './helpers';
+import { zodBody, jsonResponse, ref400, ref401, ref404, refSuccess, pathParam, sessionOnly } from './helpers';
 
 const apiTokenObject = {
   type: 'object',
@@ -46,7 +38,7 @@ export function apiTokenPaths(): Record<string, Record<string, unknown>> {
         summary: 'List API tokens',
         description:
           "Lists the current user's API tokens. Never returns the secret value. Session (cookie) auth only.",
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': jsonResponse('User API tokens', {
             type: 'object',
@@ -62,7 +54,7 @@ export function apiTokenPaths(): Record<string, Record<string, unknown>> {
         summary: 'Create an API token',
         description:
           'Creates a new API token. The plaintext token is returned ONCE in the response and cannot be retrieved again. Session (cookie) auth only.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: zodBody(createApiTokenSchema),
         responses: {
           '201': jsonResponse('Created token (plaintext shown once)', {
@@ -80,7 +72,7 @@ export function apiTokenPaths(): Record<string, Record<string, unknown>> {
         summary: 'Revoke an API token',
         description:
           'Permanently revokes (deletes) an API token. Session (cookie) auth only.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         parameters: [pathParam('id', 'API token ID')],
         responses: {
           '200': refSuccess(),

--- a/lib/openapi/billing.ts
+++ b/lib/openapi/billing.ts
@@ -1,4 +1,4 @@
-import { jsonBody, jsonResponse, ref400, ref401, refMessage, resp } from './helpers';
+import { jsonBody, jsonResponse, ref400, ref401, refMessage, resp, sessionOnly } from './helpers';
 
 export function billingPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -7,7 +7,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
         tags: ['Billing'],
         summary: 'Get subscription details',
         description: 'Returns the current subscription status, tier info, usage, limits, and active promotion.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': jsonResponse('Subscription details', {
             type: 'object',
@@ -60,7 +60,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
         tags: ['Billing'],
         summary: 'Create a checkout session',
         description: 'Creates a Stripe checkout session for subscribing to a paid plan.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -84,7 +84,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
         tags: ['Billing'],
         summary: 'Get current usage',
         description: 'Returns usage counts against plan limits.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': jsonResponse('Usage info', {
             type: 'object',
@@ -102,7 +102,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
       get: {
         tags: ['Billing'],
         summary: 'Get payment history',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': jsonResponse('Payment history', {
             type: 'object',
@@ -136,7 +136,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
         tags: ['Billing'],
         summary: 'Open Stripe billing portal',
         description: 'Returns a URL to the Stripe customer portal for managing payment methods and invoices.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': jsonResponse('Portal URL', {
             type: 'object',
@@ -150,7 +150,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
       post: {
         tags: ['Billing'],
         summary: 'Cancel subscription',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -168,7 +168,7 @@ export function billingPaths(): Record<string, Record<string, unknown>> {
       post: {
         tags: ['Billing'],
         summary: 'Apply a promotion code',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: { code: { type: 'string' } },

--- a/lib/openapi/carddav.ts
+++ b/lib/openapi/carddav.ts
@@ -1,4 +1,4 @@
-import { jsonBody, pathParam, jsonResponse, ref400, ref401, ref404, refSuccess, resp } from './helpers';
+import { jsonBody, pathParam, jsonResponse, ref400, ref401, ref404, refSuccess, resp, sessionOnly, sessionOrToken } from './helpers';
 
 export function carddavPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -7,7 +7,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Create CardDAV connection',
         description: 'Creates a new CardDAV server connection for the authenticated user. Only one connection per user is allowed.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -39,7 +39,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Update CardDAV connection',
         description: 'Updates the existing CardDAV connection settings. Password is optional (only updated if provided).',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -69,7 +69,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Delete CardDAV connection',
         description: 'Disconnects and deletes the CardDAV connection, removing all sync mappings and pending imports.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': refSuccess(),
           '401': ref401(),
@@ -82,7 +82,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Test CardDAV credentials',
         description: 'Tests connectivity to a CardDAV server with the given credentials without saving them.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -115,7 +115,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
           'Triggers a full bidirectional sync with the CardDAV server. Returns a Server-Sent Events stream with progress updates. ' +
           'Event types: `progress` (sync progress updates), `complete` (final results with counts), `error` (error message). ' +
           'The `complete` event data includes: imported, exported, updatedLocally, updatedRemotely, conflicts, errors, errorMessages, pendingImports.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': {
             description: 'SSE stream of sync progress',
@@ -134,7 +134,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Import selected contacts',
         description: 'Imports previously discovered pending contacts into Nametag. Supports assigning groups globally or per-contact.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -172,7 +172,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Bulk export contacts',
         description: 'Exports selected Nametag contacts to the connected CardDAV server. Processes in batches of 50.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -202,7 +202,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Resolve a sync conflict',
         description: 'Resolves a bidirectional sync conflict by keeping the local version, remote version, or a merged result.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Conflict ID')],
         requestBody: jsonBody({
           type: 'object',
@@ -225,7 +225,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Discover new contacts',
         description: 'Scans the CardDAV server for contacts not yet imported and creates pending import records.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Discovery result', {
             type: 'object',
@@ -245,7 +245,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Get pending import count',
         description: 'Returns the number of contacts discovered on the CardDAV server but not yet imported.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Pending count', {
             type: 'object',
@@ -262,7 +262,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['CardDAV'],
         summary: 'Download vCard backup',
         description: 'Downloads all contacts from the connected CardDAV server as a single .vcf file.',
-        security: [{ session: [] }],
+        security: sessionOnly(),
         responses: {
           '200': {
             description: 'vCard file download',
@@ -287,7 +287,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['vCard'],
         summary: 'Import vCard file',
         description: 'Parses and directly imports contacts from raw vCard data into Nametag. Maximum file size: 2 MB.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: {
           required: true,
           content: {
@@ -317,7 +317,7 @@ export function carddavPaths(): Record<string, Record<string, unknown>> {
         tags: ['vCard'],
         summary: 'Upload vCard for preview',
         description: 'Parses vCard data and creates pending import records for review before importing. Maximum file size: 2 MB.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: {
           required: true,
           content: {

--- a/lib/openapi/customFields.ts
+++ b/lib/openapi/customFields.ts
@@ -3,16 +3,7 @@ import {
   customFieldTemplateUpdateSchema,
   customFieldTemplateReorderSchema,
 } from '../validations';
-import {
-  zodBody,
-  pathParam,
-  jsonResponse,
-  ref400,
-  ref401,
-  ref404,
-  refSuccess,
-  resp,
-} from './helpers';
+import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refSuccess, resp, sessionOrToken } from './helpers';
 
 export function customFieldsPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -21,7 +12,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Custom Fields'],
         summary: 'List custom field templates',
         description: 'Returns active custom field templates for the authenticated user, ordered by display order.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('List of templates', {
             type: 'object',
@@ -39,7 +30,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Custom Fields'],
         summary: 'Create a custom field template',
         description: 'Creates a typed custom field schema. Slug is derived from name and immutable.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(customFieldTemplateCreateSchema),
         responses: {
           '201': jsonResponse('Template created', {
@@ -57,7 +48,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
       get: {
         tags: ['Custom Fields'],
         summary: 'Get a custom field template',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Template ID')],
         responses: {
           '200': jsonResponse('Template', {
@@ -72,7 +63,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Custom Fields'],
         summary: 'Update a custom field template',
         description: 'Updates name and/or options. Type and slug are immutable.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Template ID')],
         requestBody: zodBody(customFieldTemplateUpdateSchema),
         responses: {
@@ -88,7 +79,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
       delete: {
         tags: ['Custom Fields'],
         summary: 'Soft-delete a custom field template',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Template ID')],
         responses: {
           '200': refSuccess(),
@@ -102,7 +93,7 @@ export function customFieldsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Custom Fields'],
         summary: 'Reorder templates',
         description: "Reorders the user's custom field templates. The provided id list determines the new display order.",
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(customFieldTemplateReorderSchema),
         responses: {
           '200': refSuccess(),

--- a/lib/openapi/dashboard.ts
+++ b/lib/openapi/dashboard.ts
@@ -1,4 +1,4 @@
-import { jsonResponse, ref401, refGraph } from './helpers';
+import { jsonResponse, ref401, refGraph, sessionOrToken } from './helpers';
 
 export function dashboardPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -8,7 +8,7 @@ export function dashboardPaths(): Record<string, Record<string, unknown>> {
         summary: 'Get dashboard statistics',
         description:
           'Returns upcoming events (important dates and contact reminders due within 30 days), plus total people and group counts.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Dashboard stats', {
             type: 'object',
@@ -31,7 +31,7 @@ export function dashboardPaths(): Record<string, Record<string, unknown>> {
         summary: 'Get full network graph',
         description:
           'Returns a D3-compatible graph of all people and their relationships, centered on the user. Supports filtering by group inclusion and exclusion with configurable match modes.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           {
             name: 'includeGroupIds',

--- a/lib/openapi/groups.ts
+++ b/lib/openapi/groups.ts
@@ -1,7 +1,7 @@
 import {
   createGroupSchema, updateGroupSchema, addGroupMemberSchema,
 } from '../validations';
-import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refSuccess, resp } from './helpers';
+import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refSuccess, resp, sessionOrToken } from './helpers';
 
 export function groupsPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -10,7 +10,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'List all groups',
         description: 'Returns all groups for the authenticated user, with their members.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('List of groups', {
             type: 'object',
@@ -25,7 +25,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Create a new group',
         description: 'Creates a group with a name, optional description/color, and optional initial members.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(createGroupSchema),
         responses: {
           '201': jsonResponse('Group created', {
@@ -43,7 +43,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Get a group by ID',
         description: 'Returns a single group with its member list.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID')],
         responses: {
           '200': jsonResponse('Group details', {
@@ -58,7 +58,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Update a group',
         description: 'Updates the name, description, and/or color of a group.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID')],
         requestBody: zodBody(updateGroupSchema),
         responses: {
@@ -75,7 +75,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Delete a group',
         description: 'Soft-deletes a group. Optionally also soft-deletes all people in the group.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           pathParam('id', 'Group ID'),
           { name: 'deletePeople', in: 'query', schema: { type: 'boolean' }, description: 'Also delete all people in this group' },
@@ -91,7 +91,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
       post: {
         tags: ['Groups'],
         summary: 'Restore a deleted group',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID')],
         responses: {
           '200': jsonResponse('Group restored', {
@@ -109,7 +109,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Permanently delete a group',
         description: 'Permanently deletes a soft-deleted group and its memberships. This cannot be undone.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID')],
         responses: {
           '200': refSuccess(),
@@ -124,7 +124,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Groups'],
         summary: 'Add a person to a group',
         description: 'Adds an existing person as a member of the specified group.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID')],
         requestBody: zodBody(addGroupMemberSchema),
         responses: {
@@ -139,7 +139,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
       delete: {
         tags: ['Groups'],
         summary: 'Remove a person from a group',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Group ID'), pathParam('personId', 'Person ID')],
         responses: {
           '200': refSuccess(),
@@ -155,7 +155,7 @@ export function groupsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Deleted Items'],
         summary: 'List soft-deleted items',
         description: 'Returns items deleted within the retention period (30 days), filtered by type.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           {
             name: 'type',

--- a/lib/openapi/helpers.ts
+++ b/lib/openapi/helpers.ts
@@ -2,6 +2,28 @@ import { z } from 'zod';
 
 export type JsonSchema = Record<string, unknown>;
 
+/**
+ * Security for an endpoint reachable with either a browser session or a
+ * personal API token. This is the default for authenticated endpoints: withAuth
+ * accepts `Authorization: Bearer <token>` unless the route opts out.
+ */
+export function sessionOrToken() {
+  return [{ session: [] }, { apiToken: [] }];
+}
+
+/**
+ * Security for an endpoint that rejects bearer tokens, matching
+ * `withAuth(handler, { allowApiToken: false })`.
+ *
+ * Used where a token must not be able to escalate its own reach: token
+ * management, billing, and the CardDAV endpoints that read or replace stored
+ * server credentials. `tests/api/openapi-coverage.test.ts` checks that this
+ * stays in step with the route options.
+ */
+export function sessionOnly() {
+  return [{ session: [] }];
+}
+
 export function pathParam(name: string, description: string) {
   return {
     name,

--- a/lib/openapi/index.ts
+++ b/lib/openapi/index.ts
@@ -12,7 +12,7 @@ import { journalPaths } from './journal';
 import { customFieldsPaths } from './customFields';
 import { apiTokenPaths } from './apiTokens';
 import { mapPaths } from './map';
-import { jsonResponse, ref400, ref401, ref404, pathParam, jsonBody, resp } from './helpers';
+import { jsonResponse, ref400, ref401, ref404, refSuccess, pathParam, jsonBody, resp, sessionOrToken } from './helpers';
 
 // OpenAPI 3.1.0 specification generator for the Nametag API.
 // Request body schemas are generated from Zod validation schemas (single source of truth).
@@ -87,9 +87,11 @@ export function generateOpenAPISpec(): OpenAPISpec {
           scheme: 'bearer',
           description:
             'Per-user personal API token sent as `Authorization: Bearer <token>`. ' +
-            'Created and revoked in Settings → API Tokens. All endpoints documented with ' +
-            'the `session` scheme also accept a valid `apiToken` (read-only tokens are ' +
-            'restricted to GET/HEAD). The token-management endpoints themselves require a session.',
+            'Created and revoked in Settings → API Tokens. Read-only (`READ`) tokens are ' +
+            'restricted to GET, HEAD, and OPTIONS; a write attempt returns 403. ' +
+            'Each endpoint lists the schemes it accepts: those showing only `session` ' +
+            'reject bearer tokens outright, which covers token management, billing, and ' +
+            'the CardDAV endpoints that read or replace stored server credentials.',
         },
       },
       schemas: sharedSchemas(),
@@ -114,7 +116,7 @@ export function generateOpenAPISpec(): OpenAPISpec {
           tags: ['Photos'],
           summary: 'Get person photo',
           description: 'Returns the photo image for a person. Served from disk with appropriate MIME type and caching headers.',
-          security: [{ session: [] }],
+          security: sessionOrToken(),
           parameters: [pathParam('personId', 'Person ID')],
           responses: {
             '200': {
@@ -132,7 +134,7 @@ export function generateOpenAPISpec(): OpenAPISpec {
           tags: ['Photos'],
           summary: 'Get current user photo',
           description: 'Returns the photo image for the logged-in user.',
-          security: [{ session: [] }],
+          security: sessionOrToken(),
           responses: {
             '200': {
               description: 'Photo image',
@@ -150,7 +152,7 @@ export function generateOpenAPISpec(): OpenAPISpec {
           tags: ['Photos'],
           summary: 'Convert HEIC photo to JPEG',
           description: 'Accepts a HEIC/HEIF image file and returns a JPEG conversion. Applies automatic orientation correction and configurable quality. Does not store anything.',
-          security: [{ session: [] }],
+          security: sessionOrToken(),
           requestBody: {
             description: 'HEIC photo file to convert',
             required: true,
@@ -216,6 +218,31 @@ export function generateOpenAPISpec(): OpenAPISpec {
         },
       },
 
+      // Cron (reminders)
+      '/api/cron/send-reminders': {
+        get: {
+          tags: ['Cron'],
+          summary: 'Send due reminder emails',
+          description:
+            'Sends reminder emails for important dates and contact reminders that are due. ' +
+            'Each email carries a one-time unsubscribe token. Intended to run once a day.',
+          security: [{ cronBearer: [] }],
+          responses: {
+            '200': jsonResponse('Reminder run results', {
+              type: 'object',
+              properties: {
+                success: { type: 'boolean' },
+                sent: { type: 'integer' },
+                errors: { type: 'integer' },
+                processedImportantDates: { type: 'integer' },
+                processedContactReminders: { type: 'integer' },
+              },
+            }),
+            '401': ref401(),
+          },
+        },
+      },
+
       // Cron (geocode)
       '/api/cron/geocode': {
         get: {
@@ -272,6 +299,92 @@ export function generateOpenAPISpec(): OpenAPISpec {
               },
             }),
             '503': resp('Unhealthy'),
+          },
+        },
+      },
+      '/api/log-error': {
+        post: {
+          tags: ['System'],
+          summary: 'Report a client-side error',
+          description:
+            'Records an error that occurred in the browser. Unauthenticated by necessity, ' +
+            'since an error that breaks the session still needs to be reportable, so the ' +
+            'payload is treated as untrusted: the body is capped at 64KB, each field is ' +
+            'accepted only if it is a string and then truncated, and reports are rate ' +
+            'limited per IP.',
+          requestBody: jsonBody({
+            type: 'object',
+            properties: {
+              message: { type: 'string', maxLength: 1024 },
+              stack: { type: 'string', maxLength: 8192 },
+              digest: { type: 'string', maxLength: 256 },
+              url: { type: 'string', maxLength: 2048 },
+              userAgent: { type: 'string', maxLength: 512 },
+            },
+          }),
+          responses: {
+            '200': refSuccess(),
+            '400': ref400(),
+            '413': resp('Report body too large'),
+            '429': resp('Too many reports from this client'),
+          },
+        },
+      },
+      '/api/webhooks/stripe': {
+        post: {
+          tags: ['System'],
+          summary: 'Stripe webhook receiver',
+          description:
+            'Receives Stripe subscription and payment events. Authenticated by the ' +
+            '`stripe-signature` header rather than a session or token, and idempotent: ' +
+            'a repeated event id is acknowledged without being reprocessed. ' +
+            'Only active in SaaS mode.',
+          responses: {
+            '200': jsonResponse('Event acknowledged', {
+              type: 'object',
+              properties: { received: { type: 'boolean' } },
+            }),
+            '400': resp('Missing or invalid signature'),
+            '500': resp('Webhook secret not configured, or handler failure'),
+          },
+        },
+      },
+      '/api/dev/clear-rate-limits': {
+        delete: {
+          tags: ['System'],
+          summary: 'Clear rate limits',
+          description:
+            'Clears stored rate-limit counters, for unblocking an account that has locked ' +
+            'itself out. Requires `Authorization: Bearer $CRON_SECRET` in every environment, ' +
+            'and requires Redis. The matched keys are not returned, since they embed client ' +
+            'IPs and attempted email addresses.',
+          security: [{ cronBearer: [] }],
+          parameters: [
+            {
+              name: 'type',
+              in: 'query',
+              schema: { type: 'string' },
+              description: 'Clear only this category, for example `login`. Required unless `all=true`.',
+            },
+            {
+              name: 'all',
+              in: 'query',
+              schema: { type: 'boolean' },
+              description: 'Clear every category.',
+            },
+          ],
+          responses: {
+            '200': jsonResponse('Counters cleared', {
+              type: 'object',
+              properties: {
+                message: { type: 'string' },
+                pattern: { type: 'string' },
+                count: { type: 'integer' },
+              },
+            }),
+            '400': ref400(),
+            '401': ref401(),
+            '503': resp('Redis not available'),
           },
         },
       },

--- a/lib/openapi/journal.ts
+++ b/lib/openapi/journal.ts
@@ -1,7 +1,7 @@
 import {
   createJournalEntrySchema, updateJournalEntrySchema,
 } from '../validations';
-import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage } from './helpers';
+import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, sessionOrToken } from './helpers';
 
 export function journalPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -10,7 +10,7 @@ export function journalPaths(): Record<string, Record<string, unknown>> {
         tags: ['Journal'],
         summary: 'List journal entries',
         description: 'Returns journal entries for the authenticated user, ordered by date descending. Supports filtering by person and text search.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           { name: 'page', in: 'query', schema: { type: 'integer', default: 1 }, description: 'Page number' },
           { name: 'person', in: 'query', schema: { type: 'string' }, description: 'Filter by person ID' },
@@ -39,7 +39,7 @@ export function journalPaths(): Record<string, Record<string, unknown>> {
         tags: ['Journal'],
         summary: 'Create a journal entry',
         description: 'Creates a new journal entry with optional people tags. Can optionally update lastContact for tagged people.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(createJournalEntrySchema),
         responses: {
           '201': jsonResponse('Journal entry created', {
@@ -56,7 +56,7 @@ export function journalPaths(): Record<string, Record<string, unknown>> {
         tags: ['Journal'],
         summary: 'Get a journal entry by ID',
         description: 'Returns a single journal entry with tagged people.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Journal entry ID')],
         responses: {
           '200': jsonResponse('Journal entry details', {
@@ -71,7 +71,7 @@ export function journalPaths(): Record<string, Record<string, unknown>> {
         tags: ['Journal'],
         summary: 'Update a journal entry',
         description: 'Updates title, date, body, and people tags. Can optionally update lastContact.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Journal entry ID')],
         requestBody: zodBody(updateJournalEntrySchema),
         responses: {
@@ -88,7 +88,7 @@ export function journalPaths(): Record<string, Record<string, unknown>> {
         tags: ['Journal'],
         summary: 'Delete a journal entry',
         description: 'Soft-deletes a journal entry.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Journal entry ID')],
         responses: {
           '200': refMessage(),

--- a/lib/openapi/map.ts
+++ b/lib/openapi/map.ts
@@ -1,5 +1,5 @@
 import { retryGeocodeSchema } from '../validations';
-import { jsonResponse, ref400, ref401, ref404, zodBody } from './helpers';
+import { jsonResponse, ref400, ref401, ref404, zodBody, sessionOrToken } from './helpers';
 
 export function mapPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -9,7 +9,7 @@ export function mapPaths(): Record<string, Record<string, unknown>> {
         summary: 'Get map markers',
         description:
           'Returns all plottable points for the current user: successfully geocoded addresses and vCard GEO locations, plus the groups they belong to and counts of addresses still pending or failed geocoding.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Map markers', {
             type: 'object',
@@ -80,7 +80,7 @@ export function mapPaths(): Record<string, Record<string, unknown>> {
         summary: 'Retry geocoding an address',
         description:
           'Forces a fresh geocoder lookup for one address, bypassing the cached result. Used from the contact page when an address could not be located. Respects the instance kill switch and the user geocoding toggle.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(retryGeocodeSchema),
         responses: {
           '200': jsonResponse('Retry outcome', {

--- a/lib/openapi/people.ts
+++ b/lib/openapi/people.ts
@@ -3,7 +3,7 @@ import {
   createImportantDateSchema, updateImportantDateSchema,
   mergePersonSchema,
 } from '../validations';
-import { zodBody, jsonBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refGraph, refSuccess, resp } from './helpers';
+import { zodBody, jsonBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refGraph, refSuccess, resp, sessionOrToken } from './helpers';
 import { DEFAULT_PEOPLE_PAGE_SIZE, MAX_PEOPLE_PAGE_SIZE } from '../constants';
 
 export function peoplePaths(): Record<string, Record<string, unknown>> {
@@ -16,7 +16,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
           'Returns a page of people belonging to the authenticated user, sorted alphabetically by name. ' +
           `Defaults to ${DEFAULT_PEOPLE_PAGE_SIZE} per page; pass \`limit\` and \`offset\` to walk the rest. ` +
           'Includes relationship-to-user info and group memberships.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           {
             name: 'limit',
@@ -77,7 +77,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Create a new person',
         description: 'Adds a new person to your network. Can include group memberships, important dates, and a relationship type to you (or connected through another person).',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(createPersonSchema),
         responses: {
           '201': jsonResponse('Person created', {
@@ -95,7 +95,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Get a person by ID',
         description: 'Returns full details for a single person, including their relationships, groups, and important dates.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': jsonResponse('Person details', {
@@ -110,7 +110,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Update a person',
         description: 'Updates any fields of an existing person. Group memberships and important dates are replaced in full when provided.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         requestBody: zodBody(updatePersonSchema),
         responses: {
@@ -127,7 +127,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Delete a person',
         description: 'Soft-deletes a person. Optionally also deletes orphaned people who were only connected through this person.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         requestBody: zodBody(deletePersonSchema),
         responses: {
@@ -142,7 +142,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Restore a deleted person',
         description: 'Restores a soft-deleted person back to active status.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': jsonResponse('Person restored', {
@@ -160,7 +160,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Permanently delete a person',
         description: 'Permanently deletes a soft-deleted person and all related records (photos, groups, relationships, important dates, etc). This cannot be undone.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': refSuccess(),
@@ -175,7 +175,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Search people by name',
         description: 'Searches across name, surname, middle name, second last name, and nickname. Case-insensitive. Returns up to 20 results.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           { name: 'q', in: 'query', required: true, schema: { type: 'string' }, description: 'Search query (min 1 character)' },
         ],
@@ -198,7 +198,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
           'Returns all searchable data for the authenticated user\'s contacts in a flat, ' +
           'denormalized format optimized for client-side indexing. Multi-value fields ' +
           '(phones, emails, addresses, etc.) are joined into single strings.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Search index data', {
             type: 'object',
@@ -240,7 +240,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Find orphaned connections',
         description: 'Returns people who are only connected to the network through this person. Useful before deletion to warn about people who would become disconnected.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': jsonResponse('Orphan list', {
@@ -268,7 +268,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Bulk actions on people',
         description: 'Perform bulk operations on multiple people. Supports delete (soft-delete with optional orphan and CardDAV cleanup), add to groups, and set relationship type. Specify either personIds or selectAll: true.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           required: ['action'],
@@ -327,7 +327,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Find orphans for bulk deletion',
         description: 'Computes the aggregate list of people who would become disconnected from the network if the specified people were deleted. Used to warn before bulk delete.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -362,7 +362,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Get relationship graph for a person',
         description: 'Returns a D3-compatible graph (nodes and edges) centered on the specified person, showing their direct connections.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': refGraph(),
@@ -378,7 +378,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Find all duplicate contact groups',
         description: 'Scans all contacts and returns groups of potential duplicates based on name, email, phone, and birthday similarity. Dismissed pairs are excluded.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('Duplicate groups', {
             type: 'object',
@@ -414,7 +414,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Find duplicate candidates for a person',
         description: 'Returns contacts similar to the specified person, sorted by similarity descending. Dismissed pairs are excluded.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': jsonResponse('Duplicate candidates', {
@@ -444,7 +444,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Dismiss a duplicate pair',
         description: 'Marks two contacts as not duplicates so they no longer appear in duplicate detection results.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           required: ['personAId', 'personBId'],
@@ -471,7 +471,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['People'],
         summary: 'Merge two contacts',
         description: 'Merges the secondary contact into the primary contact. Relationships, groups, multi-value fields, and important dates are transferred. The secondary contact is soft-deleted after merge.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(mergePersonSchema),
         responses: {
           '200': jsonResponse('Merge result', {
@@ -493,7 +493,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'List important dates for a person',
         description: 'Returns all important dates associated with a person, sorted by date ascending.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': jsonResponse('Important dates list', {
@@ -510,7 +510,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'Create an important date',
         description: 'Adds a new important date to a person with optional reminder configuration.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         requestBody: zodBody(createImportantDateSchema),
         responses: {
@@ -530,7 +530,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'Update an important date',
         description: 'Updates the title, date, and/or reminder settings for an important date.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID'), pathParam('dateId', 'Important date ID')],
         requestBody: zodBody(updateImportantDateSchema),
         responses: {
@@ -547,7 +547,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'Delete an important date',
         description: 'Soft-deletes an important date. Can be restored within the retention period.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID'), pathParam('dateId', 'Important date ID')],
         responses: {
           '200': refMessage(),
@@ -561,7 +561,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'Restore a deleted important date',
         description: 'Restores a soft-deleted important date.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID'), pathParam('dateId', 'Important date ID')],
         responses: {
           '200': jsonResponse('Important date restored', {
@@ -580,7 +580,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Important Dates'],
         summary: 'Permanently delete an important date',
         description: 'Permanently deletes a soft-deleted important date. This cannot be undone.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID'), pathParam('dateId', 'Important date ID')],
         responses: {
           '200': refSuccess(),
@@ -597,7 +597,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Photos'],
         summary: 'Upload or replace a person photo',
         description: 'Upload a photo for a person. The image is cropped to 256x256, converted to JPEG, and EXIF data is stripped.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         requestBody: {
           required: true,
@@ -634,7 +634,7 @@ export function peoplePaths(): Record<string, Record<string, unknown>> {
         tags: ['Photos'],
         summary: 'Remove a person photo',
         description: 'Deletes the photo associated with a person.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Person ID')],
         responses: {
           '200': refMessage(),

--- a/lib/openapi/relationships.ts
+++ b/lib/openapi/relationships.ts
@@ -2,7 +2,7 @@ import {
   createRelationshipSchema, updateRelationshipSchema,
   createRelationshipTypeSchema, updateRelationshipTypeSchema,
 } from '../validations';
-import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refSuccess, resp } from './helpers';
+import { zodBody, pathParam, jsonResponse, ref400, ref401, ref404, refMessage, refSuccess, resp, sessionOrToken } from './helpers';
 
 export function relationshipsPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -11,7 +11,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'List all relationships',
         description: 'Returns all relationships between people in the authenticated user\'s network, including person and type details.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('List of relationships', {
             type: 'object',
@@ -26,7 +26,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'Create a relationship',
         description: 'Creates a bidirectional relationship between two people. Automatically creates the inverse relationship.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(createRelationshipSchema),
         responses: {
           '201': jsonResponse('Relationship created', {
@@ -44,7 +44,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'Get a relationship by ID',
         description: 'Returns a single relationship with person and type details.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship ID')],
         responses: {
           '200': jsonResponse('Relationship details', {
@@ -59,7 +59,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'Update a relationship',
         description: 'Changes the type and/or notes of an existing relationship. Also updates the inverse relationship.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship ID')],
         requestBody: zodBody(updateRelationshipSchema),
         responses: {
@@ -76,7 +76,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'Delete a relationship',
         description: 'Soft-deletes a relationship and its inverse.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship ID')],
         responses: {
           '200': refMessage(),
@@ -89,7 +89,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
       post: {
         tags: ['Relationships'],
         summary: 'Restore a deleted relationship',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship ID')],
         responses: {
           '200': jsonResponse('Relationship restored', {
@@ -108,7 +108,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationships'],
         summary: 'Permanently delete a relationship',
         description: 'Permanently deletes a soft-deleted relationship and its inverse. This cannot be undone.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship ID')],
         responses: {
           '200': refSuccess(),
@@ -125,7 +125,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationship Types'],
         summary: 'List all relationship types',
         description: 'Returns all custom relationship types for the user, including inverse type info.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('List of relationship types', {
             type: 'object',
@@ -140,7 +140,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationship Types'],
         summary: 'Create a relationship type',
         description: 'Creates a new relationship type. Can be symmetric (e.g. Friend <-> Friend) or asymmetric with an inverse (e.g. Parent -> Child). If inverseLabel is provided, the inverse type is auto-created.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(createRelationshipTypeSchema),
         responses: {
           '201': jsonResponse('Relationship type created', {
@@ -156,7 +156,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
       get: {
         tags: ['Relationship Types'],
         summary: 'Get a relationship type by ID',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship type ID')],
         responses: {
           '200': jsonResponse('Relationship type details', {
@@ -171,7 +171,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationship Types'],
         summary: 'Update a relationship type',
         description: 'Updates label, color, inverse, or symmetric status of a relationship type.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship type ID')],
         requestBody: zodBody(updateRelationshipTypeSchema),
         responses: {
@@ -188,7 +188,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationship Types'],
         summary: 'Delete a relationship type',
         description: 'Soft-deletes a relationship type. Fails if the type is currently in use by any relationships.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship type ID')],
         responses: {
           '200': refSuccess(),
@@ -202,7 +202,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
       post: {
         tags: ['Relationship Types'],
         summary: 'Restore a deleted relationship type',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship type ID')],
         responses: {
           '200': jsonResponse('Relationship type restored', {
@@ -220,7 +220,7 @@ export function relationshipsPaths(): Record<string, Record<string, unknown>> {
         tags: ['Relationship Types'],
         summary: 'Permanently delete a relationship type',
         description: 'Permanently deletes a soft-deleted relationship type and clears any remaining references to it. This cannot be undone.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [pathParam('id', 'Relationship type ID')],
         responses: {
           '200': refSuccess(),

--- a/lib/openapi/user.ts
+++ b/lib/openapi/user.ts
@@ -6,7 +6,7 @@ import {
   importDataSchema,
 } from '../validations';
 import { SUPPORTED_LOCALES } from '../locale';
-import { zodBody, jsonBody, jsonResponse, ref400, ref401, refMessage, resp } from './helpers';
+import { zodBody, jsonBody, jsonResponse, ref400, ref401, refMessage, resp, sessionOrToken } from './helpers';
 
 export function userPaths(): Record<string, Record<string, unknown>> {
   return {
@@ -15,7 +15,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Get current user profile',
         description: 'Returns the authenticated user\'s profile information and preferences.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': jsonResponse('User profile', {
             type: 'object',
@@ -28,7 +28,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Update user profile',
         description: 'Updates name, surname, nickname, and/or email. If email is changed, a verification email is sent and the account is marked as unverified.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateProfileSchema),
         responses: {
           '200': jsonResponse('Profile updated', {
@@ -48,7 +48,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Change password',
         description: 'Changes the user\'s password. Requires the current password for verification.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updatePasswordSchema),
         responses: {
           '200': refMessage(),
@@ -61,7 +61,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
       put: {
         tags: ['User Settings'],
         summary: 'Update theme preference',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateThemeSchema),
         responses: {
           '200': jsonResponse('Theme updated', {
@@ -76,7 +76,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
       put: {
         tags: ['User Settings'],
         summary: 'Update date format preference',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateDateFormatSchema),
         responses: {
           '200': jsonResponse('Date format updated', {
@@ -92,7 +92,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Update network-graph display preferences',
         description: 'Updates the user\'s network-graph display mode (individuals or bubbles).',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateGraphDisplaySchema),
         responses: {
           '200': jsonResponse('Graph display settings updated', {
@@ -110,7 +110,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         summary: 'Update address geocoding preference',
         description:
           'Enables or disables automatic geocoding of contact addresses for the map. Re-enabling queues previously skipped addresses for the background geocoder.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateGeocodingSchema),
         responses: {
           '200': jsonResponse('Geocoding preference updated', {
@@ -134,7 +134,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
       put: {
         tags: ['User Settings'],
         summary: 'Update name display order preference',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateNameOrderSchema),
         responses: {
           '200': jsonResponse('Name order updated', {
@@ -149,7 +149,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
       put: {
         tags: ['User Settings'],
         summary: 'Update name display format preference',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(updateNameDisplayFormatSchema),
         responses: {
           '200': jsonResponse('Name display format updated', {
@@ -164,7 +164,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
       put: {
         tags: ['User Settings'],
         summary: 'Update language preference',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -189,7 +189,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Export user data',
         description: 'Exports all user data (people, groups, relationships, relationship types) as JSON. Optionally filter by groups.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         parameters: [
           { name: 'groupIds', in: 'query', schema: { type: 'string' }, description: 'Comma-separated group IDs to filter export' },
         ],
@@ -229,7 +229,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Validate import data',
         description: 'Validates a data import payload without actually importing. Returns counts and conflict information.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({ type: 'object', description: 'Export-format JSON data' }),
         responses: {
           '200': jsonResponse('Validation result', {
@@ -250,7 +250,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Import user data',
         description: 'Imports people, groups, relationships, and relationship types from a Nametag export JSON file.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: zodBody(importDataSchema),
         responses: {
           '200': jsonResponse('Import result', {
@@ -279,7 +279,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['User Settings'],
         summary: 'Delete account',
         description: 'Permanently deletes the user account and all associated data. Requires typing "DELETE" to confirm.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: jsonBody({
           type: 'object',
           properties: {
@@ -300,7 +300,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['Photos'],
         summary: 'Upload or replace user photo',
         description: 'Upload a photo for the logged-in user. The image is cropped to 256x256, converted to JPEG, and EXIF data is stripped.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         requestBody: {
           required: true,
           content: {
@@ -335,7 +335,7 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         tags: ['Photos'],
         summary: 'Remove user photo',
         description: 'Deletes the photo associated with the logged-in user.',
-        security: [{ session: [] }],
+        security: sessionOrToken(),
         responses: {
           '200': refMessage(),
           '401': ref401(),

--- a/tests/api/openapi-coverage.test.ts
+++ b/tests/api/openapi-coverage.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { generateOpenAPISpec } from '@/lib/openapi';
+
+/**
+ * Cross-checks the OpenAPI spec against the routes that actually exist.
+ *
+ * The existing spec test hand-lists paths it expects to find, which cannot
+ * catch a route added without a spec entry. These tests derive the expectation
+ * from the filesystem and from each route's own auth options, so the rule in
+ * CLAUDE.md ("every API endpoint change must be reflected in the spec") fails
+ * the build instead of relying on reviewer memory.
+ */
+
+const API_ROOT = join(process.cwd(), 'app', 'api');
+
+/**
+ * Routes deliberately absent from the public spec. Each needs a reason: this
+ * list is an escape hatch for endpoints that are not part of the documented
+ * API, not a parking spot for undocumented work.
+ */
+const INTENTIONALLY_UNDOCUMENTED = new Map([
+  ['/api/auth/{nextauth}', 'NextAuth.js internal handler; its routes are framework-defined'],
+  ['/api/{notfound}', 'Catch-all that returns 404 for unknown API paths'],
+]);
+
+interface RouteFile {
+  /** Spec-style path, e.g. /api/people/{id} */
+  path: string;
+  /** Repo-relative file path, for failure messages */
+  file: string;
+  source: string;
+  methods: string[];
+  sessionOnly: boolean;
+}
+
+function collectRouteFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...collectRouteFiles(full));
+    else if (entry === 'route.ts') found.push(full);
+  }
+  return found;
+}
+
+function toSpecPath(file: string): string {
+  const dir = relative(process.cwd(), file).replace(/[/\\]route\.ts$/, '');
+  return (
+    '/' +
+    dir
+      .replace(/^app[/\\]/, '')
+      .split(/[/\\]/)
+      .map((seg) =>
+        seg
+          .replace(/^\[\.\.\.(.+)\]$/, '{$1}')
+          .replace(/^\[(.+)\]$/, '{$1}')
+      )
+      .join('/')
+  );
+}
+
+const routes: RouteFile[] = collectRouteFiles(API_ROOT).map((file) => {
+  const source = readFileSync(file, 'utf8');
+  return {
+    path: toSpecPath(file),
+    file: relative(process.cwd(), file),
+    source,
+    methods: [
+      ...new Set(
+        [...source.matchAll(/export const (GET|POST|PUT|PATCH|DELETE)\b/g)].map(
+          (m) => m[1].toLowerCase()
+        )
+      ),
+    ],
+    // Routes opted out of bearer-token auth via withAuth's options.
+    sessionOnly: /allowApiToken:\s*false/.test(source),
+  };
+});
+
+const spec = generateOpenAPISpec() as {
+  paths: Record<string, Record<string, { security?: Array<Record<string, unknown>> }>>;
+};
+
+describe('OpenAPI coverage', () => {
+  it('found the routes and the spec', () => {
+    expect(routes.length).toBeGreaterThan(50);
+    expect(Object.keys(spec.paths).length).toBeGreaterThan(50);
+  });
+
+  it('documents every API route, or explains the omission', () => {
+    const undocumented = routes
+      .filter((r) => !spec.paths[r.path])
+      .filter((r) => !INTENTIONALLY_UNDOCUMENTED.has(r.path))
+      .map((r) => `${r.path} (${r.file})`);
+
+    expect(
+      undocumented,
+      'Add a path entry in lib/openapi/, or add the route to ' +
+        'INTENTIONALLY_UNDOCUMENTED with a reason.'
+    ).toEqual([]);
+  });
+
+  it('has no spec entries for routes that no longer exist', () => {
+    const known = new Set(routes.map((r) => r.path));
+    const stale = Object.keys(spec.paths).filter((p) => !known.has(p));
+
+    expect(stale, 'These spec paths have no route file.').toEqual([]);
+  });
+
+  it('documents every HTTP method each route exports', () => {
+    const gaps: string[] = [];
+
+    for (const route of routes) {
+      const entry = spec.paths[route.path];
+      if (!entry) continue;
+      for (const method of route.methods) {
+        if (!entry[method]) gaps.push(`${method.toUpperCase()} ${route.path}`);
+      }
+    }
+
+    expect(gaps, 'These handlers exist but are not in the spec.').toEqual([]);
+  });
+
+  it('marks session-only routes as session-only in the spec', () => {
+    const wrong: string[] = [];
+
+    for (const route of routes.filter((r) => r.sessionOnly)) {
+      const entry = spec.paths[route.path];
+      if (!entry) continue;
+
+      for (const method of route.methods) {
+        const security = entry[method]?.security;
+        if (!security) continue;
+        const acceptsToken = security.some((scheme) => 'apiToken' in scheme);
+        if (acceptsToken) {
+          wrong.push(
+            `${method.toUpperCase()} ${route.path} uses allowApiToken: false ` +
+              'but the spec advertises apiToken'
+          );
+        }
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+
+  it('advertises apiToken on the routes that accept it', () => {
+    const wrong: string[] = [];
+
+    for (const route of routes.filter((r) => !r.sessionOnly)) {
+      // Only routes wrapped in withAuth participate in token auth. Cron jobs,
+      // webhooks, and the public auth flows use their own schemes.
+      if (!/withAuth\(/.test(route.source)) continue;
+
+      const entry = spec.paths[route.path];
+      if (!entry) continue;
+
+      for (const method of route.methods) {
+        const security = entry[method]?.security;
+        if (!security) {
+          wrong.push(`${method.toUpperCase()} ${route.path} declares no security`);
+          continue;
+        }
+        if (!security.some((scheme) => 'apiToken' in scheme)) {
+          wrong.push(
+            `${method.toUpperCase()} ${route.path} accepts API tokens but the ` +
+              'spec only advertises session'
+          );
+        }
+      }
+    }
+
+    expect(wrong).toEqual([]);
+  });
+});

--- a/tests/api/openapi-spec.test.ts
+++ b/tests/api/openapi-spec.test.ts
@@ -61,9 +61,22 @@ describe('OpenAPI Specification', () => {
   });
 
   it('should require auth on protected endpoints', () => {
-    expect(spec.paths['/api/dashboard/stats'].get.security).toEqual([{ session: [] }]);
-    expect(spec.paths['/api/relationships'].get.security).toEqual([{ session: [] }]);
-    expect(spec.paths['/api/user/profile'].get.security).toEqual([{ session: [] }]);
+    // These accept either a browser session or a personal API token, which is
+    // the default for withAuth. Routes that reject tokens list session alone;
+    // tests/api/openapi-coverage.test.ts checks that against the route options.
+    const sessionOrToken = [{ session: [] }, { apiToken: [] }];
+    expect(spec.paths['/api/dashboard/stats'].get.security).toEqual(sessionOrToken);
+    expect(spec.paths['/api/relationships'].get.security).toEqual(sessionOrToken);
+    expect(spec.paths['/api/user/profile'].get.security).toEqual(sessionOrToken);
+  });
+
+  it('should reject API tokens on credential and billing endpoints', () => {
+    const sessionOnly = [{ session: [] }];
+    expect(spec.paths['/api/user/api-tokens'].post.security).toEqual(sessionOnly);
+    expect(spec.paths['/api/billing/checkout'].post.security).toEqual(sessionOnly);
+    expect(spec.paths['/api/carddav/connection'].post.security).toEqual(sessionOnly);
+    expect(spec.paths['/api/carddav/connection/test'].post.security).toEqual(sessionOnly);
+    expect(spec.paths['/api/carddav/backup'].post.security).toEqual(sessionOnly);
   });
 
   it('should not require auth on public system endpoints', () => {


### PR DESCRIPTION
> Stacked on #386. Merge order: #383, #384, #385, #386, then this.

You asked whether the earlier changes were reflected in the OpenAPI spec and docs. Mostly yes, but auditing it properly turned up drift that predates those PRs and that they made worse. This fixes it and adds a test so it stops recurring.

## The spec could not express "session but not API token"

Every authenticated endpoint declared the same thing:

```js
security: [{ session: [] }]
```

and the difference was carried in the `apiToken` scheme description as prose:

> All endpoints documented with the `session` scheme also accept a valid `apiToken` ... The token-management endpoints themselves require a session.

That was **already wrong on master** for the seven `/api/billing/*` routes, which have used `allowApiToken: false` for a while. Marking `carddav/connection`, `connection/test`, and `backup` session-only in #384 made it wrong for three more.

Security is now explicit per endpoint via two helpers:

| Helper | Meaning | Count |
| --- | --- | --- |
| `sessionOrToken()` | `[{session}, {apiToken}]`, the withAuth default | 91 |
| `sessionOnly()` | `[{session}]`, matches `allowApiToken: false` | 12 |

The scheme description no longer makes a blanket claim; it points the reader at each endpoint's own list.

## The docs had the same error, in a form a reader would trip over

Five curl examples in `api/carddav.md` showed `Authorization: Bearer ntag_xxx` against endpoints that now answer `401`:

- Create / Update / Delete a CardDAV connection
- Test CardDAV credentials
- Download vCard backup

Those now use `--cookie "authjs.session-token=..."`. Anyone copy-pasting them would have got a confusing 401 with no hint why.

`api/overview.md` called token management "the one exception" and now lists all three groups with the reason for each.

## Four routes were missing from the spec entirely

| Route | Note |
| --- | --- |
| `/api/log-error` | Its `413` and `429` responses are new in #384, and it had never been in the spec |
| `/api/webhooks/stripe` | Signature-authed, idempotent, SaaS-only |
| `/api/cron/send-reminders` | The other three cron jobs were documented; this one was not |
| `/api/dev/clear-rate-limits` | #384 changed its guard; documented in `cron-jobs.md` prose but not the spec |

`/api/auth/[...nextauth]` and the `/api/[...notfound]` catch-all stay out deliberately, with the reason recorded next to the exclusion rather than left implicit.

## Why this kept drifting

`tests/api/openapi-spec.test.ts` checks coverage with a hand-written list:

```js
expect(spec.paths['/api/dashboard/stats']).toBeDefined();
expect(spec.paths['/api/relationships']).toBeDefined();
// ...
```

That can only catch a path someone remembered to add to the list, which is exactly the memory the CLAUDE.md rule was already relying on.

`tests/api/openapi-coverage.test.ts` derives its expectations from the filesystem and from each route's own `withAuth` options instead. It fails when:

- a route has no spec entry, unless listed in `INTENTIONALLY_UNDOCUMENTED` **with a reason**
- a spec path has no corresponding route file
- a route exports an HTTP method the spec does not document
- a route uses `allowApiToken: false` but the spec advertises `apiToken`
- a route accepts tokens but the spec advertises `session` alone

I checked both directions actually bite rather than assuming:

```
# added app/api/drift-canary/route.ts
FAIL  OpenAPI coverage > documents every API route, or explains the omission

# removed allowApiToken: false from carddav/backup
FAIL  OpenAPI coverage > advertises apiToken on the routes that accept it
```

The three `security` assertions in the old spec test needed updating for the new shape, and I added one asserting the credential and billing endpoints stay session-only.

## Verification

`npm run lint`, `npm run typecheck`, `npx vitest run` (2592 passed, 1 skipped), `npm run build` (exit 0), `cd docs && npm run build`.
