### PR TITLE
fix: anchor parsed vCard dates to UTC to stop per-sync date drift

### DIFF
--- a/lib/carddav/vcard-parser.ts
+++ b/lib/carddav/vcard-parser.ts
@@ -584,7 +584,7 @@ function processProperty(
 
     // Server-authored metadata that has no user-facing meaning in Nametag.
     // We consume it so it doesn't leak into unknownProperties, but we do NOT
-    // preserve it — round-tripping REV/PRODID accumulates duplicates and has
+    // preserve it. Round-tripping REV/PRODID accumulates duplicates and has
     // caused CardDAV push failures when exported values carry odd escaping.
     case 'REV':
     case 'PRODID':
@@ -776,6 +776,12 @@ function parseSocialProfile(
 
 /**
  * Parse vCard date (supports multiple formats)
+ *
+ * Calendar dates are anchored at UTC midnight, matching how the rest of
+ * Nametag stores them (see `lib/date-format.ts` and the important-dates API)
+ * and how `formatVCardV3Date` reads them back. Building them at local midnight
+ * instead put every date on the previous UTC day for users east of UTC, so
+ * each sync shifted dates one day earlier and rewrote the vCard every cycle.
  */
 function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Date | null {
   if (!dateStr) {
@@ -790,7 +796,7 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
       const month = parseInt(yearMatch[2], 10);
       const day = parseInt(yearMatch[3], 10);
       // Use year 1604 to indicate unknown year (matches Apple convention)
-      return new Date(1604, month - 1, day);
+      return new Date(Date.UTC(1604, month - 1, day));
     }
   }
 
@@ -805,7 +811,7 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
         const month = parseInt(parts[0], 10);
         const day = parseInt(parts[1], 10);
         // Use year 1604 to indicate unknown year (matches Apple convention)
-        return new Date(1604, month - 1, day);
+        return new Date(Date.UTC(1604, month - 1, day));
       }
     }
 
@@ -814,7 +820,7 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
       const month = parseInt(rest.substring(0, 2), 10);
       const day = parseInt(rest.substring(2, 4), 10);
       // Use year 1604 to indicate unknown year (matches Apple convention)
-      return new Date(1604, month - 1, day);
+      return new Date(Date.UTC(1604, month - 1, day));
     }
   }
 
@@ -823,7 +829,7 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
     const year = parseInt(dateStr.substring(0, 4), 10);
     const month = parseInt(dateStr.substring(4, 6), 10);
     const day = parseInt(dateStr.substring(6, 8), 10);
-    return new Date(year, month - 1, day);
+    return new Date(Date.UTC(year, month - 1, day));
   }
 
   // Handle YYYY-MM-DD or ISO 8601

--- a/tests/lib/carddav/vcard-date-timezone.test.ts
+++ b/tests/lib/carddav/vcard-date-timezone.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { personToVCard, formatVCardV3Date } from '@/lib/carddav/vcard-export';
+import { parseVCard } from '@/lib/carddav/vcard-parser';
+import type { PersonWithRelations } from '@/lib/carddav/types';
+
+/**
+ * Regression tests for issue #373 follow-up: calendar dates drifted one day
+ * earlier on every CardDAV round trip for users east of UTC.
+ *
+ * `parseVCardDate` built dates at local midnight while `formatVCardV3Date`
+ * reads UTC components, so in any timezone ahead of UTC a parsed date landed
+ * on the previous UTC day. Each import shifted every date back by one, and the
+ * sync engine re-exports afterwards, so the vCard (and its etag) changed on
+ * every cycle. Nametag stores calendar dates as UTC midnight everywhere else
+ * (see `lib/date-format.ts` and the important-dates API), so the parser is the
+ * side that has to change.
+ *
+ * These tests pin the process timezone because the bug is invisible under UTC
+ * and under any timezone west of UTC, which is why the existing suite passed.
+ */
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+// Two zones ahead of UTC (where the bug appeared), one behind, plus UTC.
+const TIMEZONES = ['UTC', 'Europe/Berlin', 'Australia/Sydney', 'America/New_York'];
+
+function withTimezone<T>(tz: string, fn: () => T): T {
+  process.env.TZ = tz;
+  return fn();
+}
+
+function buildPerson(
+  importantDates: PersonWithRelations['importantDates']
+): PersonWithRelations {
+  return {
+    id: 'person-1',
+    uid: 'uid-1',
+    name: 'Jane',
+    surname: 'Doe',
+    phoneNumbers: [],
+    emails: [],
+    addresses: [],
+    urls: [],
+    imHandles: [],
+    locations: [],
+    customFields: [],
+    customFieldValues: [],
+    importantDates,
+    groups: [],
+  } as unknown as PersonWithRelations;
+}
+
+function dateLinesOf(vCard: string): string[] {
+  return vCard
+    .split(/\r?\n/)
+    .filter((line) => /^(BDAY:|item\d+\.X-ABDATE|item\d+\.X-ABLabel)/.test(line))
+    .sort();
+}
+
+function importantDate(
+  type: string | null,
+  title: string,
+  iso: string
+): PersonWithRelations['importantDates'][number] {
+  return {
+    id: `date-${type ?? title}`,
+    type,
+    title,
+    date: new Date(iso),
+    deletedAt: null,
+  } as unknown as PersonWithRelations['importantDates'][number];
+}
+
+describe('vCard date timezone handling', () => {
+  describe.each(TIMEZONES)('in %s', (tz) => {
+    it('parses a v3 BDAY to UTC midnight, not local midnight', () => {
+      withTimezone(tz, () => {
+        const parsed = parseVCard(
+          ['BEGIN:VCARD', 'VERSION:3.0', 'FN:Jane Doe', 'BDAY:19800315', 'END:VCARD'].join('\r\n')
+        );
+
+        expect(parsed.importantDates).toHaveLength(1);
+        expect(parsed.importantDates[0].date.toISOString()).toBe('1980-03-15T00:00:00.000Z');
+      });
+    });
+
+    it('round-trips a parsed date back to the same wire value', () => {
+      withTimezone(tz, () => {
+        const parsed = parseVCard(
+          ['BEGIN:VCARD', 'VERSION:3.0', 'FN:Jane Doe', 'BDAY:19800315', 'END:VCARD'].join('\r\n')
+        );
+
+        expect(formatVCardV3Date(parsed.importantDates[0].date)).toBe('19800315');
+      });
+    });
+
+    it('keeps every date stable across repeated export/import sync cycles', () => {
+      withTimezone(tz, () => {
+        let dates = [
+          importantDate('birthday', '', '1980-03-15T00:00:00Z'),
+          importantDate('anniversary', '', '2005-06-01T00:00:00Z'),
+          importantDate('nameday', '', '2001-01-02T00:00:00Z'),
+          importantDate(null, 'Graduation', '2010-09-09T00:00:00Z'),
+        ];
+
+        const emitted: string[][] = [];
+        for (let cycle = 0; cycle < 4; cycle++) {
+          const vCard = personToVCard(buildPerson(dates));
+          emitted.push(dateLinesOf(vCard));
+          dates = parseVCard(vCard).importantDates.map((d, i) =>
+            importantDate(d.type ?? null, d.title || `date-${i}`, d.date.toISOString())
+          );
+        }
+
+        // Every cycle must emit byte-identical date lines. Any difference means
+        // the sync engine would rewrite the vCard (and bump the etag) forever.
+        for (let cycle = 1; cycle < emitted.length; cycle++) {
+          expect(emitted[cycle], `drifted on cycle ${cycle}`).toEqual(emitted[0]);
+        }
+        expect(emitted[0]).toContain('BDAY:19800315');
+      });
+    });
+
+    it('does not shift year-omitted dates (--MMDD)', () => {
+      withTimezone(tz, () => {
+        const parsed = parseVCard(
+          ['BEGIN:VCARD', 'VERSION:3.0', 'FN:Jane Doe', 'BDAY:--0315', 'END:VCARD'].join('\r\n')
+        );
+
+        const date = parsed.importantDates[0].date;
+        expect(date.getUTCMonth() + 1).toBe(3);
+        expect(date.getUTCDate()).toBe(15);
+        expect(formatVCardV3Date(date)).toBe('--0315');
+      });
+    });
+
+    it('does not shift dates carrying X-APPLE-OMIT-YEAR', () => {
+      withTimezone(tz, () => {
+        const parsed = parseVCard(
+          [
+            'BEGIN:VCARD',
+            'VERSION:3.0',
+            'FN:Jane Doe',
+            'BDAY;X-APPLE-OMIT-YEAR=1604:1604-03-15',
+            'END:VCARD',
+          ].join('\r\n')
+        );
+
+        const date = parsed.importantDates[0].date;
+        expect(date.getUTCMonth() + 1).toBe(3);
+        expect(date.getUTCDate()).toBe(15);
+        expect(formatVCardV3Date(date)).toBe('--0315');
+      });
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #373. The reporter confirmed the original fix resolved the macOS lockup, but [noted](https://github.com/mattogodoy/nametag/issues/373#issuecomment-5146748807) that CalDAV Synchronizer still sees multiple yearly reminders. This is a separate bug that explains that.

## The bug

Calendar dates move **one day earlier on every CardDAV round trip** for users east of UTC.

| | Location | Behavior |
|---|---|---|
| Parse | `vcard-parser.ts:826` | `new Date(year, month-1, day)` → **local** midnight |
| Format | `vcard-export.ts:480-482` | `getUTCFullYear/Month/Date` → **UTC** |

In any timezone ahead of UTC, local midnight falls on the previous UTC day. Running export → parse → export six times under `TZ=Europe/Berlin`:

```
BDAY:19800315 → 19800314 → 19800313 → 19800312 → 19800311 → 19800310
```

| Timezone | Before |
|---|---|
| UTC | ok |
| America/New_York (UTC-) | no drift, but still parsed to the wrong instant |
| Europe/Berlin (UTC+) | **drifts** |
| Australia/Sydney (UTC+) | **drifts** |

`lib/date-format.ts:6` states the convention directly: *"Nametag stores calendar dates as UTC-midnight DateTime values"*. The important-dates API (`app/api/people/[id]/important-dates/route.ts:83`) does `new Date(date)` on `YYYY-MM-DD`, which is UTC midnight per spec. `parseVCardDate` was the only place that disagreed.

## Why it produces duplicate reminders in Outlook

The shift rewrites the vCard on every sync cycle, so the server etag changes every cycle and CalDAV Synchronizer re-pushes the contact into Outlook each time. Outlook regenerates its yearly birthday/anniversary event on each re-import rather than replacing it.

The drift happens on import, and several paths trigger an import every cycle:

- `client.ts:235` does `response.headers?.get('etag') || vCard.etag` on PUT. A server that omits the ETag header (permitted by RFC 6352) silently persists the **stale** etag, so the next pull sees `mapping.etag !== vCard.etag` (`sync.ts:243`) and re-imports the card Nametag just wrote.
- Photo mismatch marks `syncStatus: 'pending'` in two places (`sync.ts:250-264` and `sync.ts:411-433`). Many servers strip `PHOTO`, so this fires every cycle.
- Name drift does the same when `cardDavNameFormat !== 'FULL'` or a display-name override exists.

At the default 5 minute interval that is roughly 288 days of drift per day of uptime. Conflict detection is timestamp-only, so a date-only difference is never flagged and is applied silently. Both dedup keys added in #374 key on the already-shifted day, so they cannot mask it.

There is also a user-visible symptom independent of sync: an imported birthday is stored at local midnight, so `parseAsLocalDate` reads the ISO prefix and displays it **one day early** for UTC+ users.

## The fix

Anchor all four `parseVCardDate` branches at UTC midnight, including the year-omitted `--MMDD` and `X-APPLE-OMIT-YEAR` paths.

## Why the suite missed it

Parse and export were tested separately, each internally consistent, with no round-trip assertion. All 344 CardDAV tests pass under `TZ=Europe/Berlin` on master.

This adds a timezone-parameterized regression test over UTC, Europe/Berlin, Australia/Sydney and America/New_York asserting UTC-midnight parsing and byte-identical output across four export/import cycles. **It fails 11 of 20 cases without the fix.**

## Test plan

- [x] New regression test fails on master (11/20), passes with the fix (20/20)
- [x] Full suite green under `TZ=UTC`: 196 files, 2612 passed
- [x] Full suite green under `TZ=Europe/Berlin`: 196 files, 2612 passed
- [x] `tsc --noEmit` and `eslint` clean
- [ ] Manual: sync from a UTC+ timezone and confirm a birthday stays put across several cycles

## Not included

`client.ts:235` falling back to a stale etag is a real loop-closing defect but is a broader behavioral change, so I left it out. Worth a follow-up issue.

## Note for the reporter

Dates already walked backward on affected installs. This stops the drift but does not restore the original values, so those contacts need correcting by hand. Their planned account re-add should clear the stale Outlook-side reminder duplicates.