### PR TITLE
test: make date assertions timezone and clock independent

### DIFF
--- a/tests/components/LastContactQuickUpdate.test.tsx
+++ b/tests/components/LastContactQuickUpdate.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { getLocalDateString } from '@/lib/date-format';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NextIntlClientProvider } from 'next-intl';
@@ -44,10 +45,30 @@ describe('LastContactQuickUpdate', () => {
     global.fetch = vi.fn();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The component derives relative time and "is today" from the current clock,
+  // so tests that depend on it pin the clock. A real "now" makes them drift
+  // across midnight and across the spring DST jump.
+  //
+  // Late-evening UTC is deliberate: east of UTC the local date is already the
+  // next day, so building a date via toISOString() lands on the wrong calendar
+  // day and these tests catch it. Mid-March keeps clear of every DST switch.
+  function pinClock() {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-15T23:30:00Z'));
+  }
+
   it('renders last contact date and relative time when date exists', () => {
+    pinClock();
+    // Step back a day in local terms and serialise locally. Mixing the two,
+    // by stepping back locally then calling toISOString(), lands two calendar
+    // days back whenever local and UTC disagree on the date.
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
-    const isoDate = yesterday.toISOString().split('T')[0];
+    const isoDate = getLocalDateString(yesterday);
 
     render(
       <Wrapper>
@@ -109,11 +130,12 @@ describe('LastContactQuickUpdate', () => {
   });
 
   it('hides the button when last contact is today', () => {
+    pinClock();
     render(
       <Wrapper>
         <LastContactQuickUpdate
           personId="person-1"
-          currentLastContact={new Date().toISOString()}
+          currentLastContact={getLocalDateString()}
           dateFormat="MDY"
         />
       </Wrapper>

--- a/tests/lib/carddav/vcard-parser.test.ts
+++ b/tests/lib/carddav/vcard-parser.test.ts
@@ -379,9 +379,10 @@ END:VCARD`;
       const parsed = parseVCard(vCard);
 
       expect(parsed.importantDates).toHaveLength(1);
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(1604); // Year unknown marker
-      expect(parsed.importantDates[0].date.getMonth()).toBe(4);
-      expect(parsed.importantDates[0].date.getDate()).toBe(15);
+      // Calendar dates are stored as UTC midnight, so assert the UTC instant.
+      // Local getters would report the previous day west of UTC, and 1604
+      // predates standard time so every zone has an offset there.
+      expect(parsed.importantDates[0].date.toISOString()).toBe('1604-05-15T00:00:00.000Z'); // 1604 = year unknown marker
     });
 
     it('should parse BDAY with year-omitted (v3 format)', () => {
@@ -394,9 +395,7 @@ END:VCARD`;
       const parsed = parseVCard(vCard);
 
       expect(parsed.importantDates).toHaveLength(1);
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(1604);
-      expect(parsed.importantDates[0].date.getMonth()).toBe(4);
-      expect(parsed.importantDates[0].date.getDate()).toBe(15);
+      expect(parsed.importantDates[0].date.toISOString()).toBe('1604-05-15T00:00:00.000Z');
     });
 
     it('should parse BDAY in compact format (v3)', () => {
@@ -409,7 +408,7 @@ END:VCARD`;
       const parsed = parseVCard(vCard);
 
       expect(parsed.importantDates).toHaveLength(1);
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(1990);
+      expect(parsed.importantDates[0].date.toISOString()).toBe('1990-05-15T00:00:00.000Z');
     });
 
     it('should handle X-APPLE-OMIT-YEAR parameter', () => {
@@ -421,7 +420,7 @@ END:VCARD`;
 
       const parsed = parseVCard(vCard);
 
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(1604);
+      expect(parsed.importantDates[0].date.toISOString()).toBe('1604-05-15T00:00:00.000Z');
     });
 
     it('should parse ANNIVERSARY', () => {
@@ -448,7 +447,7 @@ END:VCARD`;
       const parsed = parseVCard(vCard);
 
       expect(parsed.lastContact).toBeDefined();
-      expect(parsed.lastContact?.getFullYear()).toBe(2023);
+      expect(parsed.lastContact?.toISOString()).toBe('2023-12-25T00:00:00.000Z');
     });
   });
 
@@ -568,7 +567,7 @@ END:VCARD`;
       expect(parsed.importantDates).toHaveLength(1);
       expect(parsed.importantDates[0].type).toBeNull();
       expect(parsed.importantDates[0].title).toBe('Custom Date');
-      expect(parsed.importantDates[0].date.getFullYear()).toBe(2023);
+      expect(parsed.importantDates[0].date.toISOString()).toBe('2023-06-15T00:00:00.000Z');
     });
 
     it('should map X-ABDATE with Anniversary label to predefined type', () => {
@@ -937,7 +936,7 @@ END:VCARD`;
 
       const birthday = parsed.importantDates.find(d => d.type === 'birthday');
       expect(birthday?.title).toBe('');
-      expect(birthday?.date.getFullYear()).toBe(1604); // Year unknown
+      expect(birthday?.date.toISOString()).toBe('1604-01-22T00:00:00.000Z'); // 1604 = year unknown
     });
   });
 


### PR DESCRIPTION
## Problem

Two test files passed in CI and failed on a developer machine, because both read dates in a different frame from the one the code writes them in. CI runs in UTC, which is the one timezone where the mistakes are invisible.

### vCard parser (2 tests failing anywhere but UTC)

`lib/carddav/vcard-parser.ts` stores calendar dates as UTC midnight, the convention documented in `lib/date-format.ts`:

> Nametag stores calendar dates as UTC-midnight DateTime values, which would otherwise shift west of UTC under `getDate()`

The tests read those values back with local `getDate()` / `getMonth()` / `getFullYear()`, the exact thing that comment warns against.

The year-unknown marker is **1604**, which predates standard time, so every timezone resolves to a Local Mean Time offset there. Europe/Madrid is `GMT-00:14:44` in 1604, putting UTC midnight on May 15 at `23:45:16` on **May 14** local. Hence `expected 14 to be 15`.

### Last contact (2 tests failing in a nightly window)

`tests/components/LastContactQuickUpdate.test.tsx` stepped back a day in local time and then serialised with `toISOString()`, which is UTC. Between local midnight and UTC midnight that lands *two* calendar days back, so the component rendered "2 days ago" against an assertion for "1 day ago". In Europe/Madrid that is a two hour window every night; west of UTC the mirror case hits in the afternoon.

## Fix

No production code changed. Both commits touch tests only.

- **vCard parser**: all 7 date assertions now use `toISOString()` against the exact UTC instant. Stronger than swapping in `getUTC*`, since it also pins the time component, so a date accidentally built at local midnight no longer slips through. Only 2 of the 7 were failing; the other 5 were latent and would have tripped on a Jan 1 test date.
- **Last contact**: dates now come from `getLocalDateString()`, which `lib/date-format.ts` already documents as the replacement for this pattern, and the clock is pinned in the two affected tests.

The pinned instant, `2026-03-15T23:30:00Z`, is chosen for two reasons. Late-evening UTC means east-of-UTC zones are already on the next local day, so these tests **fail if the `toISOString()` pattern comes back**; a noon-UTC pin would have made local and UTC agree and the test would have passed with the bug reinstated. Mid-March clears every DST switch (US Mar 8, EU Mar 29, NZ Apr 5), closing a separate one-hour-a-year hole where the spring-forward jump made yesterday only 23 hours ago and the component would have said "today".

Fake timers are scoped to just those two tests, so the six `userEvent` tests in the file keep running on real timers.

## Verification

- Full suite green in Europe/Madrid, UTC and America/Los_Angeles: **2628 passed, 1 skipped, 196/196 files**. Previously 2 failed in Madrid.
- Per-file runs green across six zones including Asia/Kathmandu (+5:45) and Pacific/Chatham (+12:45).
- Bite-checked with 5 mutations, each caught: vCard day off-by-one (4 failures), month shift (2), sentinel year change (4); reintroduced `toISOString()` (1, in Madrid), component day off-by-one (1), `isToday` forced false (2). Both source files restored and verified clean with `git diff --quiet`.
- eslint and `tsc --noEmit` clean.

## Known limitation

Reintroducing the `toISOString()` pattern fails in Madrid but still passes in UTC, because in UTC there is no divergence to detect. CI runs in UTC, so it would not catch that specific regression. Pinning a non-UTC `TZ` for the test process in `vitest.config.ts` would turn this whole bug class into something CI catches. Not done here since it affects all 2629 tests and deserves its own change.

No user-facing behaviour changes, so no docs or OpenAPI updates.