### PR TITLE
fix(carddav): stop re-importing contacts when only the ETag moved

### DIFF
--- a/docs/src/content/docs/features/carddav.md
+++ b/docs/src/content/docs/features/carddav.md
@@ -77,6 +77,14 @@ If you're setting up sync for the first time and already have contacts in Nameta
 | Auto-sync interval range | 60 seconds to 24 hours (default: 12 hours) |
 | Cron inter-user delay | 200ms between users |
 
+### How Nametag decides a contact changed
+
+Nametag tracks each synced contact's ETag, a version marker the server updates whenever the contact's data changes. When the ETag moves, the contact is pulled back in.
+
+An ETag on its own isn't always a reliable signal. Some servers don't return one when Nametag uploads a contact, and others (Google and iCloud among them) rewrite the contact after receiving it, which moves the ETag even though nothing actually changed. To avoid re-importing contacts it just wrote, Nametag also compares a content fingerprint of the incoming contact against the last version it imported. If the fingerprint matches, it records the new ETag and leaves the contact alone.
+
+This is also why a contact edited only in Nametag won't be flagged as a conflict just because the server reshuffled its copy.
+
 ## Troubleshooting
 
 - **Wrong password type**: Google and iCloud require an app-specific password, not your regular account password. If sign-in fails, double-check you generated one and are using it here.

--- a/lib/carddav/client.ts
+++ b/lib/carddav/client.ts
@@ -232,7 +232,13 @@ export async function createCardDavClient(
         });
       }
 
-      const etag = response.headers?.get('etag') || vCard.etag;
+      // Returning an ETag on PUT is only a recommendation in RFC 6352, so a
+      // server may legally omit it. Never fall back to the etag we sent: it is
+      // already stale, and storing it as though it were fresh makes every later
+      // pull believe the contact changed remotely and re-import the vCard we
+      // just wrote (issue #392). An empty etag records the truth ("unknown"),
+      // which the sync engine resolves with a content hash comparison.
+      const etag = response.headers?.get('etag') || '';
 
       return {
         url: vCard.url,

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -240,12 +240,34 @@ export async function syncFromServer(
         }
 
         if (mapping) {
-          const remoteChanged = mapping.etag !== vCard.etag;
+          let remoteChanged = mapping.etag !== vCard.etag;
+          const remoteHash = buildLocalHash(parsedData);
 
           // Check if both local and remote changed since last sync
           const localChanged = mapping.lastLocalChange &&
             mapping.lastSyncedAt &&
             mapping.lastLocalChange > mapping.lastSyncedAt;
+
+          // A moved etag does not always mean the contact changed. Servers may
+          // omit the ETag on PUT (we then store an empty one) or re-serialize
+          // the card after we upload it, as Google and iCloud both do. Taking
+          // the etag at face value makes Nametag re-import the vCard it just
+          // wrote, every cycle, silently overwriting the person with whatever
+          // the parser produced (issue #392). Compare the parsed content
+          // against the hash recorded at the last import: if it matches, only
+          // the etag moved, so record the new etag and treat the remote as
+          // unchanged.
+          if (remoteChanged && mapping.remoteVersion === remoteHash) {
+            await prisma.cardDavMapping.update({
+              where: { id: mapping.id },
+              data: { etag: vCard.etag, href: vCard.url },
+            });
+            log.info(
+              { event: 'carddav.etag_refresh', personId: mapping.personId },
+              'Remote etag moved but content is unchanged; refreshing etag without re-importing',
+            );
+            remoteChanged = false;
+          }
 
           if (!remoteChanged && !localChanged) {
             // Heal stuck mappings left by pre-862a415 syncs: local person
@@ -288,8 +310,6 @@ export async function syncFromServer(
           if (!fullMapping) {
             continue;
           }
-
-          const remoteHash = buildLocalHash(parsedData);
 
           if (localChanged && remoteChanged) {
             // CONFLICT - both changed

--- a/lib/carddav/sync.ts
+++ b/lib/carddav/sync.ts
@@ -258,9 +258,21 @@ export async function syncFromServer(
           // the etag moved, so record the new etag and treat the remote as
           // unchanged.
           if (remoteChanged && mapping.remoteVersion === remoteHash) {
+            // The hash only covers fields that map onto a Person, so an edit
+            // confined to a round-tripped property (SOURCE, KIND, LOGO,
+            // CLIENTPIDMAP and the like) looks identical here. Re-read them
+            // alongside the etag, otherwise the next push would re-emit the
+            // copy we stored earlier and revert the server's edit.
+            const guardParsed = parseVCard(vCard.data);
             await prisma.cardDavMapping.update({
               where: { id: mapping.id },
-              data: { etag: vCard.etag, href: vCard.url },
+              data: {
+                etag: vCard.etag,
+                href: vCard.url,
+                preservedProperties: guardParsed.unknownProperties.length > 0
+                  ? guardParsed.unknownProperties
+                  : undefined,
+              },
             });
             log.info(
               { event: 'carddav.etag_refresh', personId: mapping.personId },

--- a/tests/lib/carddav/client.test.ts
+++ b/tests/lib/carddav/client.test.ts
@@ -80,6 +80,35 @@ describe('CardDavClient error handling', () => {
     ).rejects.toBeInstanceOf(ExternalServiceError);
   });
 
+  it('does not reuse the stale ETag when the server omits one on PUT (issue #392)', async () => {
+    // RFC 6352 only recommends returning an ETag on PUT, so a server may
+    // legally omit it. Falling back to the old etag would store it as though
+    // it were fresh, making every later pull see a phantom remote change.
+    updateVCardMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const client = await createCardDavClient(connection);
+    const updated = await client.updateVCard(
+      { url: '/contacts/abc.vcf', etag: '"stale"', data: '' },
+      'BEGIN:VCARD\r\nEND:VCARD'
+    );
+
+    expect(updated.etag).toBe('');
+  });
+
+  it('keeps the ETag returned by the server on PUT', async () => {
+    updateVCardMock.mockResolvedValueOnce(
+      new Response('', { status: 200, headers: { etag: '"fresh"' } })
+    );
+
+    const client = await createCardDavClient(connection);
+    const updated = await client.updateVCard(
+      { url: '/contacts/abc.vcf', etag: '"stale"', data: '' },
+      'BEGIN:VCARD\r\nEND:VCARD'
+    );
+
+    expect(updated.etag).toBe('"fresh"');
+  });
+
   it('throws ExternalServiceError on 400 from deleteVCard', async () => {
     deleteVCardMock.mockResolvedValueOnce(
       new Response('nope', { status: 400, statusText: 'Bad Request' })

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -162,6 +162,7 @@ vi.mock('uuid', () => ({
 // --- Import after mocks ---
 import { syncFromServer, syncToServer, bidirectionalSync, createOrAdoptVCard } from '@/lib/carddav/sync';
 import { ExternalServiceError } from '@/lib/errors';
+import { buildLocalHash } from '@/lib/carddav/hash';
 import type { AddressBook } from '@/lib/carddav/client';
 
 // --- Test data helpers ---
@@ -634,6 +635,131 @@ describe('CardDAV Sync Engine', () => {
         expect(mocks.cardDavConflictCreate).not.toHaveBeenCalled();
         expect(mocks.cardDavPendingImportUpsert).not.toHaveBeenCalled();
         expect(result.updatedLocally).toBe(0);
+        expect(result.conflicts).toBe(0);
+      });
+    });
+
+    describe('content-hash guard for moved ETags (issue #392)', () => {
+      it('should refresh the etag without re-importing when only the etag moved', async () => {
+        const uid = 'etag-only-uid';
+        const mappingId = 'mapping-etag-only';
+        const parsed = makeParsedVCard(uid, 'Frank');
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            remoteVersion: buildLocalHash(parsed),
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/etag-only.vcf', 'etag-new', 'Frank'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(parsed);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        const result = await syncFromServer(USER_ID);
+
+        // The vCard we just wrote must not be re-imported over the person
+        expect(mocks.updatePersonFromVCard).not.toHaveBeenCalled();
+        expect(result.updatedLocally).toBe(0);
+        // No need to load full person data just to discard it
+        expect(mocks.cardDavMappingFindFirst).not.toHaveBeenCalled();
+        // The stored etag is refreshed so the next pull sees no change
+        expect(mocks.cardDavMappingUpdate).toHaveBeenCalledWith({
+          where: { id: mappingId },
+          data: expect.objectContaining({ etag: 'etag-new' }),
+        });
+      });
+
+      it('should still import when the etag moved and the content changed', async () => {
+        const uid = 'content-changed-uid';
+        const mappingId = 'mapping-content-changed';
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            remoteVersion: buildLocalHash(makeParsedVCard(uid, 'Frank')),
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/content-changed.vcf', 'etag-new', 'Francis'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'Francis'));
+        mocks.cardDavMappingFindFirst.mockResolvedValue(
+          makeFullMapping({ id: mappingId, uid, etag: 'etag-stale' })
+        );
+        mocks.$transaction.mockResolvedValue([]);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        const result = await syncFromServer(USER_ID);
+
+        expect(mocks.updatePersonFromVCard).toHaveBeenCalled();
+        expect(result.updatedLocally).toBe(1);
+      });
+
+      it('should import when there is no recorded remote hash to compare against', async () => {
+        const uid = 'no-hash-uid';
+        const mappingId = 'mapping-no-hash';
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            remoteVersion: null,
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/no-hash.vcf', 'etag-new', 'Frank'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(makeParsedVCard(uid, 'Frank'));
+        mocks.cardDavMappingFindFirst.mockResolvedValue(
+          makeFullMapping({ id: mappingId, uid, etag: 'etag-stale' })
+        );
+        mocks.$transaction.mockResolvedValue([]);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        const result = await syncFromServer(USER_ID);
+
+        expect(mocks.updatePersonFromVCard).toHaveBeenCalled();
+        expect(result.updatedLocally).toBe(1);
+      });
+
+      it('should not raise a conflict when the local side changed and only the etag moved', async () => {
+        const uid = 'false-conflict-uid';
+        const mappingId = 'mapping-false-conflict';
+        const parsed = makeParsedVCard(uid, 'Frank');
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastSyncedAt: new Date('2025-01-01'),
+            lastLocalChange: new Date('2025-01-02'),
+            remoteVersion: buildLocalHash(parsed),
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/false-conflict.vcf', 'etag-new', 'Frank'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(parsed);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        const result = await syncFromServer(USER_ID);
+
+        expect(mocks.cardDavConflictCreate).not.toHaveBeenCalled();
+        expect(mocks.updatePersonFromVCard).not.toHaveBeenCalled();
         expect(result.conflicts).toBe(0);
       });
     });

--- a/tests/lib/carddav/sync.test.ts
+++ b/tests/lib/carddav/sync.test.ts
@@ -735,6 +735,86 @@ describe('CardDAV Sync Engine', () => {
         expect(result.updatedLocally).toBe(1);
       });
 
+      it('should refresh preserved properties when skipping the import', async () => {
+        // buildLocalHash only covers fields Nametag maps onto a Person, so a
+        // server-side edit confined to a round-tripped property (SOURCE, KIND,
+        // LOGO, CLIENTPIDMAP and friends) hashes identically. Acknowledging the
+        // new etag without re-reading those properties would leave the stored
+        // copy stale, and the next push would revert the server's edit.
+        const uid = 'preserved-uid';
+        const mappingId = 'mapping-preserved';
+        const parsed = makeParsedVCard(uid, 'Frank');
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            remoteVersion: buildLocalHash(parsed),
+            preservedProperties: [{ key: 'SOURCE', value: 'http://old/x.vcf', params: {} }],
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          {
+            url: '/contacts/preserved.vcf',
+            etag: 'etag-new',
+            data: 'BEGIN:VCARD\nVERSION:3.0\nUID:' + uid
+              + '\nFN:Frank\nN:Frank;;;;\nSOURCE:http://new/x.vcf\nEND:VCARD',
+          },
+        ]);
+        mocks.vCardToPerson.mockReturnValue(parsed);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        expect(mocks.updatePersonFromVCard).not.toHaveBeenCalled();
+        expect(mocks.cardDavMappingUpdate).toHaveBeenCalledWith({
+          where: { id: mappingId },
+          data: expect.objectContaining({
+            etag: 'etag-new',
+            preservedProperties: [
+              expect.objectContaining({ key: 'SOURCE', value: 'http://new/x.vcf' }),
+            ],
+          }),
+        });
+      });
+
+      it('should still heal a photo mismatch when the import is skipped', async () => {
+        // Servers that strip PHOTO also tend to be the ones that move the etag
+        // without changing anything else, so the guard must not swallow the
+        // re-export that puts the photo back (see 862a415, 2e01049, 844223a).
+        const uid = 'guard-photo-uid';
+        const mappingId = 'mapping-guard-photo';
+        const parsed = makeParsedVCard(uid, 'Frank');
+
+        mocks.cardDavMappingFindMany.mockResolvedValue([
+          makeLightMapping({
+            id: mappingId,
+            uid,
+            etag: 'etag-stale',
+            lastLocalChange: null,
+            lastSyncedAt: new Date('2025-01-01'),
+            remoteVersion: buildLocalHash(parsed),
+            person: { photo: 'local-photo.jpg' },
+          }),
+        ]);
+        mocks.fetchVCards.mockResolvedValue([
+          makeVCard(uid, '/contacts/guard-photo.vcf', 'etag-new', 'Frank'),
+        ]);
+        mocks.vCardToPerson.mockReturnValue(parsed);
+        mocks.cardDavPendingImportCount.mockResolvedValue(0);
+
+        await syncFromServer(USER_ID);
+
+        expect(mocks.updatePersonFromVCard).not.toHaveBeenCalled();
+        expect(mocks.cardDavMappingUpdate).toHaveBeenCalledWith({
+          where: { id: mappingId },
+          data: expect.objectContaining({ syncStatus: 'pending' }),
+        });
+      });
+
       it('should not raise a conflict when the local side changed and only the etag moved', async () => {
         const uid = 'false-conflict-uid';
         const mappingId = 'mapping-false-conflict';


### PR DESCRIPTION
Closes #392.

## The problem

`lib/carddav/client.ts` fell back to the ETag it had just sent whenever the server did not return a fresh one on `PUT`:

```ts
const etag = response.headers?.get('etag') || vCard.etag;
```

Returning an ETag on `PUT` is only a recommendation in RFC 6352, so omitting it is legal and common. Storing the old value as though it were fresh meant the next pull compared a stale ETag against the server's real one, decided the contact had changed remotely, and re-imported the vCard Nametag itself had just written. Servers that re-serialize a card after the upload (Google and iCloud both do) hit the same path.

Because nothing in the sync engine compared content, there was no circuit breaker. `buildLocalHash` results were written to `remoteVersion` but never read back, so the re-import ran on every cycle and wrote whatever the parser produced straight into the database.

## The fix

Both directions from the issue, since they cover different halves:

**1. Do not poison the next pull.** `updateVCard` now returns an empty ETag when the server omits one, matching what `createVCard` already did. tsdav strips a falsy `If-Match`, so the following push becomes unconditional instead of carrying a precondition we already know is wrong. Behaviour is unchanged in practice: a stale `If-Match` previously produced a 412 that the recovery path resolved by refetching and overwriting anyway, just with an extra round trip.

**2. Compare content before importing.** `syncFromServer` now uses the hash it was already computing. If the ETag moved but the parsed contact hashes identically to the last version imported, the new ETag is recorded and the contact is left untouched:

```ts
if (remoteChanged && mapping.remoteVersion === remoteHash) {
  // ...record etag, href, preserved properties...
  remoteChanged = false;
}
```

The hash is computed before the full-person `findFirst`, so a guarded contact also skips that query. Setting `remoteChanged = false` rather than `continue` matters: the contact still falls through to the photo-mismatch healing check and the local-changes push path.

This also stops a server-side reshuffle from raising a false conflict against a genuine local edit, since `remoteChanged` goes false before conflict detection runs.

`remoteVersion` is only recorded on import, so a freshly exported contact still gets one re-import before the guard has a baseline. That converges after a single cycle instead of looping forever.

### Scope of the guard

Worth being precise, because the issue was optimistic on this point. The guard stops re-imports of **identical** content, which is the stale-ETag and re-serialization case, and it converges any asymmetry that settles after one application. It does **not** stop an asymmetry that drifts monotonically, like the date shift in #391: each cycle produces genuinely different content, so the hashes differ every time and the guard never fires. What this PR removes is the phantom-change amplifier, not a universal circuit breaker for parser bugs.

### Preserved properties

`buildLocalHash` only covers fields that map onto a `Person`, so an edit confined to a round-tripped property hashes identically. `SOURCE`, `KIND`, `LOGO`, `SOUND`, `FBURL`, `CALURI` and `CLIENTPIDMAP` all land in `preservedProperties` and none of them are hashed. Skipping the import would have left that column stale and the next push would have re-emitted it, reverting the server's edit. The guarded path re-reads them alongside the ETag.

## Out of scope

The two paths that independently re-mark mappings as `pending` (photo stripping, name drift) are untouched, as flagged in the issue. `localVersion` is still write-only; only `remoteVersion` is wired up here.

## Verification

- Six new sync tests: ETag-only move skips the import and refreshes the ETag, real content changes still import, a null `remoteVersion` still imports, a local edit plus an ETag-only move raises no conflict, preserved properties stay fresh on the guarded path, and photo healing still fires when the import is skipped.
- Two new client tests: no stale fallback when the server omits the ETag, and the server's ETag is still used when present.
- Each fix was reverted individually to confirm the corresponding tests fail without it. The photo-healing test was checked against a `continue`-based guard, which it catches.
- Full suite: 2636 passed, 1 skipped, 0 failed. `tsc --noEmit` clean, lint clean on the changed files.
- Docs updated with a "How Nametag decides a contact changed" section; docs site builds.