### PR TITLE
fix(dates): keep year-unknown dates on the day they were saved

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -472,11 +472,25 @@ function formatDateForEmail(
   dateFormat: string | null,
   locale: string = 'en'
 ): string {
-  const d = new Date(date);
+  // Stored values are UTC midnight on the calendar day they encode; reading
+  // them with local accessors would report the previous day west of UTC.
+  const d = parseCalendarDate(date);
   const localeCode = locale === 'en' ? 'en-US' : locale;
   const month = d.toLocaleDateString(localeCode, { month: 'long' });
   const day = d.getDate();
   const year = d.getFullYear();
+
+  // Year-unknown dates carry the 1604 sentinel year; show only month and day.
+  if (year <= 1604) {
+    switch (dateFormat) {
+      case 'DMY':
+        return `${day} ${month}`;
+      case 'MDY':
+      case 'YMD':
+      default:
+        return `${month} ${day}`;
+    }
+  }
 
   switch (dateFormat) {
     case 'DMY':

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -8,7 +8,7 @@ import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
-import { parseAsLocalDate } from '@/lib/date-format';
+import { parseCalendarDate } from '@/lib/date-format';
 import { getTranslationsForLocale, type SupportedLocale } from '@/lib/i18n-utils';
 import { getDateDisplayTitle } from '@/lib/important-date-types';
 
@@ -288,7 +288,7 @@ async function shouldSendImportantDateReminder(
   },
   today: Date
 ): Promise<boolean> {
-  const eventDate = parseAsLocalDate(importantDate.date);
+  const eventDate = parseCalendarDate(importantDate.date);
 
   if (importantDate.reminderType === 'ONCE') {
     // For one-time reminders, send on the exact date if not already sent

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -11,7 +11,7 @@ import PersonVCardRawView from '@/components/PersonVCardRawView';
 import PersonActionsMenu from '@/components/PersonActionsMenu';
 import LastContactQuickUpdate from '@/components/LastContactQuickUpdate';
 import RetryGeocodeButton from '@/components/RetryGeocodeButton';
-import { formatDate, formatDateWithoutYear, parseAsLocalDate, type DateFormat } from '@/lib/date-format';
+import { formatDate, formatDateWithoutYear, parseCalendarDate, type DateFormat } from '@/lib/date-format';
 import { getCountryName } from '@/lib/countries';
 import { formatCanonicalName, formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
@@ -431,7 +431,7 @@ export default async function PersonDetailsPage({
                   )}
 
                   {person.anniversary && (() => {
-                    const anniversaryDate = parseAsLocalDate(person.anniversary.toISOString());
+                    const anniversaryDate = parseCalendarDate(person.anniversary);
                     const yearsAgo = getYearsAgo(anniversaryDate, t);
                     return (
                       <div>
@@ -712,7 +712,7 @@ export default async function PersonDetailsPage({
                   <div className="space-y-2">
                     {person.importantDates.map((date) => {
                       const reminderDesc = getReminderDescription(date, t);
-                      const dateObj = parseAsLocalDate(date.date);
+                      const dateObj = parseCalendarDate(date.date);
                       const isYearUnknown = dateObj.getFullYear() === 1604;
                       const yearsAgo = !isYearUnknown ? getYearsAgo(dateObj, t) : null;
                       return (

--- a/docs/src/content/docs/features/important-dates.md
+++ b/docs/src/content/docs/features/important-dates.md
@@ -50,3 +50,5 @@ Self-hosted installations are not subject to these limits. Turning off a reminde
 - **Reminder interval range**: 1-99
 - **Reminder interval units**: Days, Weeks, Months, Years
 - **Reminder types**: Once (fires a single time), Recurring (fires every interval, for example every year)
+- **Date storage**: calendar dates are stored as UTC midnight on the day you picked, so the day never shifts with your timezone
+- **Unknown years**: dates saved without a year are stored under year 1604, Apple's marker for an unknown year, which keeps them compatible with Contacts and other CardDAV clients

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -5,7 +5,9 @@ export type DateFormat = 'MDY' | 'DMY' | 'YMD';
  * calendar day. Accepts `YYYY-MM-DD` and ISO datetime strings (where only the
  * date prefix is meaningful — Nametag stores calendar dates as UTC-midnight
  * DateTime values, which would otherwise shift west of UTC under `getDate()`).
- * Date objects pass through unchanged; for real timestamps use `formatDateTime`.
+ * Date objects pass through unchanged, on the assumption that they were built
+ * locally and already sit on the right calendar day; for a Date read from the
+ * database use `parseCalendarDate`. For real timestamps use `formatDateTime`.
  */
 export function parseAsLocalDate(date: Date | string): Date {
   if (typeof date === 'string') {
@@ -25,6 +27,27 @@ export function parseAsLocalDate(date: Date | string): Date {
     return new Date(date);
   }
   return date;
+}
+
+/**
+ * Anchor a calendar-date column to local midnight on the day it encodes.
+ *
+ * Use this for any birthday, anniversary or last-contact value read from the
+ * database. Those are stored as UTC midnight, so a `Date` handed straight to
+ * `parseAsLocalDate` passes through untouched and the formatters then read it
+ * with `getDate()`, reporting the previous day anywhere west of UTC.
+ *
+ * Year-unknown dates make that far wider than it sounds. They use 1604, which
+ * predates standard time zones, so JavaScript falls back to Local Mean Time and
+ * puts almost every zone west of UTC: Madrid is -0:14:44 and London is -0:01:15
+ * in 1604, though both are east of UTC today. Reading the UTC components is the
+ * only way to get the stored calendar day back out.
+ */
+export function parseCalendarDate(date: Date | string): Date {
+  if (typeof date === 'string') {
+    return parseAsLocalDate(date);
+  }
+  return new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 }
 
 /**

--- a/lib/services/person.ts
+++ b/lib/services/person.ts
@@ -64,13 +64,14 @@ function resolveDisplayNameOverride(
 
 /** Convert an importantDate input to the Prisma create shape. */
 function mapImportantDate(date: NonNullable<PersonInput['importantDates']>[number]) {
+  // Calendar dates are stored as UTC midnight. `setFullYear` would rewrite the
+  // year in local time and store a different instant than the important-dates
+  // API and the CardDAV importer do for the same day, so read and rebuild the
+  // UTC components instead. 1604 is Apple's marker for an unknown year.
+  const parsed = new Date(date.date);
   const dateValue = date.yearUnknown
-    ? (() => {
-        const d = new Date(date.date);
-        d.setFullYear(1604);
-        return d;
-      })()
-    : new Date(date.date);
+    ? new Date(Date.UTC(1604, parsed.getUTCMonth(), parsed.getUTCDate()))
+    : parsed;
 
   return {
     title: date.title,

--- a/lib/upcoming-events.ts
+++ b/lib/upcoming-events.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { formatGraphName } from '@/lib/nameUtils';
-import { parseAsLocalDate } from '@/lib/date-format';
+import { parseCalendarDate } from '@/lib/date-format';
 import { getTranslationsForLocale } from '@/lib/i18n-utils';
 import { getDateDisplayTitle } from '@/lib/important-date-types';
 import { getUserLocale } from '@/lib/locale';
@@ -161,12 +161,12 @@ export async function getUpcomingEvents(userId: string): Promise<UpcomingEvent[]
     let eventDate: Date;
 
     if (importantDate.reminderType === 'ONCE') {
-      eventDate = parseAsLocalDate(importantDate.date);
+      eventDate = parseCalendarDate(importantDate.date);
     } else {
       const interval = importantDate.reminderInterval || 1;
       const intervalUnit = importantDate.reminderIntervalUnit || 'YEARS';
       eventDate = getNextOccurrence(
-        parseAsLocalDate(importantDate.date),
+        parseCalendarDate(importantDate.date),
         today,
         interval,
         intervalUnit,
@@ -186,7 +186,7 @@ export async function getUpcomingEvents(userId: string): Promise<UpcomingEvent[]
         titleKey: null,
         date: eventDate,
         daysUntil,
-        isYearUnknown: parseAsLocalDate(importantDate.date).getFullYear() <= 1604,
+        isYearUnknown: parseCalendarDate(importantDate.date).getFullYear() <= 1604,
         personPhoto: importantDate.person.photo,
       });
     }

--- a/prisma/migrations/20260811143000_realign_year_unknown_dates/migration.sql
+++ b/prisma/migrations/20260811143000_realign_year_unknown_dates/migration.sql
@@ -1,0 +1,23 @@
+-- Data-only migration: the person form used to rewrite year-unknown dates with
+-- setFullYear, which works in local time. Because year 1604 predates standard
+-- time zones, JavaScript fell back to Local Mean Time and stored an instant
+-- offset from UTC midnight by the difference between the server zone's 1604
+-- LMT and its modern offset (for example Sydney wrote 1604-08-09T23:55:08Z for
+-- August 10). Now that dates are read as UTC calendar days, those rows would
+-- display and remind on the wrong day, so round them to the nearest UTC
+-- midnight. The offset is always well under twelve hours, which makes nearest
+-- midnight the day the user picked.
+--
+-- Rows written near a year boundary can round to 1605-01-01 (a January 1 saved
+-- from a zone west of UTC); clamp those back to 1604-01-01 so they keep the
+-- year-unknown sentinel. Correctly written rows sit exactly on UTC midnight
+-- and are left untouched, as are known-year dates, which were never rewritten
+-- with setFullYear.
+UPDATE "important_dates"
+SET "date" = CASE
+  WHEN date_trunc('day', "date" + interval '12 hours') >= TIMESTAMP '1605-01-01'
+    THEN TIMESTAMP '1604-01-01'
+  ELSE date_trunc('day', "date" + interval '12 hours')
+END
+WHERE EXTRACT(YEAR FROM "date") BETWEEN 1603 AND 1605
+  AND "date" <> date_trunc('day', "date");

--- a/tests/api/cron-reminders-unsubscribe.test.ts
+++ b/tests/api/cron-reminders-unsubscribe.test.ts
@@ -764,4 +764,176 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
     });
   });
+
+  /**
+   * The date printed inside the email body has to match the stored calendar
+   * day too. Reading the stored UTC-midnight value with local accessors put
+   * the previous day into the email in the same timezones where the send-day
+   * check used to misfire, and year-unknown dates leaked the 1604 sentinel
+   * year into the text.
+   */
+  describe('email body dates across timezones', () => {
+    const ORIGINAL_TZ = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = ORIGINAL_TZ;
+    });
+
+    const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+
+    function importantDateFixture(date: Date, overrides: Record<string, unknown> = {}) {
+      return {
+        id: 'date-1',
+        title: 'Birthday',
+        date,
+        reminderType: 'RECURRING',
+        reminderInterval: 1,
+        reminderIntervalUnit: 'YEARS',
+        lastReminderSent: null,
+        person: {
+          userId: 'user-1',
+          name: 'John',
+          surname: 'Doe',
+          middleName: null,
+          secondLastName: null,
+          nickname: null,
+          user: { email: 'john@example.com', dateFormat: 'MDY', language: 'en' },
+        },
+        ...overrides,
+      };
+    }
+
+    async function runCron() {
+      mocks.createUnsubscribeToken.mockResolvedValue('token-abc123');
+      mocks.importantDateReminderTemplate.mockResolvedValue({
+        subject: 'Reminder',
+        html: '<p>Reminder</p>',
+        text: 'Reminder',
+      });
+      mocks.contactReminderTemplate.mockResolvedValue({
+        subject: 'Contact Reminder',
+        html: '<p>Contact Reminder</p>',
+        text: 'Contact Reminder',
+      });
+      await GET(
+        new Request('http://localhost/api/cron/send-reminders', {
+          headers: { authorization: 'Bearer test-cron-secret' },
+        })
+      );
+    }
+
+    it.each(TIMEZONES)('prints the stored day without the sentinel year in %s', async (tz) => {
+      process.env.TZ = tz;
+      const today = new Date();
+      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      mocks.importantDateFindMany.mockResolvedValue([importantDateFixture(stored)]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      await runCron();
+
+      const expected = `${today.toLocaleDateString('en-US', { month: 'long' })} ${today.getDate()}`;
+      expect(mocks.importantDateReminderTemplate).toHaveBeenCalledWith(
+        'John Doe',
+        'Birthday',
+        expected,
+        expect.any(String),
+        'en'
+      );
+    });
+
+    it.each(TIMEZONES)('prints known-year dates on the stored day with their year in %s', async (tz) => {
+      process.env.TZ = tz;
+      const today = new Date();
+      const stored = new Date(Date.UTC(1990, today.getMonth(), today.getDate()));
+      mocks.importantDateFindMany.mockResolvedValue([importantDateFixture(stored)]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      await runCron();
+
+      const expected = `${today.toLocaleDateString('en-US', { month: 'long' })} ${today.getDate()}, 1990`;
+      expect(mocks.importantDateReminderTemplate).toHaveBeenCalledWith(
+        'John Doe',
+        'Birthday',
+        expected,
+        expect.any(String),
+        'en'
+      );
+    });
+
+    it.each(TIMEZONES)('prints the recorded last-contact day in %s', async (tz) => {
+      process.env.TZ = tz;
+      const lastContactDay = new Date();
+      lastContactDay.setMonth(lastContactDay.getMonth() - 4);
+      const person = {
+        id: 'person-1',
+        userId: 'user-1',
+        name: 'Jane',
+        surname: 'Smith',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        lastContact: asStoredCalendarDate(lastContactDay),
+        contactReminderInterval: 3,
+        contactReminderIntervalUnit: 'MONTHS',
+        lastContactReminderSent: null,
+        user: { email: 'jane@example.com', dateFormat: 'MDY', language: 'en' },
+      };
+      mocks.importantDateFindMany.mockResolvedValue([]);
+      mocks.personFindMany.mockResolvedValue([person]);
+
+      await runCron();
+
+      const expected = `${lastContactDay.toLocaleDateString('en-US', { month: 'long' })} ${lastContactDay.getDate()}, ${lastContactDay.getFullYear()}`;
+      expect(mocks.contactReminderTemplate).toHaveBeenCalledWith(
+        'John Doe',
+        expected,
+        expect.any(String),
+        expect.any(String),
+        'en'
+      );
+    });
+
+    it('lays out year-unknown dates as day-first for DMY users', async () => {
+      process.env.TZ = 'Europe/Madrid';
+      const today = new Date();
+      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      const fixture = importantDateFixture(stored);
+      fixture.person.user.dateFormat = 'DMY';
+      mocks.importantDateFindMany.mockResolvedValue([fixture]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      await runCron();
+
+      const expected = `${today.getDate()} ${today.toLocaleDateString('en-US', { month: 'long' })}`;
+      expect(mocks.importantDateReminderTemplate).toHaveBeenCalledWith(
+        'John Doe',
+        'Birthday',
+        expected,
+        expect.any(String),
+        'en'
+      );
+    });
+
+    it('localizes the month name for year-unknown dates', async () => {
+      process.env.TZ = 'Europe/Madrid';
+      const today = new Date();
+      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      const fixture = importantDateFixture(stored);
+      fixture.person.user.dateFormat = 'DMY';
+      fixture.person.user.language = 'es-ES';
+      mocks.importantDateFindMany.mockResolvedValue([fixture]);
+      mocks.personFindMany.mockResolvedValue([]);
+
+      await runCron();
+
+      const expected = `${today.getDate()} ${today.toLocaleDateString('es-ES', { month: 'long' })}`;
+      expect(mocks.importantDateReminderTemplate).toHaveBeenCalledWith(
+        'John Doe',
+        expect.any(String),
+        expected,
+        expect.any(String),
+        'es-ES'
+      );
+    });
+  });
 });

--- a/tests/api/cron-reminders-unsubscribe.test.ts
+++ b/tests/api/cron-reminders-unsubscribe.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // Use vi.hoisted to create mocks before hoisting
 const mocks = vi.hoisted(() => ({
@@ -109,6 +109,16 @@ vi.mock('../../lib/api-utils', () => ({
 // Import after mocking
 import { GET } from '../../app/api/cron/send-reminders/route';
 
+/**
+ * Nametag stores calendar dates as UTC midnight on the day they encode, never
+ * local midnight. Fixtures have to match, otherwise they stand in for a row
+ * production never writes and the reminder logic gets exercised against the
+ * wrong calendar day.
+ */
+function asStoredCalendarDate(day: Date): Date {
+  return new Date(Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()));
+}
+
 describe('Cron Job - Unsubscribe Token Generation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -133,7 +143,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       const importantDate = {
         id: 'date-1',
         title: 'Birthday',
-        date: new Date(today),
+        date: asStoredCalendarDate(today),
         reminderType: 'ONCE',
         reminderInterval: null,
         reminderIntervalUnit: null,
@@ -182,7 +192,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       const importantDate = {
         id: 'date-1',
         title: 'Birthday',
-        date: new Date(today),
+        date: asStoredCalendarDate(today),
         reminderType: 'ONCE',
         reminderInterval: null,
         reminderIntervalUnit: null,
@@ -233,7 +243,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       const importantDate = {
         id: 'date-1',
         title: 'Anniversary',
-        date: new Date(today),
+        date: asStoredCalendarDate(today),
         reminderType: 'ONCE',
         reminderInterval: null,
         reminderIntervalUnit: null,
@@ -279,7 +289,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       const importantDate = {
         id: 'important-date-123',
         title: 'Birthday',
-        date: new Date(today),
+        date: asStoredCalendarDate(today),
         reminderType: 'ONCE',
         reminderInterval: null,
         reminderIntervalUnit: null,
@@ -325,7 +335,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       const importantDate = {
         id: 'date-1',
         title: 'Cumpleaños',
-        date: new Date(today),
+        date: asStoredCalendarDate(today),
         reminderType: 'ONCE',
         reminderInterval: null,
         reminderIntervalUnit: null,
@@ -609,7 +619,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
         {
           id: 'date-1',
           title: 'Birthday',
-          date: new Date(today),
+          date: asStoredCalendarDate(today),
           reminderType: 'ONCE',
           reminderInterval: null,
           reminderIntervalUnit: null,
@@ -631,7 +641,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
         {
           id: 'date-2',
           title: 'Anniversary',
-          date: new Date(today),
+          date: asStoredCalendarDate(today),
           reminderType: 'ONCE',
           reminderInterval: null,
           reminderIntervalUnit: null,
@@ -680,6 +690,78 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
         reminderType: 'IMPORTANT_DATE',
         entityId: 'date-2',
       });
+    });
+  });
+
+  /**
+   * Year-unknown dates are stored under year 1604, which predates standard time
+   * zones, so JavaScript falls back to Local Mean Time and puts almost every
+   * zone west of UTC. Reading the stored day with local accessors moved it back
+   * a day, which meant birthday reminders went out the day before.
+   */
+  describe('year-unknown birthdays across timezones', () => {
+    const ORIGINAL_TZ = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = ORIGINAL_TZ;
+    });
+
+    const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+
+    function yearUnknownDateOn(day: Date) {
+      return {
+        id: 'date-1',
+        title: 'Birthday',
+        date: new Date(Date.UTC(1604, day.getMonth(), day.getDate())),
+        reminderType: 'RECURRING',
+        reminderInterval: 1,
+        reminderIntervalUnit: 'YEARS',
+        lastReminderSent: null,
+        person: {
+          userId: 'user-1',
+          name: 'John',
+          surname: 'Doe',
+          middleName: null,
+          secondLastName: null,
+          nickname: null,
+          user: { email: 'john@example.com', dateFormat: 'MDY', language: 'en' },
+        },
+      };
+    }
+
+    async function runCron() {
+      mocks.personFindMany.mockResolvedValue([]);
+      mocks.createUnsubscribeToken.mockResolvedValue('token-abc123');
+      mocks.importantDateReminderTemplate.mockResolvedValue({
+        subject: 'Reminder',
+        html: '<p>Reminder</p>',
+        text: 'Reminder',
+      });
+      await GET(
+        new Request('http://localhost/api/cron/send-reminders', {
+          headers: { authorization: 'Bearer test-cron-secret' },
+        })
+      );
+    }
+
+    it.each(TIMEZONES)('sends on the birthday itself in %s', async (tz) => {
+      process.env.TZ = tz;
+      mocks.importantDateFindMany.mockResolvedValue([yearUnknownDateOn(new Date())]);
+
+      await runCron();
+
+      expect(mocks.createUnsubscribeToken).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(TIMEZONES)('stays quiet the day before in %s', async (tz) => {
+      process.env.TZ = tz;
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      mocks.importantDateFindMany.mockResolvedValue([yearUnknownDateOn(tomorrow)]);
+
+      await runCron();
+
+      expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/lib/calendar-date-timezone.test.ts
+++ b/tests/lib/calendar-date-timezone.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  formatDate,
+  formatDateWithoutYear,
+  parseAsLocalDate,
+  parseCalendarDate,
+} from '@/lib/date-format';
+import { getNextOccurrence } from '@/lib/upcoming-events';
+
+/**
+ * Regression tests for calendar dates read straight from the database.
+ *
+ * Nametag stores calendar dates as UTC midnight, but `parseAsLocalDate` only
+ * anchors the calendar day when it is handed a string. `Date` values pass
+ * through untouched, and the formatters then read them with `getDate()`, which
+ * reports the previous day anywhere west of UTC.
+ *
+ * Year-unknown dates make this much wider than it looks. They use 1604, which
+ * predates standard time zones, so JavaScript falls back to Local Mean Time and
+ * almost every zone sits west of UTC: Madrid is -0:14:44 and London is -0:01:15
+ * in 1604, even though both are east of UTC today. A birthday saved as
+ * "August 10" with no year rendered as "August 9" for nearly everyone, while
+ * the edit form (a client component, where the same value arrives as a string)
+ * kept showing the correct day.
+ *
+ * These tests pin the process timezone because the bug is invisible under UTC.
+ */
+
+const ORIGINAL_TZ = process.env.TZ;
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+function withTimezone<T>(tz: string, fn: () => T): T {
+  process.env.TZ = tz;
+  return fn();
+}
+
+// Madrid and London are east of UTC today but west of it in 1604, which is the
+// combination that made only year-unknown dates look broken. New York is west
+// in both eras, Sydney east in both.
+const TIMEZONES = [
+  'UTC',
+  'Europe/Madrid',
+  'Europe/London',
+  'America/New_York',
+  'Australia/Sydney',
+];
+
+/** A calendar date as Prisma hands it back: UTC midnight on the stored day. */
+function storedCalendarDate(iso: string): Date {
+  return new Date(`${iso}T00:00:00.000Z`);
+}
+
+describe('calendar dates read from the database', () => {
+  describe('parseCalendarDate', () => {
+    it.each(TIMEZONES)('keeps a year-unknown date on its own day in %s', (tz) => {
+      withTimezone(tz, () => {
+        const parsed = parseCalendarDate(storedCalendarDate('1604-08-10'));
+        expect(parsed.getFullYear()).toBe(1604);
+        expect(parsed.getMonth()).toBe(7);
+        expect(parsed.getDate()).toBe(10);
+      });
+    });
+
+    it.each(TIMEZONES)('keeps a known-year date on its own day in %s', (tz) => {
+      withTimezone(tz, () => {
+        const parsed = parseCalendarDate(storedCalendarDate('1990-05-15'));
+        expect(parsed.getFullYear()).toBe(1990);
+        expect(parsed.getMonth()).toBe(4);
+        expect(parsed.getDate()).toBe(15);
+      });
+    });
+
+    it.each(TIMEZONES)('agrees with the string form it replaces in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1604-08-10');
+        expect(parseCalendarDate(stored).getTime()).toBe(
+          parseAsLocalDate(stored.toISOString()).getTime(),
+        );
+      });
+    });
+
+    it.each(TIMEZONES)('still anchors strings in %s', (tz) => {
+      withTimezone(tz, () => {
+        const parsed = parseCalendarDate('1604-08-10');
+        expect(parsed.getMonth()).toBe(7);
+        expect(parsed.getDate()).toBe(10);
+      });
+    });
+  });
+
+  describe('rendering, as the person detail page does it', () => {
+    it.each(TIMEZONES)('renders a year-unknown birthday as August 10 in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1604-08-10');
+        expect(formatDateWithoutYear(parseCalendarDate(stored), 'MDY')).toBe('August 10');
+        expect(formatDateWithoutYear(parseCalendarDate(stored), 'DMY')).toBe('10 August');
+      });
+    });
+
+    it.each(TIMEZONES)('renders a known-year birthday on its own day in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1990-05-15');
+        expect(formatDate(parseCalendarDate(stored), 'YMD')).toBe('1990-05-15');
+      });
+    });
+
+    it.each(TIMEZONES)('reports the year-unknown sentinel as 1604 in %s', (tz) => {
+      withTimezone(tz, () => {
+        // The person page decides which formatter to use from getFullYear().
+        expect(parseCalendarDate(storedCalendarDate('1604-08-10')).getFullYear()).toBe(1604);
+      });
+    });
+  });
+
+  describe('next occurrence, as the dashboard and reminders do it', () => {
+    it.each(TIMEZONES)('projects a year-unknown birthday onto August 10 in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1604-08-10');
+        const today = new Date(2026, 7, 1);
+        const next = getNextOccurrence(parseCalendarDate(stored), today, 1, 'YEARS', null);
+
+        expect(next.getFullYear()).toBe(2026);
+        expect(next.getMonth()).toBe(7);
+        expect(next.getDate()).toBe(10);
+      });
+    });
+
+    it.each(TIMEZONES)('rolls to next year once the day has passed in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1604-08-10');
+        const today = new Date(2026, 7, 11);
+        const next = getNextOccurrence(parseCalendarDate(stored), today, 1, 'YEARS', null);
+
+        expect(next.getFullYear()).toBe(2027);
+        expect(next.getMonth()).toBe(7);
+        expect(next.getDate()).toBe(10);
+      });
+    });
+
+    it.each(TIMEZONES)('treats the birthday itself as due today in %s', (tz) => {
+      withTimezone(tz, () => {
+        const stored = storedCalendarDate('1604-08-10');
+        const today = new Date(2026, 7, 10);
+        const next = getNextOccurrence(parseCalendarDate(stored), today, 1, 'YEARS', null);
+
+        // A reminder that fires a day early is the same bug wearing a hat.
+        expect(next.getFullYear()).toBe(2026);
+        expect(next.getDate()).toBe(10);
+      });
+    });
+  });
+});

--- a/tests/lib/services/person.test.ts
+++ b/tests/lib/services/person.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks (must be defined before any imports that use them)
@@ -266,6 +266,48 @@ describe('createPerson', () => {
 
     const call = mocks.personCreate.mock.calls[0][0];
     expect(call.data.relationshipToUser).toEqual({ connect: { id: 'rel-type-1' } });
+  });
+
+  /**
+   * Calendar dates are stored as UTC midnight everywhere else in the app (the
+   * important-dates API and the CardDAV importer both do this). Rewriting the
+   * year in local time here stored a different instant for the same day, so
+   * the same birthday rendered differently depending on which endpoint had
+   * written it last.
+   */
+  describe('year-unknown important dates', () => {
+    const ORIGINAL_TZ = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = ORIGINAL_TZ;
+    });
+
+    it.each(['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'])(
+      'stores August 10 at UTC midnight under year 1604 in %s',
+      async (tz) => {
+        process.env.TZ = tz;
+
+        await createPerson(USER_ID, {
+          ...makeMinimalPersonData(),
+          importantDates: [{ title: 'Birthday', date: '2026-08-10', yearUnknown: true, reminderEnabled: false }],
+        });
+
+        const call = mocks.personCreate.mock.calls[0][0];
+        const stored = call.data.importantDates.create[0].date as Date;
+        expect(stored.toISOString()).toBe('1604-08-10T00:00:00.000Z');
+      },
+    );
+
+    it('leaves a known-year date at UTC midnight on its own day', async () => {
+      await createPerson(USER_ID, {
+        ...makeMinimalPersonData(),
+        importantDates: [{ title: 'Birthday', date: '1990-03-14', reminderEnabled: false }],
+      });
+
+      const call = mocks.personCreate.mock.calls[0][0];
+      const stored = call.data.importantDates.create[0].date as Date;
+      expect(stored.toISOString()).toBe('1990-03-14T00:00:00.000Z');
+    });
   });
 
   it('omits relationshipToUser when not provided', async () => {

--- a/tests/lib/upcoming-events-timezone.test.ts
+++ b/tests/lib/upcoming-events-timezone.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/**
+ * The dashboard renders `event.date` straight from `getUpcomingEvents`, so the
+ * day a year-unknown birthday lands on is decided here, not in the page.
+ *
+ * These dates are stored as UTC midnight under year 1604, which predates
+ * standard time zones. JavaScript falls back to Local Mean Time for it and puts
+ * almost every zone west of UTC (Madrid -0:14:44, London -0:01:15), so reading
+ * the stored day with local accessors moved it back a day for nearly everyone.
+ */
+
+const mocks = vi.hoisted(() => ({
+  importantDateFindMany: vi.fn(),
+  personFindMany: vi.fn(),
+  userFindUnique: vi.fn(),
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  prisma: {
+    importantDate: { findMany: mocks.importantDateFindMany },
+    person: { findMany: mocks.personFindMany },
+    user: { findUnique: mocks.userFindUnique },
+  },
+}));
+
+vi.mock('@/lib/nameUtils', () => ({
+  formatGraphName: () => 'John Doe',
+}));
+
+vi.mock('@/lib/i18n-utils', () => ({
+  getTranslationsForLocale: () => Promise.resolve((key: string) => key),
+}));
+
+vi.mock('@/lib/locale', () => ({
+  getUserLocale: () => Promise.resolve('en'),
+}));
+
+import { getUpcomingEvents } from '@/lib/upcoming-events';
+
+const ORIGINAL_TZ = process.env.TZ;
+
+const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.personFindMany.mockResolvedValue([]);
+  mocks.userFindUnique.mockResolvedValue({ nameOrder: 'WESTERN', language: 'en', nameDisplayFormat: 'FULL' });
+});
+
+afterEach(() => {
+  process.env.TZ = ORIGINAL_TZ;
+});
+
+/** A year-unknown birthday as stored: UTC midnight under year 1604. */
+function yearUnknownBirthdayOn(day: Date) {
+  return {
+    id: 'date-1',
+    title: 'Birthday',
+    type: 'BIRTHDAY',
+    date: new Date(Date.UTC(1604, day.getMonth(), day.getDate())),
+    reminderEnabled: true,
+    reminderType: 'RECURRING',
+    reminderInterval: 1,
+    reminderIntervalUnit: 'YEARS',
+    lastReminderSent: null,
+    person: {
+      id: 'person-1',
+      name: 'John',
+      surname: 'Doe',
+      nickname: null,
+      displayNameOverride: null,
+      photo: null,
+    },
+  };
+}
+
+describe('getUpcomingEvents with year-unknown birthdays', () => {
+  it.each(TIMEZONES)('keeps a birthday three days out on its own day in %s', async (tz) => {
+    process.env.TZ = tz;
+    const target = new Date();
+    target.setDate(target.getDate() + 3);
+    mocks.importantDateFindMany.mockResolvedValue([yearUnknownBirthdayOn(target)]);
+
+    const [event] = await getUpcomingEvents('user-1');
+
+    expect(event.date.getMonth()).toBe(target.getMonth());
+    expect(event.date.getDate()).toBe(target.getDate());
+    expect(event.daysUntil).toBe(3);
+    expect(event.isYearUnknown).toBe(true);
+  });
+
+  it.each(TIMEZONES)('reports a birthday today as zero days away in %s', async (tz) => {
+    process.env.TZ = tz;
+    const today = new Date();
+    mocks.importantDateFindMany.mockResolvedValue([yearUnknownBirthdayOn(today)]);
+
+    const [event] = await getUpcomingEvents('user-1');
+
+    expect(event.daysUntil).toBe(0);
+    expect(event.date.getDate()).toBe(today.getDate());
+  });
+});


### PR DESCRIPTION
A birthday saved as **August 10** with "unknown year" checked displayed as **August 9**, while the edit form kept showing August 10. Re-saving changed nothing. Later the same day it started showing August 10 on its own.

Nothing was ever wrong with the stored value.

## What was happening

Nametag stores calendar dates as UTC midnight. `parseAsLocalDate` anchors the calendar day when given a **string**, but passes **`Date` objects through untouched**, and the formatters then read them with `getDate()`, which reports the previous day anywhere west of UTC.

Three server-side paths hand it raw Prisma values:

- `app/people/[id]/page.tsx` (person detail)
- `lib/upcoming-events.ts` (dashboard)
- `app/api/cron/send-reminders/route.ts` (reminder scheduling)

The edit form is a client component, so the same value arrives as a JSON string, takes the string branch, and reads correctly. One value, two readings, which is why the list and the form disagreed.

## Why only year-unknown dates broke

Year 1604 predates standard time zones, so JavaScript falls back to Local Mean Time:

```
Europe/Madrid   1604: -0:14:44   today: +2:00
Europe/London   1604: -0:01:15   today: +1:00
```

Madrid and London are east of UTC today but west of it in 1604. So known-year birthdays render correctly and only the year-unknown ones slip back a day. London is caught by 75 seconds.

## The fix

Adds `parseCalendarDate` for values read from the database, and routes the three paths through it.

`parseAsLocalDate` keeps its `Date` pass-through deliberately. Locally-built dates do flow into it (the settings date-format example, and `getNextOccurrence` results on the dashboard) and those are already on the right calendar day, so re-anchoring them from UTC would break them. Making the distinction explicit at the call site is what actually removes the footgun.

### Reminders fired a day early

Same root cause, worse consequence: `send-reminders` read the date the same way, so year-unknown birthday emails went out on the wrong day. Now covered across five timezones. Reverting just that line fails in Madrid, London and New York, and passes in UTC and Sydney, exactly as the Local Mean Time offsets predict.

### Two write paths disagreed

`mapImportantDate` rewrote the year with `setFullYear`, which operates in local time, so the person form stored a different instant than the important-dates API and the CardDAV importer did for the same calendar day:

```
important-dates route   new Date('1604-08-10')  -> 1604-08-10T00:00:00Z
person form             setFullYear(1604)       -> 1604-08-10T02:14:44Z
CardDAV import          Date.UTC(1604, 7, 10)   -> 1604-08-10T00:00:00Z
```

All three now agree on UTC midnight. This is also the likely reason the date appeared to correct itself: a save through the person-form path rewrote the instant to one that happened to display correctly.

## Verification

- New `tests/lib/calendar-date-timezone.test.ts` and `tests/lib/upcoming-events-timezone.test.ts`, both pinning the process timezone across UTC, Madrid, London, New York and Sydney. The bug is invisible under UTC, which is why the existing suite passed.
- New timezone coverage for the reminder cron and for the year-unknown write path.
- Every fix was reverted individually to confirm its tests fail without it.
- The reminder cron fixtures were building local-midnight dates, which production never writes, so they were pinning the wrong storage convention. Corrected rather than worked around.
- Full suite: 2704 passed, 1 skipped, 0 failed. `tsc --noEmit` clean, lint clean on changed files, docs site builds.

## Note

The person detail page itself has no direct test (it is a React server component), but the exact composition it uses, `formatDateWithoutYear(parseCalendarDate(stored))`, is asserted across all five timezones.

## Post-review additions

Two gaps surfaced in review, both now covered here:

### The email body printed the wrong date

The send-day fix made the reminder fire on the right day, but `formatDateForEmail` still read the raw stored value with local accessors, so the text of the email named the previous day in the same timezones, and year-unknown dates printed the 1604 sentinel year. It now goes through `parseCalendarDate`, and year-unknown dates render as month and day only, matching the UI. Covered across the same five timezones for both important dates and the last-contact date in contact reminders.

### Backfill for rows written by the old setFullYear path

The old write path stored instants offset from UTC midnight on servers whose 1604 Local Mean Time differs from their modern offset (Sydney wrote `1604-08-09T23:55:08Z` for August 10). Those legacy rows would regress under the new UTC read, permanently showing a day early until re-saved. A data-only migration rounds them to the nearest UTC midnight, which recovers the picked day since the write error is always well under twelve hours. Rows that round across the year boundary to 1605-01-01 are clamped back to 1604-01-01 to keep the sentinel. Correct rows sit exactly on UTC midnight and match nothing in the `WHERE` clause. The migration logic was validated row-by-row against fixtures reproducing Sydney, Paris, New York, Brisbane and Azores writes, plus untouched clean and known-year rows.

No action needed from self-hosters: the migration runs automatically via `prisma migrate deploy` in the Docker entrypoint.
