### PR TITLE
fix: remove ESLint auto-fix-on-save from VS Code settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,6 @@
 {
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
-  },
   "typescript.tsdk": "node_modules/typescript/lib",
   "files.exclude": {
     "**/.git": true,


### PR DESCRIPTION
## Summary

- Removes `source.fixAll.eslint: "explicit"` from `.vscode/settings.json`
- This setting caused ESLint auto-fixes on save, which introduced unrelated formatting changes into PRs (see [#390 review comment](https://github.com/mattogodoy/nametag/pull/390#discussion_r3695336621))

## Test plan

- [ ] Open a `.ts` file in VS Code, make a change, save, and confirm no unrelated formatting changes appear in the diff