### PR TITLE
fix(people): show the full name in the people list on narrow screens

### DIFF
--- a/app/people/page.tsx
+++ b/app/people/page.tsx
@@ -38,7 +38,7 @@ export default async function PeoplePage({
   const canCreate = await canCreateResource(session.user.id, 'people');
 
   // Fetch user's date format preference
-  const { dateFormat, nameOrder } = await getUserDisplayPreferences(session.user.id);
+  const { dateFormat, nameOrder, nameDisplayFormat } = await getUserDisplayPreferences(session.user.id);
 
   const params = await searchParams;
   const currentPage = Number(params.page) || 1;
@@ -274,7 +274,9 @@ export default async function PeoplePage({
                 relationshipTypes={relationshipTypes}
                 customFieldTemplates={customFieldTemplates}
                 nameOrder={nameOrder}
+                nameDisplayFormat={nameDisplayFormat}
                 translations={{
+                  fullName: t('fullName'),
                   surname: t('surname'),
                   nickname: t('nickname'),
                   relationshipToUser: t('relationshipToUser'),

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -9,7 +9,7 @@ import BulkDeleteModal from './BulkDeleteModal';
 import BulkGroupAssignModal from './BulkGroupAssignModal';
 import BulkRelationshipModal from './BulkRelationshipModal';
 import PersonAvatar from './PersonPhoto';
-import { formatCanonicalName } from '@/lib/nameUtils';
+import { formatCanonicalName, type NameDisplayFormat } from '@/lib/nameUtils';
 import { formatDate, type DateFormat } from '@/lib/date-format';
 import CustomFieldFilter from './customFields/CustomFieldFilter';
 import type { CustomFieldTemplate } from '@prisma/client';
@@ -57,7 +57,9 @@ interface PeopleListClientProps {
   relationshipTypes: RelationshipType[];
   customFieldTemplates: CustomFieldTemplate[];
   nameOrder?: 'WESTERN' | 'EASTERN';
+  nameDisplayFormat?: NameDisplayFormat;
   translations: {
+    fullName: string;
     surname: string;
     nickname: string;
     relationshipToUser: string;
@@ -79,6 +81,49 @@ interface PeopleListClientProps {
   };
 }
 
+/**
+ * The linked name in a person row, plus the orphan marker and any display
+ * override. Rendered twice per row: once for the combined mobile column and
+ * once for the first-name column shown from md up.
+ */
+function NameCell({
+  href,
+  label,
+  isOrphan,
+  orphanWarning,
+  displayNameOverride,
+}: {
+  href: string;
+  label: string;
+  isOrphan: boolean;
+  orphanWarning: string;
+  displayNameOverride?: string | null;
+}) {
+  return (
+    <div>
+      <div className="flex items-center gap-2">
+        <Link href={href} className="text-primary hover:underline font-medium">
+          {label}
+        </Link>
+        {isOrphan && (
+          <span className="relative group cursor-help">
+            <span className="text-yellow-500">{'⚠️'}</span>
+            <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-xs text-foreground bg-surface-elevated rounded-lg whitespace-normal max-w-xs z-50 shadow-lg border border-border">
+              {orphanWarning}
+              <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-px border-4 border-transparent border-t-surface-elevated"></span>
+            </span>
+          </span>
+        )}
+      </div>
+      {displayNameOverride && (
+        <div className="mt-1 text-xs text-muted">
+          {displayNameOverride}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function PeopleListClient({
   people,
   totalCount,
@@ -94,6 +139,7 @@ export default function PeopleListClient({
   relationshipTypes,
   customFieldTemplates,
   nameOrder,
+  nameDisplayFormat,
   translations: tt,
   commonTranslations: tc,
 }: PeopleListClientProps) {
@@ -210,6 +256,10 @@ export default function PeopleListClient({
     return `/people?${params.toString()}`;
   };
 
+  // Sort the combined column by whichever part the reader sees first, so the
+  // list looks alphabetical in the order it is actually displayed.
+  const fullNameSortKey = nameOrder === 'EASTERN' ? 'surname' : 'name';
+
   const buildPageUrl = (page: number) => {
     const params = buildFilterParams();
     params.set('page', page.toString());
@@ -291,7 +341,16 @@ export default function PeopleListClient({
                   />
                 </th>
                 <th className="w-[32px] py-3 px-2" />
-                <th className="px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+                {/* Narrow screens have no room for the separate name parts, so
+                    they get a single combined column instead (see the Name,
+                    Surname and Nickname headers below). */}
+                <th className="md:hidden px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
+                  <Link href={buildSortUrl(fullNameSortKey)} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
+                    {tt.fullName}
+                    {sortBy === fullNameSortKey && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
+                  </Link>
+                </th>
+                <th className="hidden md:table-cell px-6 py-3 text-left text-xs font-medium text-muted uppercase tracking-wider">
                   <Link href={buildSortUrl('name')} className="flex items-center gap-1 hover:text-foreground py-2 -my-2 min-h-11 sm:min-h-0">
                     {tc.name}
                     {sortBy === 'name' && <span className="text-primary">{order === 'asc' ? '\u2191' : '\u2193'}</span>}
@@ -339,6 +398,10 @@ export default function PeopleListClient({
                                  person.relationshipsTo.length === 0;
                 const isChecked = selectAllPages || selectedIds.has(person.id);
                 const fullDisplayName = formatCanonicalName(person, nameOrder);
+                // What the combined mobile column shows. Unlike fullDisplayName
+                // (avatar initials, checkbox label) this also applies the user's
+                // name display format, so SHORT collapses it to a first name.
+                const combinedName = formatCanonicalName(person, nameOrder, nameDisplayFormat);
 
                 return (
                   <tr key={person.id} className={`hover:bg-surface-elevated transition-colors ${isChecked ? 'bg-primary/5' : ''}`}>
@@ -359,28 +422,23 @@ export default function PeopleListClient({
                         size={32}
                       />
                     </td>
-                    <td className="px-6 py-4 whitespace-nowrap">
-                      <div>
-                        <div className="flex items-center gap-2">
-                          <Link href={`/people/${person.id}`} className="text-primary hover:underline font-medium">
-                            {person.name}
-                          </Link>
-                          {isOrphan && (
-                            <span className="relative group cursor-help">
-                              <span className="text-yellow-500">{'\u26A0\uFE0F'}</span>
-                              <span className="invisible group-hover:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 text-xs text-foreground bg-surface-elevated rounded-lg whitespace-normal max-w-xs z-50 shadow-lg border border-border">
-                                {tt.orphanWarning}
-                                <span className="absolute top-full left-1/2 -translate-x-1/2 -mt-px border-4 border-transparent border-t-surface-elevated"></span>
-                              </span>
-                            </span>
-                          )}
-                        </div>
-                        {person.displayNameOverride && (
-                          <div className="mt-1 text-xs text-muted">
-                            {person.displayNameOverride}
-                          </div>
-                        )}
-                      </div>
+                    <td className="md:hidden px-6 py-4 whitespace-nowrap">
+                      <NameCell
+                        href={`/people/${person.id}`}
+                        label={combinedName}
+                        isOrphan={isOrphan}
+                        orphanWarning={tt.orphanWarning}
+                        displayNameOverride={person.displayNameOverride}
+                      />
+                    </td>
+                    <td className="hidden md:table-cell px-6 py-4 whitespace-nowrap">
+                      <NameCell
+                        href={`/people/${person.id}`}
+                        label={person.name}
+                        isOrphan={isOrphan}
+                        orphanWarning={tt.orphanWarning}
+                        displayNameOverride={person.displayNameOverride}
+                      />
                     </td>
                     <td className="hidden md:table-cell px-6 py-4 whitespace-nowrap text-sm text-foreground">
                       {person.surname || '\u2014'}

--- a/docs/src/content/docs/features/people.md
+++ b/docs/src/content/docs/features/people.md
@@ -63,6 +63,8 @@ If you've defined custom field templates in Settings (text, number, boolean, or 
 
 The People page shows everyone in your network, 50 per page.
 
+**Columns adapt to your screen width.** On wide screens the list breaks names into separate Name, Surname and Nickname columns, so each one can be sorted on its own. On narrow screens there is no room for all three, so they collapse into a single **Full Name** column showing the complete name. That column follows your [name order and name display format](/features/settings/) settings, so a Short name display format shows only the nickname or first name there too.
+
 **Sorting** is available by:
 
 - Name

--- a/tests/components/PeopleListClient.test.tsx
+++ b/tests/components/PeopleListClient.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NextIntlClientProvider } from 'next-intl';
 import PeopleListClient from '../../components/PeopleListClient';
@@ -83,6 +83,7 @@ function makePerson(overrides: Partial<PersonRow> = {}): PersonRow {
 }
 
 const defaultTranslations: React.ComponentProps<typeof PeopleListClient>['translations'] = {
+  fullName: 'Full Name',
   surname: 'Last Name',
   nickname: 'Nickname',
   relationshipToUser: 'Relationship',
@@ -285,8 +286,11 @@ describe('PeopleListClient', () => {
         </Wrapper>
       );
 
-      // Orphan warning icon appears (⚠️)
-      expect(screen.getByText('⚠️')).toBeInTheDocument();
+      // Orphan warning icon appears (⚠️) in whichever name column is visible
+      const mobileCell = screen.getByText('Alice Smith').closest('td')!;
+      const desktopCell = screen.getByText('Alice').closest('td')!;
+      expect(within(mobileCell).getByText('⚠️')).toBeInTheDocument();
+      expect(within(desktopCell).getByText('⚠️')).toBeInTheDocument();
     });
 
     it('keeps the real name primary and shows display override as secondary text', () => {
@@ -308,9 +312,153 @@ describe('PeopleListClient', () => {
         </Wrapper>
       );
 
-      expect(screen.getByRole('link', { name: 'Robert' })).toBeInTheDocument();
-      expect(screen.getByText('Dad')).toBeInTheDocument();
+      // Both name columns link the canonical name and keep the override secondary
+      const mobileCell = screen.getByRole('link', { name: 'Robert Johnson' }).closest('td')!;
+      const desktopCell = screen.getByRole('link', { name: 'Robert' }).closest('td')!;
+      expect(within(mobileCell).getByText('Dad')).toBeInTheDocument();
+      expect(within(desktopCell).getByText('Dad')).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Dad' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Mobile full name column', () => {
+    it('renders a full name column combining every name part', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+            })}
+          />
+        </Wrapper>
+      );
+
+      expect(screen.getByText('Full Name')).toBeInTheDocument();
+      expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    });
+
+    it('links the full name to the person', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+            })}
+          />
+        </Wrapper>
+      );
+
+      expect(screen.getByRole('link', { name: 'Alice Smith' })).toHaveAttribute(
+        'href',
+        '/people/p-1'
+      );
+    });
+
+    it('puts the surname first when the user picked Eastern name order', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+              nameOrder: 'EASTERN',
+            })}
+          />
+        </Wrapper>
+      );
+
+      expect(screen.getByText('Smith Alice')).toBeInTheDocument();
+      expect(screen.queryByText('Alice Smith')).not.toBeInTheDocument();
+    });
+
+    it('honours the Short name display format', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [
+                makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith', nickname: 'Ali' }),
+              ],
+              nameDisplayFormat: 'SHORT',
+            })}
+          />
+        </Wrapper>
+      );
+
+      expect(screen.getByText('Ali')).toBeInTheDocument();
+      expect(screen.queryByText("Alice 'Ali' Smith")).not.toBeInTheDocument();
+    });
+
+    it('sorts the combined column by first name in Western order', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+            })}
+          />
+        </Wrapper>
+      );
+
+      const header = screen.getByText('Full Name').closest('th')!;
+      expect(within(header).getByRole('link')).toHaveAttribute(
+        'href',
+        expect.stringContaining('sortBy=name')
+      );
+    });
+
+    it('sorts the combined column by surname in Eastern order, matching what is read first', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+              nameOrder: 'EASTERN',
+            })}
+          />
+        </Wrapper>
+      );
+
+      const header = screen.getByText('Full Name').closest('th')!;
+      expect(within(header).getByRole('link')).toHaveAttribute(
+        'href',
+        expect.stringContaining('sortBy=surname')
+      );
+    });
+
+    it('shows the full name column only below the md breakpoint', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+            })}
+          />
+        </Wrapper>
+      );
+
+      const fullNameHeader = screen.getByText('Full Name').closest('th');
+      const fullNameCell = screen.getByText('Alice Smith').closest('td');
+
+      expect(fullNameHeader).toHaveClass('md:hidden');
+      expect(fullNameCell).toHaveClass('md:hidden');
+    });
+
+    it('hides the first-name column below the md breakpoint so names are not duplicated', () => {
+      render(
+        <Wrapper>
+          <PeopleListClient
+            {...defaultProps({
+              people: [makePerson({ id: 'p-1', name: 'Alice', surname: 'Smith' })],
+            })}
+          />
+        </Wrapper>
+      );
+
+      const nameHeader = screen.getByText('Name').closest('th');
+      const nameCell = screen.getByText('Alice').closest('td');
+
+      expect(nameHeader).toHaveClass('hidden', 'md:table-cell');
+      expect(nameCell).toHaveClass('hidden', 'md:table-cell');
     });
   });
 
@@ -549,8 +697,12 @@ describe('PeopleListClient', () => {
         </Wrapper>
       );
 
-      // Ascending arrow ↑ should appear next to Name
-      expect(screen.getByText('↑')).toBeInTheDocument();
+      // Ascending arrow ↑ should appear on both name headers, since Western
+      // order sorts the combined mobile column by first name too
+      expect(within(screen.getByText('Name').closest('th')!).getByText('↑')).toBeInTheDocument();
+      expect(
+        within(screen.getByText('Full Name').closest('th')!).getByText('↑')
+      ).toBeInTheDocument();
     });
 
     it('shows descending indicator when order is desc', () => {
@@ -562,7 +714,7 @@ describe('PeopleListClient', () => {
         </Wrapper>
       );
 
-      expect(screen.getByText('↓')).toBeInTheDocument();
+      expect(within(screen.getByText('Name').closest('th')!).getByText('↓')).toBeInTheDocument();
     });
 
     it('renders sort links for table headers', () => {


### PR DESCRIPTION
## Problem

Reported by a user: the People tab shows only first names, so their iCloud-synced contacts read "Bob", "Dave", "Linda", "Scott" with no way to tell them apart.

The list splits names across Name, Surname and Nickname columns, but Surname is hidden below the `md` breakpoint and Nickname below `lg`. On a phone or a narrow window only the first name survives. The columns are `display: none` rather than off-screen, so there is nothing to scroll to, and no setting anywhere changes it.

The data itself was fine: `lib/carddav/vcard-parser.ts` maps `N` to `surname` correctly, it just never got rendered.

## Fix

Two name columns, one visible per breakpoint:

- New **Full Name** column, `md:hidden`, rendering `formatCanonicalName(person, nameOrder, nameDisplayFormat)`
- Existing **Name** column becomes `hidden md:table-cell`, so the surname is never printed twice

Surname and Nickname columns are unchanged. Sorting is preserved on mobile: the Full Name header sorts by `name` in Western order and by `surname` in Eastern, so the list reads alphabetically by whichever part appears first.

`app/people/page.tsx` now destructures `nameDisplayFormat` (already loaded by `getUserDisplayPreferences`, previously unused) and passes it through with `t('fullName')`. `people.fullName` already existed in all 9 locale files, so no new translation keys were needed.

The name cell markup is extracted into a `NameCell` component rather than duplicating the link, orphan warning and display-override blocks across both columns.

## Verification

- 6 new tests written first and watched fail before implementing. 37/37 pass in `tests/components/PeopleListClient.test.tsx`.
- Bite-checked with 4 mutations (sort key forced to `name`, `nameDisplayFormat` dropped, `md:hidden` removed, Name column reverted to always-visible). Each caught by exactly one test.
- `tsc --noEmit`, eslint, `npm run build` and the docs build all clean.
- Full suite: 2626 passed, 2 failed. Both failures are pre-existing in `tests/lib/carddav/vcard-parser.test.ts` (BDAY year-omitted day off-by-one, looks timezone-dependent); reproduced on a clean `origin/master` and unrelated to this change.

## Notes

- The breakpoint tests assert the Tailwind class contract, since jsdom applies no CSS. A Playwright test at a 390px viewport would be the stronger check if we want one later.
- Avatar initials and the checkbox aria-label still use name order only, not the display format, so a user on Short format keeps "AS" rather than "A". Left deliberately unchanged.
- No API changes, so no OpenAPI spec update. No breaking changes or migrations, so no release warning block needed.

Docs updated at `docs/src/content/docs/features/people.md`.