### PR TITLE
fix(dates): finish the calendar-date sweep across every read site

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -8,7 +8,7 @@ import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
-import { parseCalendarDate } from '@/lib/date-format';
+import { parseCalendarDate, YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
 import { getTranslationsForLocale, type SupportedLocale } from '@/lib/i18n-utils';
 import { getDateDisplayTitle } from '@/lib/important-date-types';
 
@@ -327,13 +327,19 @@ async function shouldSendImportantDateReminder(
 
     // Special handling for YEARS to avoid leap year drift
     if (intervalUnit === 'YEARS') {
-      const eventDay = eventDateNormalized.getDate();
-      const eventMonth = eventDateNormalized.getMonth();
-      const todayDay = today.getDate();
-      const todayMonth = today.getMonth();
+      // Project the anniversary into the current year the same way the
+      // dashboard's getNextOccurrence does: a February 29 birthday has no
+      // matching day in non-leap years, and the Date constructor rolls it to
+      // March 1. A plain month/day equality check would never fire that year.
+      const thisYearOccurrence = new Date(
+        today.getFullYear(),
+        eventDateNormalized.getMonth(),
+        eventDateNormalized.getDate()
+      );
+      thisYearOccurrence.setHours(0, 0, 0, 0);
 
-      // Check if today is the anniversary (same month and day)
-      if (todayDay !== eventDay || todayMonth !== eventMonth) {
+      // Check if today is the anniversary
+      if (thisYearOccurrence.getTime() !== today.getTime()) {
         return false;
       }
 
@@ -375,9 +381,9 @@ async function shouldSendImportantDateReminder(
     }
 
     // Never sent before - check if we should send based on event date
-    // For unknown-year dates (year <= 1604), normalize to current year to avoid
+    // For unknown-year dates, normalize to current year to avoid
     // DST drift over centuries breaking the interval math
-    if (eventDateNormalized.getFullYear() <= 1604) {
+    if (eventDateNormalized.getFullYear() <= YEAR_UNKNOWN_SENTINEL) {
       const currentYear = today.getFullYear();
       eventDateNormalized.setFullYear(currentYear);
       // If the normalized date is in the future, use previous year
@@ -398,8 +404,10 @@ async function shouldSendImportantDateReminder(
   return false;
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 function getIntervalMs(interval: number, unit: string): number {
-  const msPerDay = 24 * 60 * 60 * 1000;
+  const msPerDay = MS_PER_DAY;
 
   switch (unit) {
     case 'DAYS':
@@ -426,31 +434,44 @@ function shouldSendContactReminder(
 ): boolean {
   const interval = person.contactReminderInterval || 1;
   const unit = person.contactReminderIntervalUnit || 'MONTHS';
-  const intervalMs = getIntervalMs(interval, unit);
+  const intervalDays = Math.round(getIntervalMs(interval, unit) / MS_PER_DAY);
 
   // Calculate when the reminder should be sent
   // If no lastContact, use lastContactReminderSent or send immediately
-  const referenceDate = person.lastContact || person.lastContactReminderSent;
+  const reference = person.lastContact ?? person.lastContactReminderSent;
 
-  if (!referenceDate) {
+  if (!reference) {
     // No reference date - don't send (need at least one contact first)
     return false;
   }
 
-  const timeSinceReference = today.getTime() - new Date(referenceDate).getTime();
+  // lastContact is a stored calendar date (UTC midnight); anchor it to the
+  // local calendar day before comparing against local-midnight today, and
+  // compare in whole days so DST transitions cannot shift the send day.
+  const referenceDate = person.lastContact
+    ? parseCalendarDate(person.lastContact)
+    : new Date(reference);
+  referenceDate.setHours(0, 0, 0, 0);
+
+  const daysSinceReference = Math.round(
+    (today.getTime() - referenceDate.getTime()) / MS_PER_DAY
+  );
 
   // Check if enough time has passed since last contact
-  if (timeSinceReference < intervalMs) {
+  if (daysSinceReference < intervalDays) {
     return false;
   }
 
   // Check if we've already sent a reminder recently
   if (person.lastContactReminderSent) {
-    const timeSinceLastReminder =
-      today.getTime() - new Date(person.lastContactReminderSent).getTime();
+    const lastReminder = new Date(person.lastContactReminderSent);
+    lastReminder.setHours(0, 0, 0, 0);
+    const daysSinceLastReminder = Math.round(
+      (today.getTime() - lastReminder.getTime()) / MS_PER_DAY
+    );
 
     // Don't send if we sent a reminder within the interval period
-    if (timeSinceLastReminder < intervalMs * 0.9) {
+    if (daysSinceLastReminder < intervalDays * 0.9) {
       return false;
     }
   }
@@ -480,8 +501,8 @@ function formatDateForEmail(
   const day = d.getDate();
   const year = d.getFullYear();
 
-  // Year-unknown dates carry the 1604 sentinel year; show only month and day.
-  if (year <= 1604) {
+  // Year-unknown dates carry the sentinel year; show only month and day.
+  if (year <= YEAR_UNKNOWN_SENTINEL) {
     switch (dateFormat) {
       case 'DMY':
         return `${day} ${month}`;

--- a/app/people/[id]/page.tsx
+++ b/app/people/[id]/page.tsx
@@ -11,7 +11,7 @@ import PersonVCardRawView from '@/components/PersonVCardRawView';
 import PersonActionsMenu from '@/components/PersonActionsMenu';
 import LastContactQuickUpdate from '@/components/LastContactQuickUpdate';
 import RetryGeocodeButton from '@/components/RetryGeocodeButton';
-import { formatDate, formatDateWithoutYear, parseCalendarDate, type DateFormat } from '@/lib/date-format';
+import { formatDate, formatDateWithoutYear, parseCalendarDate, YEAR_UNKNOWN_SENTINEL, type DateFormat } from '@/lib/date-format';
 import { getCountryName } from '@/lib/countries';
 import { formatCanonicalName, formatGraphName, type NameDisplayFormat } from '@/lib/nameUtils';
 import MarkdownRenderer from '@/components/MarkdownRenderer';
@@ -713,7 +713,7 @@ export default async function PersonDetailsPage({
                     {person.importantDates.map((date) => {
                       const reminderDesc = getReminderDescription(date, t);
                       const dateObj = parseCalendarDate(date.date);
-                      const isYearUnknown = dateObj.getFullYear() === 1604;
+                      const isYearUnknown = dateObj.getFullYear() <= YEAR_UNKNOWN_SENTINEL;
                       const yearsAgo = !isYearUnknown ? getYearsAgo(dateObj, t) : null;
                       return (
                         <div

--- a/components/ImportantDatesManager.tsx
+++ b/components/ImportantDatesManager.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { parseAsLocalDate, formatDate, formatDateWithoutYear } from '@/lib/date-format';
+import { parseAsLocalDate, formatDate, formatDateWithoutYear, YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
 import DatePicker from './ui/DatePicker';
 import ComboboxInput from './ui/ComboboxInput';
 import { PREDEFINED_DATE_TYPES, getDateDisplayTitle } from '@/lib/important-date-types';
@@ -202,8 +202,8 @@ export default function ImportantDatesManager({
   const handleYearlessDateChange = (isoDate: string): string => {
     const parts = isoDate.split('-');
     if (parts.length === 3) {
-      // Extract month and day, set year to 1604 (Apple's convention for unknown year)
-      return `1604-${parts[1]}-${parts[2]}`;
+      // Extract month and day, set the sentinel year (Apple's convention for unknown year)
+      return `${YEAR_UNKNOWN_SENTINEL}-${parts[1]}-${parts[2]}`;
     }
     return isoDate;
   };
@@ -219,12 +219,12 @@ export default function ImportantDatesManager({
   const handleAdd = () => {
     if ((!newDate.type && !newDate.title.trim()) || !newDate.date) return;
 
-    // If year unknown, set year to 1604 (Apple's convention for unknown year)
+    // If year unknown, set the sentinel year (Apple's convention for unknown year)
     let finalDate = newDate.date;
     if (newDate.yearUnknown && newDate.date) {
       const dateParts = newDate.date.split('-');
       if (dateParts.length === 3) {
-        finalDate = `1604-${dateParts[1]}-${dateParts[2]}`;
+        finalDate = `${YEAR_UNKNOWN_SENTINEL}-${dateParts[1]}-${dateParts[2]}`;
       }
     }
 
@@ -250,7 +250,7 @@ export default function ImportantDatesManager({
   const handleStartEdit = (index: number) => {
     setEditingIndex(index);
     const dateToEdit = dates[index];
-    const yearUnknown = dateToEdit.date.startsWith('1604-');
+    const yearUnknown = dateToEdit.date.startsWith(`${YEAR_UNKNOWN_SENTINEL}-`);
     setEditingDate({
       ...dateToEdit,
       yearUnknown,
@@ -263,12 +263,12 @@ export default function ImportantDatesManager({
     if (!editingDate || editingIndex === null) return;
     if ((!editingDate.type && !editingDate.title.trim()) || !editingDate.date) return;
 
-    // If year unknown, set year to 1604 (Apple's convention for unknown year)
+    // If year unknown, set the sentinel year (Apple's convention for unknown year)
     let finalDate = editingDate.date;
     if (editingDate.yearUnknown && editingDate.date) {
       const dateParts = editingDate.date.split('-');
       if (dateParts.length === 3) {
-        finalDate = `1604-${dateParts[1]}-${dateParts[2]}`;
+        finalDate = `${YEAR_UNKNOWN_SENTINEL}-${dateParts[1]}-${dateParts[2]}`;
       }
     }
 
@@ -460,7 +460,7 @@ export default function ImportantDatesManager({
                     {getDateDisplayTitle(date, t)}
                   </div>
                   <div className="text-xs text-muted">
-                    {date.date.startsWith('1604-')
+                    {date.date.startsWith(`${YEAR_UNKNOWN_SENTINEL}-`)
                       ? formatDateWithoutYear(parseAsLocalDate(date.date), dateFormat)
                       : formatDate(parseAsLocalDate(date.date), dateFormat)}
                   </div>

--- a/components/PeopleListClient.tsx
+++ b/components/PeopleListClient.tsx
@@ -10,7 +10,7 @@ import BulkGroupAssignModal from './BulkGroupAssignModal';
 import BulkRelationshipModal from './BulkRelationshipModal';
 import PersonAvatar from './PersonPhoto';
 import { formatCanonicalName, type NameDisplayFormat } from '@/lib/nameUtils';
-import { formatDate, type DateFormat } from '@/lib/date-format';
+import { formatDate, parseCalendarDate, type DateFormat } from '@/lib/date-format';
 import CustomFieldFilter from './customFields/CustomFieldFilter';
 import type { CustomFieldTemplate } from '@prisma/client';
 
@@ -481,7 +481,7 @@ export default function PeopleListClient({
                       </div>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-muted">
-                      {person.lastContact ? formatDate(person.lastContact, dateFormat) : '\u2014'}
+                      {person.lastContact ? formatDate(parseCalendarDate(person.lastContact), dateFormat) : '\u2014'}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-right">
                       <div className="flex justify-end gap-3">

--- a/components/TrashManager.tsx
+++ b/components/TrashManager.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/Button';
+import { parseCalendarDate, isYearUnknownDate } from '@/lib/date-format';
 import ConfirmationModal from '@/components/ui/ConfirmationModal';
 
 type EntityType = 'people' | 'groups' | 'relationships' | 'relationshipTypes' | 'importantDates';
@@ -99,8 +100,10 @@ function formatPersonName(person: { name: string; surname: string | null }): str
 }
 
 function formatDeletedDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  if (d.getFullYear() === 1604) {
+  // Stored calendar dates are UTC midnight; anchor to the encoded day so the
+  // list does not show the previous day west of UTC.
+  const d = parseCalendarDate(dateStr);
+  if (isYearUnknownDate(dateStr)) {
     return d.toLocaleDateString(undefined, { month: 'long', day: 'numeric' });
   }
   return d.toLocaleDateString();

--- a/docs/src/content/docs/features/important-dates.md
+++ b/docs/src/content/docs/features/important-dates.md
@@ -52,3 +52,4 @@ Self-hosted installations are not subject to these limits. Turning off a reminde
 - **Reminder types**: Once (fires a single time), Recurring (fires every interval, for example every year)
 - **Date storage**: calendar dates are stored as UTC midnight on the day you picked, so the day never shifts with your timezone
 - **Unknown years**: dates saved without a year are stored under year 1604, Apple's marker for an unknown year, which keeps them compatible with Contacts and other CardDAV clients
+- **February 29**: in non-leap years, a February 29 date appears (and its yearly reminder fires) on March 1

--- a/lib/carddav/vcard-export.ts
+++ b/lib/carddav/vcard-export.ts
@@ -19,6 +19,7 @@ import {
   filterFreeFormCustomFieldsAgainstTemplates,
 } from '@/lib/customFields/serialize';
 import { formatGraphName, nameSeparator } from '@/lib/nameUtils';
+import { YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
 
 export interface VCardOptions {
   includePhoto?: boolean; // Default: true (requires base64 encoding)
@@ -481,8 +482,8 @@ export function formatVCardV3Date(date: Date): string {
   const month = String(d.getUTCMonth() + 1).padStart(2, '0');
   const day = String(d.getUTCDate()).padStart(2, '0');
 
-  // If year is 1604 or earlier, omit it (year unknown - Apple uses 1604 as marker)
-  if (year <= 1604) {
+  // If year is the sentinel or earlier, omit it (year unknown - Apple convention)
+  if (year <= YEAR_UNKNOWN_SENTINEL) {
     return `--${month}${day}`;
   }
 

--- a/lib/carddav/vcard-parser.ts
+++ b/lib/carddav/vcard-parser.ts
@@ -5,6 +5,7 @@
  */
 
 import type { ParsedVCardData } from './types';
+import { yearUnknownDate } from '@/lib/date-format';
 
 /**
  * Unknown property that wasn't explicitly handled
@@ -795,8 +796,8 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
     if (yearMatch) {
       const month = parseInt(yearMatch[2], 10);
       const day = parseInt(yearMatch[3], 10);
-      // Use year 1604 to indicate unknown year (matches Apple convention)
-      return new Date(Date.UTC(1604, month - 1, day));
+      // Sentinel form for an unknown year (matches Apple convention)
+      return yearUnknownDate(month - 1, day);
     }
   }
 
@@ -810,8 +811,8 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
       if (parts.length === 2) {
         const month = parseInt(parts[0], 10);
         const day = parseInt(parts[1], 10);
-        // Use year 1604 to indicate unknown year (matches Apple convention)
-        return new Date(Date.UTC(1604, month - 1, day));
+        // Sentinel form for an unknown year (matches Apple convention)
+        return yearUnknownDate(month - 1, day);
       }
     }
 
@@ -819,8 +820,8 @@ function parseVCardDate(dateStr: string, omitYearParam?: string | string[]): Dat
     if (/^\d{4}$/.test(rest)) {
       const month = parseInt(rest.substring(0, 2), 10);
       const day = parseInt(rest.substring(2, 4), 10);
-      // Use year 1604 to indicate unknown year (matches Apple convention)
-      return new Date(Date.UTC(1604, month - 1, day));
+      // Sentinel form for an unknown year (matches Apple convention)
+      return yearUnknownDate(month - 1, day);
     }
   }
 

--- a/lib/date-format.ts
+++ b/lib/date-format.ts
@@ -51,6 +51,24 @@ export function parseCalendarDate(date: Date | string): Date {
 }
 
 /**
+ * Apple's marker year for dates whose year is unknown. It predates standard
+ * time zones, which is why these values must always be read as UTC calendar
+ * days (see `parseCalendarDate`). Legacy rows written through local-time paths
+ * can sit slightly below it, so checks use `<=` rather than equality.
+ */
+export const YEAR_UNKNOWN_SENTINEL = 1604;
+
+/** Build the stored form of a year-unknown calendar date: UTC midnight under the sentinel year. */
+export function yearUnknownDate(monthIndex: number, day: number): Date {
+  return new Date(Date.UTC(YEAR_UNKNOWN_SENTINEL, monthIndex, day));
+}
+
+/** True when a stored calendar date (Date or string) carries the year-unknown sentinel. */
+export function isYearUnknownDate(date: Date | string): boolean {
+  return parseCalendarDate(date).getFullYear() <= YEAR_UNKNOWN_SENTINEL;
+}
+
+/**
  * Today's calendar date in the viewer's local timezone, as `YYYY-MM-DD`.
  * Use instead of `new Date().toISOString().split('T')[0]`, which is UTC and
  * rolls forward after UTC midnight for users west of UTC.

--- a/lib/duplicate-detection.ts
+++ b/lib/duplicate-detection.ts
@@ -171,13 +171,17 @@ function birthdaySignal(a: PersonForComparison, b: PersonForComparison): { compa
     return { comparable: false, score: 0 };
   }
   let best = 0;
+  // Stored birthdays are UTC midnight on the calendar day they encode, so read
+  // them with UTC accessors. Local accessors shift year-unknown dates (year
+  // 1604, where Local Mean Time applies) by a different amount than modern
+  // years, which breaks the month/day comparison between the two.
   for (const da of a.birthdays) {
     for (const db of b.birthdays) {
-      if (da.getFullYear() === db.getFullYear() && da.getMonth() === db.getMonth() && da.getDate() === db.getDate()) {
+      if (da.getUTCFullYear() === db.getUTCFullYear() && da.getUTCMonth() === db.getUTCMonth() && da.getUTCDate() === db.getUTCDate()) {
         best = 1.0;
         break;
       }
-      if (da.getMonth() === db.getMonth() && da.getDate() === db.getDate()) {
+      if (da.getUTCMonth() === db.getUTCMonth() && da.getUTCDate() === db.getUTCDate()) {
         best = Math.max(best, 0.5);
       }
     }

--- a/lib/services/person.ts
+++ b/lib/services/person.ts
@@ -10,6 +10,7 @@ import type { Prisma } from '@prisma/client';
 import { prisma, prismaIncludingDeleted } from '@/lib/prisma';
 import { createPersonSchema, updatePersonSchema } from '@/lib/validations';
 import { sanitizeName, sanitizeNotes } from '@/lib/sanitize';
+import { yearUnknownDate } from '@/lib/date-format';
 import { autoExportPerson, autoUpdatePerson } from '@/lib/carddav/auto-export';
 import { geocodePersonAddresses } from '@/lib/geocoding/geocode-person';
 import { personUpdateInclude, personDetailsInclude } from '@/lib/prisma-queries';
@@ -67,10 +68,10 @@ function mapImportantDate(date: NonNullable<PersonInput['importantDates']>[numbe
   // Calendar dates are stored as UTC midnight. `setFullYear` would rewrite the
   // year in local time and store a different instant than the important-dates
   // API and the CardDAV importer do for the same day, so read and rebuild the
-  // UTC components instead. 1604 is Apple's marker for an unknown year.
+  // UTC components instead.
   const parsed = new Date(date.date);
   const dateValue = date.yearUnknown
-    ? new Date(Date.UTC(1604, parsed.getUTCMonth(), parsed.getUTCDate()))
+    ? yearUnknownDate(parsed.getUTCMonth(), parsed.getUTCDate())
     : parsed;
 
   return {

--- a/lib/upcoming-events.ts
+++ b/lib/upcoming-events.ts
@@ -1,6 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { formatGraphName } from '@/lib/nameUtils';
-import { parseCalendarDate } from '@/lib/date-format';
+import { parseCalendarDate, YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
 import { getTranslationsForLocale } from '@/lib/i18n-utils';
 import { getDateDisplayTitle } from '@/lib/important-date-types';
 import { getUserLocale } from '@/lib/locale';
@@ -74,8 +74,10 @@ export function getNextOccurrence(
   return nextOccurrence;
 }
 
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
 export function getIntervalMs(interval: number, unit: string): number {
-  const msPerDay = 24 * 60 * 60 * 1000;
+  const msPerDay = MS_PER_DAY;
   switch (unit) {
     case 'DAYS':
       return interval * msPerDay;
@@ -158,15 +160,16 @@ export async function getUpcomingEvents(userId: string): Promise<UpcomingEvent[]
 
   // Process important dates
   for (const importantDate of importantDates) {
+    const storedDate = parseCalendarDate(importantDate.date);
     let eventDate: Date;
 
     if (importantDate.reminderType === 'ONCE') {
-      eventDate = parseCalendarDate(importantDate.date);
+      eventDate = storedDate;
     } else {
       const interval = importantDate.reminderInterval || 1;
       const intervalUnit = importantDate.reminderIntervalUnit || 'YEARS';
       eventDate = getNextOccurrence(
-        parseCalendarDate(importantDate.date),
+        storedDate,
         today,
         interval,
         intervalUnit,
@@ -186,7 +189,7 @@ export async function getUpcomingEvents(userId: string): Promise<UpcomingEvent[]
         titleKey: null,
         date: eventDate,
         daysUntil,
-        isYearUnknown: parseCalendarDate(importantDate.date).getFullYear() <= 1604,
+        isYearUnknown: storedDate.getFullYear() <= YEAR_UNKNOWN_SENTINEL,
         personPhoto: importantDate.person.photo,
       });
     }
@@ -198,10 +201,15 @@ export async function getUpcomingEvents(userId: string): Promise<UpcomingEvent[]
     const unit = person.contactReminderIntervalUnit || 'MONTHS';
     const intervalMs = getIntervalMs(interval, unit);
 
-    const referenceDate = person.lastContact ? new Date(person.lastContact) : null;
+    // lastContact is a stored calendar date (UTC midnight); anchor it to the
+    // local calendar day before doing day arithmetic, and add whole days
+    // rather than milliseconds so DST transitions cannot shift the result.
+    const referenceDate = person.lastContact ? parseCalendarDate(person.lastContact) : null;
 
     if (referenceDate) {
-      const reminderDueDate = new Date(referenceDate.getTime() + intervalMs);
+      const intervalDays = Math.round(intervalMs / MS_PER_DAY);
+      const reminderDueDate = new Date(referenceDate);
+      reminderDueDate.setDate(reminderDueDate.getDate() + intervalDays);
       reminderDueDate.setHours(0, 0, 0, 0);
 
       const daysUntil = getDaysUntil(reminderDueDate, today);

--- a/tests/api/cron-reminders-unsubscribe.test.ts
+++ b/tests/api/cron-reminders-unsubscribe.test.ts
@@ -108,16 +108,17 @@ vi.mock('../../lib/api-utils', () => ({
 
 // Import after mocking
 import { GET } from '../../app/api/cron/send-reminders/route';
-
-/**
- * Nametag stores calendar dates as UTC midnight on the day they encode, never
- * local midnight. Fixtures have to match, otherwise they stand in for a row
- * production never writes and the reminder logic gets exercised against the
- * wrong calendar day.
- */
-function asStoredCalendarDate(day: Date): Date {
-  return new Date(Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()));
-}
+// Nametag stores calendar dates as UTC midnight on the day they encode, never
+// local midnight. Fixtures have to match, otherwise they stand in for a row
+// production never writes and the reminder logic gets exercised against the
+// wrong calendar day.
+import {
+  TIMEZONES,
+  setProcessTimezone,
+  restoreTimezoneAfterEach,
+  storedCalendarDate as asStoredCalendarDate,
+  storedYearUnknownDate,
+} from '../helpers/timezone';
 
 describe('Cron Job - Unsubscribe Token Generation', () => {
   beforeEach(() => {
@@ -700,19 +701,13 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
    * a day, which meant birthday reminders went out the day before.
    */
   describe('year-unknown birthdays across timezones', () => {
-    const ORIGINAL_TZ = process.env.TZ;
-
-    afterEach(() => {
-      process.env.TZ = ORIGINAL_TZ;
-    });
-
-    const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+    restoreTimezoneAfterEach();
 
     function yearUnknownDateOn(day: Date) {
       return {
         id: 'date-1',
         title: 'Birthday',
-        date: new Date(Date.UTC(1604, day.getMonth(), day.getDate())),
+        date: storedYearUnknownDate(day),
         reminderType: 'RECURRING',
         reminderInterval: 1,
         reminderIntervalUnit: 'YEARS',
@@ -745,7 +740,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
     }
 
     it.each(TIMEZONES)('sends on the birthday itself in %s', async (tz) => {
-      process.env.TZ = tz;
+      setProcessTimezone(tz);
       mocks.importantDateFindMany.mockResolvedValue([yearUnknownDateOn(new Date())]);
 
       await runCron();
@@ -754,12 +749,86 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
     });
 
     it.each(TIMEZONES)('stays quiet the day before in %s', async (tz) => {
-      process.env.TZ = tz;
+      setProcessTimezone(tz);
       const tomorrow = new Date();
       tomorrow.setDate(tomorrow.getDate() + 1);
       mocks.importantDateFindMany.mockResolvedValue([yearUnknownDateOn(tomorrow)]);
 
       await runCron();
+
+      expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * A February 29 birthday (year 1604 is a leap year, so the sentinel form is
+   * valid) has no matching calendar day in non-leap years. The dashboard rolls
+   * it to March 1, and the cron must agree instead of skipping the year.
+   */
+  describe('February 29 birthdays', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function feb29Birthday() {
+      return {
+        id: 'date-1',
+        title: 'Birthday',
+        date: new Date(Date.UTC(1604, 1, 29)),
+        reminderType: 'RECURRING',
+        reminderInterval: 1,
+        reminderIntervalUnit: 'YEARS',
+        lastReminderSent: null,
+        person: {
+          userId: 'user-1',
+          name: 'John',
+          surname: 'Doe',
+          middleName: null,
+          secondLastName: null,
+          nickname: null,
+          user: { email: 'john@example.com', dateFormat: 'MDY', language: 'en' },
+        },
+      };
+    }
+
+    async function runCronOn(localDate: Date) {
+      vi.useFakeTimers({ toFake: ['Date'] });
+      vi.setSystemTime(localDate);
+      mocks.importantDateFindMany.mockResolvedValue([feb29Birthday()]);
+      mocks.personFindMany.mockResolvedValue([]);
+      mocks.createUnsubscribeToken.mockResolvedValue('token-abc123');
+      mocks.importantDateReminderTemplate.mockResolvedValue({
+        subject: 'Reminder',
+        html: '<p>Reminder</p>',
+        text: 'Reminder',
+      });
+      await GET(
+        new Request('http://localhost/api/cron/send-reminders', {
+          headers: { authorization: 'Bearer test-cron-secret' },
+        })
+      );
+    }
+
+    it('fires on March 1 in non-leap years, matching the dashboard', async () => {
+      await runCronOn(new Date(2026, 2, 1, 9, 0, 0));
+
+      expect(mocks.createUnsubscribeToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays quiet on February 28 in non-leap years', async () => {
+      await runCronOn(new Date(2026, 1, 28, 9, 0, 0));
+
+      expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
+    });
+
+    it('fires on February 29 in leap years', async () => {
+      await runCronOn(new Date(2028, 1, 29, 9, 0, 0));
+
+      expect(mocks.createUnsubscribeToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays quiet on March 1 in leap years', async () => {
+      await runCronOn(new Date(2028, 2, 1, 9, 0, 0));
 
       expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
     });
@@ -773,13 +842,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
    * year into the text.
    */
   describe('email body dates across timezones', () => {
-    const ORIGINAL_TZ = process.env.TZ;
-
-    afterEach(() => {
-      process.env.TZ = ORIGINAL_TZ;
-    });
-
-    const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+    restoreTimezoneAfterEach();
 
     function importantDateFixture(date: Date, overrides: Record<string, unknown> = {}) {
       return {
@@ -822,10 +885,27 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       );
     }
 
+    function contactPersonFixture(lastContactDay: Date) {
+      return {
+        id: 'person-1',
+        userId: 'user-1',
+        name: 'Jane',
+        surname: 'Smith',
+        middleName: null,
+        secondLastName: null,
+        nickname: null,
+        lastContact: asStoredCalendarDate(lastContactDay),
+        contactReminderInterval: 30,
+        contactReminderIntervalUnit: 'DAYS',
+        lastContactReminderSent: null,
+        user: { email: 'jane@example.com', dateFormat: 'MDY', language: 'en' },
+      };
+    }
+
     it.each(TIMEZONES)('prints the stored day without the sentinel year in %s', async (tz) => {
-      process.env.TZ = tz;
+      setProcessTimezone(tz);
       const today = new Date();
-      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      const stored = storedYearUnknownDate(today);
       mocks.importantDateFindMany.mockResolvedValue([importantDateFixture(stored)]);
       mocks.personFindMany.mockResolvedValue([]);
 
@@ -842,7 +922,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
     });
 
     it.each(TIMEZONES)('prints known-year dates on the stored day with their year in %s', async (tz) => {
-      process.env.TZ = tz;
+      setProcessTimezone(tz);
       const today = new Date();
       const stored = new Date(Date.UTC(1990, today.getMonth(), today.getDate()));
       mocks.importantDateFindMany.mockResolvedValue([importantDateFixture(stored)]);
@@ -861,7 +941,7 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
     });
 
     it.each(TIMEZONES)('prints the recorded last-contact day in %s', async (tz) => {
-      process.env.TZ = tz;
+      setProcessTimezone(tz);
       const lastContactDay = new Date();
       lastContactDay.setMonth(lastContactDay.getMonth() - 4);
       const person = {
@@ -894,9 +974,9 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
     });
 
     it('lays out year-unknown dates as day-first for DMY users', async () => {
-      process.env.TZ = 'Europe/Madrid';
+      setProcessTimezone('Europe/Madrid');
       const today = new Date();
-      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      const stored = storedYearUnknownDate(today);
       const fixture = importantDateFixture(stored);
       fixture.person.user.dateFormat = 'DMY';
       mocks.importantDateFindMany.mockResolvedValue([fixture]);
@@ -914,10 +994,34 @@ describe('Cron Job - Unsubscribe Token Generation', () => {
       );
     });
 
+    it.each(TIMEZONES)('sends the catch-up reminder on the day the interval elapses in %s', async (tz) => {
+      setProcessTimezone(tz);
+      const lastContactDay = new Date();
+      lastContactDay.setDate(lastContactDay.getDate() - 30);
+      mocks.importantDateFindMany.mockResolvedValue([]);
+      mocks.personFindMany.mockResolvedValue([contactPersonFixture(lastContactDay)]);
+
+      await runCron();
+
+      expect(mocks.createUnsubscribeToken).toHaveBeenCalledTimes(1);
+    });
+
+    it.each(TIMEZONES)('stays quiet the day before the interval elapses in %s', async (tz) => {
+      setProcessTimezone(tz);
+      const lastContactDay = new Date();
+      lastContactDay.setDate(lastContactDay.getDate() - 29);
+      mocks.importantDateFindMany.mockResolvedValue([]);
+      mocks.personFindMany.mockResolvedValue([contactPersonFixture(lastContactDay)]);
+
+      await runCron();
+
+      expect(mocks.createUnsubscribeToken).not.toHaveBeenCalled();
+    });
+
     it('localizes the month name for year-unknown dates', async () => {
-      process.env.TZ = 'Europe/Madrid';
+      setProcessTimezone('Europe/Madrid');
       const today = new Date();
-      const stored = new Date(Date.UTC(1604, today.getMonth(), today.getDate()));
+      const stored = storedYearUnknownDate(today);
       const fixture = importantDateFixture(stored);
       fixture.person.user.dateFormat = 'DMY';
       fixture.person.user.language = 'es-ES';

--- a/tests/components/PeopleListClient.test.tsx
+++ b/tests/components/PeopleListClient.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { NextIntlClientProvider } from 'next-intl';
 import PeopleListClient from '../../components/PeopleListClient';
 import enMessages from '../../locales/en.json';
+import { TIMEZONES, setProcessTimezone, restoreTimezoneAfterEach } from '../helpers/timezone';
 
 vi.mock('next/navigation', () => ({
   useRouter: vi.fn(() => ({
@@ -157,6 +158,30 @@ describe('PeopleListClient', () => {
 
       expect(screen.getByText('Alice')).toBeInTheDocument();
       expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
+    describe('last contact across timezones', () => {
+      restoreTimezoneAfterEach();
+
+      // The people page hands this component raw Prisma rows, so lastContact
+      // arrives as a real Date at UTC midnight and local accessors would show
+      // the previous day west of UTC, disagreeing with the detail page.
+      it.each(TIMEZONES)('shows the recorded last-contact day in %s', (tz) => {
+        setProcessTimezone(tz);
+        render(
+          <Wrapper>
+            <PeopleListClient
+              {...defaultProps({
+                people: [
+                  makePerson({ id: 'p-1', lastContact: new Date('2026-08-10T00:00:00.000Z') }),
+                ],
+              })}
+            />
+          </Wrapper>
+        );
+
+        expect(screen.getByText('08/10/2026')).toBeInTheDocument();
+      });
     });
 
     it('renders showing count text', () => {

--- a/tests/helpers/timezone.ts
+++ b/tests/helpers/timezone.ts
@@ -1,0 +1,65 @@
+import { afterEach } from 'vitest';
+import { YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
+
+/**
+ * Timezones that exercise the calendar-date storage convention from every
+ * angle. Madrid and London are east of UTC today but west of it in 1604
+ * (Local Mean Time applies under the year-unknown sentinel), which is the
+ * combination that made only year-unknown dates look broken. New York is west
+ * in both eras, Sydney east in both. The bug class is invisible under UTC.
+ */
+export const TIMEZONES = [
+  'UTC',
+  'Europe/Madrid',
+  'Europe/London',
+  'America/New_York',
+  'Australia/Sydney',
+];
+
+const ORIGINAL_TZ = process.env.TZ;
+
+export function setProcessTimezone(tz: string): void {
+  process.env.TZ = tz;
+}
+
+export function restoreProcessTimezone(): void {
+  // Assigning `undefined` to process.env.TZ would coerce it to the string
+  // "undefined", which Node treats as a fallback UTC zone: exactly the one
+  // timezone where calendar-date bugs are invisible. Delete instead.
+  if (ORIGINAL_TZ === undefined) {
+    delete process.env.TZ;
+  } else {
+    process.env.TZ = ORIGINAL_TZ;
+  }
+}
+
+/** Restore the process timezone after each test in the enclosing suite. */
+export function restoreTimezoneAfterEach(): void {
+  afterEach(restoreProcessTimezone);
+}
+
+/** Run `fn` under a pinned process timezone, restoring afterwards. */
+export function withTimezone<T>(tz: string, fn: () => T): T {
+  setProcessTimezone(tz);
+  try {
+    return fn();
+  } finally {
+    restoreProcessTimezone();
+  }
+}
+
+/**
+ * A calendar date as Prisma hands it back: UTC midnight on the stored day.
+ * Accepts `YYYY-MM-DD` or a local Date whose calendar day should be encoded.
+ */
+export function storedCalendarDate(day: Date | string): Date {
+  if (typeof day === 'string') {
+    return new Date(`${day}T00:00:00.000Z`);
+  }
+  return new Date(Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()));
+}
+
+/** The stored form of a year-unknown date on the same month and day as `day`. */
+export function storedYearUnknownDate(day: Date): Date {
+  return new Date(Date.UTC(YEAR_UNKNOWN_SENTINEL, day.getMonth(), day.getDate()));
+}

--- a/tests/lib/calendar-date-timezone.test.ts
+++ b/tests/lib/calendar-date-timezone.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import {
   formatDate,
   formatDateWithoutYear,
@@ -6,6 +6,7 @@ import {
   parseCalendarDate,
 } from '@/lib/date-format';
 import { getNextOccurrence } from '@/lib/upcoming-events';
+import { TIMEZONES, withTimezone, storedCalendarDate } from '../helpers/timezone';
 
 /**
  * Regression tests for calendar dates read straight from the database.
@@ -25,33 +26,6 @@ import { getNextOccurrence } from '@/lib/upcoming-events';
  *
  * These tests pin the process timezone because the bug is invisible under UTC.
  */
-
-const ORIGINAL_TZ = process.env.TZ;
-
-afterEach(() => {
-  process.env.TZ = ORIGINAL_TZ;
-});
-
-function withTimezone<T>(tz: string, fn: () => T): T {
-  process.env.TZ = tz;
-  return fn();
-}
-
-// Madrid and London are east of UTC today but west of it in 1604, which is the
-// combination that made only year-unknown dates look broken. New York is west
-// in both eras, Sydney east in both.
-const TIMEZONES = [
-  'UTC',
-  'Europe/Madrid',
-  'Europe/London',
-  'America/New_York',
-  'Australia/Sydney',
-];
-
-/** A calendar date as Prisma hands it back: UTC midnight on the stored day. */
-function storedCalendarDate(iso: string): Date {
-  return new Date(`${iso}T00:00:00.000Z`);
-}
 
 describe('calendar dates read from the database', () => {
   describe('parseCalendarDate', () => {
@@ -138,6 +112,29 @@ describe('calendar dates read from the database', () => {
         expect(next.getMonth()).toBe(7);
         expect(next.getDate()).toBe(10);
       });
+    });
+
+    it('rolls a February 29 birthday to March 1 in non-leap years', () => {
+      // Year 1604 is a leap year, so the sentinel form of Feb 29 is valid.
+      // This rollover is the convention: the reminder cron matches it, so the
+      // dashboard and the emails agree on the day.
+      const stored = storedCalendarDate('1604-02-29');
+      const today = new Date(2026, 1, 20);
+      const next = getNextOccurrence(parseCalendarDate(stored), today, 1, 'YEARS', null);
+
+      expect(next.getFullYear()).toBe(2026);
+      expect(next.getMonth()).toBe(2);
+      expect(next.getDate()).toBe(1);
+    });
+
+    it('keeps a February 29 birthday on its own day in leap years', () => {
+      const stored = storedCalendarDate('1604-02-29');
+      const today = new Date(2028, 1, 20);
+      const next = getNextOccurrence(parseCalendarDate(stored), today, 1, 'YEARS', null);
+
+      expect(next.getFullYear()).toBe(2028);
+      expect(next.getMonth()).toBe(1);
+      expect(next.getDate()).toBe(29);
     });
 
     it.each(TIMEZONES)('treats the birthday itself as due today in %s', (tz) => {

--- a/tests/lib/carddav/vcard-date-timezone.test.ts
+++ b/tests/lib/carddav/vcard-date-timezone.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { personToVCard, formatVCardV3Date } from '@/lib/carddav/vcard-export';
 import { parseVCard } from '@/lib/carddav/vcard-parser';
 import type { PersonWithRelations } from '@/lib/carddav/types';
+import { withTimezone } from '../../helpers/timezone';
 
 /**
  * Regression tests for issue #373 follow-up: calendar dates drifted one day
@@ -19,19 +20,8 @@ import type { PersonWithRelations } from '@/lib/carddav/types';
  * and under any timezone west of UTC, which is why the existing suite passed.
  */
 
-const ORIGINAL_TZ = process.env.TZ;
-
-afterEach(() => {
-  process.env.TZ = ORIGINAL_TZ;
-});
-
 // Two zones ahead of UTC (where the bug appeared), one behind, plus UTC.
 const TIMEZONES = ['UTC', 'Europe/Berlin', 'Australia/Sydney', 'America/New_York'];
-
-function withTimezone<T>(tz: string, fn: () => T): T {
-  process.env.TZ = tz;
-  return fn();
-}
 
 function buildPerson(
   importantDates: PersonWithRelations['importantDates']

--- a/tests/lib/date-format.test.ts
+++ b/tests/lib/date-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate, formatDateWithoutYear, getDateFormatLabel, getDateFormatExample, getLocalDateString, parseAsLocalDate } from '@/lib/date-format';
+import { formatDate, formatDateWithoutYear, getDateFormatLabel, getDateFormatExample, getLocalDateString, parseAsLocalDate, yearUnknownDate, isYearUnknownDate } from '@/lib/date-format';
 
 describe('date-format', () => {
   describe('parseAsLocalDate', () => {
@@ -324,6 +324,36 @@ describe('date-format', () => {
         const date = new Date(2024, 11, 25); // December 25, 2024
         expect(formatDateWithoutYear(date, 'MDY')).toBe('December 25');
         expect(formatDateWithoutYear(date, 'DMY')).toBe('25 December');
+      });
+    });
+  });
+
+  describe('year-unknown sentinel helpers', () => {
+    describe('yearUnknownDate', () => {
+      it('builds the stored form: UTC midnight under the sentinel year', () => {
+        const stored = yearUnknownDate(7, 10);
+        expect(stored.toISOString()).toBe('1604-08-10T00:00:00.000Z');
+      });
+    });
+
+    describe('isYearUnknownDate', () => {
+      it('recognizes a stored sentinel Date', () => {
+        expect(isYearUnknownDate(new Date('1604-08-10T00:00:00.000Z'))).toBe(true);
+      });
+
+      it('recognizes a sentinel date string', () => {
+        expect(isYearUnknownDate('1604-08-10')).toBe(true);
+      });
+
+      it('recognizes legacy rows that drifted below the sentinel year', () => {
+        // The old local-time write path could store a January 1 pick as late
+        // December 1603 on some server timezones.
+        expect(isYearUnknownDate(new Date('1603-12-31T23:47:52.000Z'))).toBe(true);
+      });
+
+      it('treats known-year dates as known', () => {
+        expect(isYearUnknownDate(new Date('1990-08-10T00:00:00.000Z'))).toBe(false);
+        expect(isYearUnknownDate('1990-08-10')).toBe(false);
       });
     });
   });

--- a/tests/lib/duplicate-detection.test.ts
+++ b/tests/lib/duplicate-detection.test.ts
@@ -7,6 +7,7 @@ import {
   compositeSimilarity,
 } from '@/lib/duplicate-detection';
 import type { PersonForComparison } from '@/lib/duplicate-detection';
+import { TIMEZONES, setProcessTimezone, restoreTimezoneAfterEach } from '../helpers/timezone';
 
 describe('normalizeEmail', () => {
   it('lowercases and trims', () => {
@@ -172,6 +173,34 @@ describe('compositeSimilarity', () => {
     const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [bday] });
     const result = compositeSimilarity(a, b);
     expect(result.score).toBeGreaterThan(0.6);
+  });
+
+  describe('birthday signal across timezones', () => {
+    restoreTimezoneAfterEach();
+
+    // Stored birthdays are UTC midnight. A year-unknown one sits under year
+    // 1604, where Local Mean Time applies, so local accessors shift it by a
+    // different amount than a modern year and the month/day match breaks.
+    it.each(TIMEZONES)('partial-matches a year-unknown birthday against the same day with a known year in %s', (tz) => {
+      setProcessTimezone(tz);
+      const a = person({ id: '1', name: 'Roberto', surname: 'Sanchez', birthdays: [new Date('1604-08-10T00:00:00.000Z')] });
+      const sameDay = person({ id: '2', name: 'Robert', surname: 'Sanchez', birthdays: [new Date('1990-08-10T00:00:00.000Z')] });
+      const differentDay = person({ id: '3', name: 'Robert', surname: 'Sanchez', birthdays: [new Date('1990-11-20T00:00:00.000Z')] });
+
+      const sameDayScore = compositeSimilarity(a, sameDay).score;
+      const differentDayScore = compositeSimilarity(a, differentDay).score;
+
+      expect(sameDayScore).toBeGreaterThan(differentDayScore);
+    });
+
+    it.each(TIMEZONES)('exact-matches two identical known-year birthdays in %s', (tz) => {
+      setProcessTimezone(tz);
+      const bday = new Date('1990-05-15T00:00:00.000Z');
+      const a = person({ id: '1', name: 'John', surname: 'Smith', birthdays: [bday] });
+      const b = person({ id: '2', name: 'John', surname: 'Smith', birthdays: [new Date(bday)] });
+
+      expect(compositeSimilarity(a, b).score).toBeGreaterThan(0.6);
+    });
   });
 
   it('scores birthday same month+day different year as 0.5', () => {

--- a/tests/lib/services/person.test.ts
+++ b/tests/lib/services/person.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 // ---------------------------------------------------------------------------
 // Mocks (must be defined before any imports that use them)
@@ -156,6 +156,7 @@ import {
   restorePerson,
   mergePeople,
 } from '../../../lib/services/person';
+import { TIMEZONES, setProcessTimezone, restoreTimezoneAfterEach } from '../../helpers/timezone';
 
 // ---------------------------------------------------------------------------
 // Test helpers
@@ -276,16 +277,12 @@ describe('createPerson', () => {
    * written it last.
    */
   describe('year-unknown important dates', () => {
-    const ORIGINAL_TZ = process.env.TZ;
+    restoreTimezoneAfterEach();
 
-    afterEach(() => {
-      process.env.TZ = ORIGINAL_TZ;
-    });
-
-    it.each(['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'])(
+    it.each(TIMEZONES)(
       'stores August 10 at UTC midnight under year 1604 in %s',
       async (tz) => {
-        process.env.TZ = tz;
+        setProcessTimezone(tz);
 
         await createPerson(USER_ID, {
           ...makeMinimalPersonData(),

--- a/tests/lib/upcoming-events-timezone.test.ts
+++ b/tests/lib/upcoming-events-timezone.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 /**
  * The dashboard renders `event.date` straight from `getUpcomingEvents`, so the
@@ -37,10 +37,13 @@ vi.mock('@/lib/locale', () => ({
 }));
 
 import { getUpcomingEvents } from '@/lib/upcoming-events';
-
-const ORIGINAL_TZ = process.env.TZ;
-
-const TIMEZONES = ['UTC', 'Europe/Madrid', 'Europe/London', 'America/New_York', 'Australia/Sydney'];
+import {
+  TIMEZONES,
+  setProcessTimezone,
+  restoreTimezoneAfterEach,
+  storedCalendarDate,
+  storedYearUnknownDate,
+} from '../helpers/timezone';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -48,17 +51,15 @@ beforeEach(() => {
   mocks.userFindUnique.mockResolvedValue({ nameOrder: 'WESTERN', language: 'en', nameDisplayFormat: 'FULL' });
 });
 
-afterEach(() => {
-  process.env.TZ = ORIGINAL_TZ;
-});
+restoreTimezoneAfterEach();
 
-/** A year-unknown birthday as stored: UTC midnight under year 1604. */
+/** A year-unknown birthday as stored: UTC midnight under the sentinel year. */
 function yearUnknownBirthdayOn(day: Date) {
   return {
     id: 'date-1',
     title: 'Birthday',
     type: 'BIRTHDAY',
-    date: new Date(Date.UTC(1604, day.getMonth(), day.getDate())),
+    date: storedYearUnknownDate(day),
     reminderEnabled: true,
     reminderType: 'RECURRING',
     reminderInterval: 1,
@@ -77,7 +78,7 @@ function yearUnknownBirthdayOn(day: Date) {
 
 describe('getUpcomingEvents with year-unknown birthdays', () => {
   it.each(TIMEZONES)('keeps a birthday three days out on its own day in %s', async (tz) => {
-    process.env.TZ = tz;
+    setProcessTimezone(tz);
     const target = new Date();
     target.setDate(target.getDate() + 3);
     mocks.importantDateFindMany.mockResolvedValue([yearUnknownBirthdayOn(target)]);
@@ -91,7 +92,7 @@ describe('getUpcomingEvents with year-unknown birthdays', () => {
   });
 
   it.each(TIMEZONES)('reports a birthday today as zero days away in %s', async (tz) => {
-    process.env.TZ = tz;
+    setProcessTimezone(tz);
     const today = new Date();
     mocks.importantDateFindMany.mockResolvedValue([yearUnknownBirthdayOn(today)]);
 
@@ -99,5 +100,50 @@ describe('getUpcomingEvents with year-unknown birthdays', () => {
 
     expect(event.daysUntil).toBe(0);
     expect(event.date.getDate()).toBe(today.getDate());
+  });
+});
+
+/** A person due for a catch-up, with lastContact as stored: UTC midnight. */
+function personLastContactedOn(day: Date) {
+  return {
+    id: 'person-1',
+    name: 'Jane',
+    surname: 'Doe',
+    nickname: null,
+    displayNameOverride: null,
+    photo: null,
+    lastContact: storedCalendarDate(day),
+    contactReminderInterval: 1,
+    contactReminderIntervalUnit: 'MONTHS',
+  };
+}
+
+describe('getUpcomingEvents contact reminders', () => {
+  it.each(TIMEZONES)('puts the catch-up thirty days after the recorded day in %s', async (tz) => {
+    setProcessTimezone(tz);
+    const lastContactDay = new Date();
+    lastContactDay.setDate(lastContactDay.getDate() - 10);
+    mocks.importantDateFindMany.mockResolvedValue([]);
+    mocks.personFindMany.mockResolvedValue([personLastContactedOn(lastContactDay)]);
+
+    const [event] = await getUpcomingEvents('user-1');
+
+    const expected = new Date(lastContactDay);
+    expected.setDate(expected.getDate() + 30);
+    expect(event.daysUntil).toBe(20);
+    expect(event.date.getMonth()).toBe(expected.getMonth());
+    expect(event.date.getDate()).toBe(expected.getDate());
+  });
+
+  it.each(TIMEZONES)('reports a catch-up due today as zero days away in %s', async (tz) => {
+    setProcessTimezone(tz);
+    const lastContactDay = new Date();
+    lastContactDay.setDate(lastContactDay.getDate() - 30);
+    mocks.importantDateFindMany.mockResolvedValue([]);
+    mocks.personFindMany.mockResolvedValue([personLastContactedOn(lastContactDay)]);
+
+    const [event] = await getUpcomingEvents('user-1');
+
+    expect(event.daysUntil).toBe(0);
   });
 });


### PR DESCRIPTION
Follow-up to #402, now rebased onto master after that PR merged.

The UTC-anchoring fix in #402 covered the person page, the dashboard and the reminder send day. Review of that PR found the same raw-Date read pattern surviving in four more places, plus two adjacent bugs in the touched code. This PR closes out all of them.

## Same bug, remaining read sites

All of these read a stored UTC-midnight calendar date with local accessors, and all are now covered across the same five timezones as #402 (UTC, Madrid, London, New York, Sydney):

- **People list**: `lastContact` crosses the RSC boundary as a real `Date`, so the list showed the previous day west of UTC while the detail page showed the right one. The same person had two different last-contact dates depending on which screen you looked at.
- **Contact reminders, both consumers**: the dashboard computed the catch-up date from the raw stored instant (a day early west of UTC), and the cron compared raw milliseconds (a day late east of UTC). Both now anchor the calendar day first and do arithmetic in whole days, which also removes a latent DST wobble in the old millisecond math.
- **Duplicate detection**: birthdays were compared with local accessors. A year-unknown birthday sits in year 1604 where Local Mean Time applies, so in Madrid it read as August 9 while a known-year birthday on the same day read as August 10, and the month/day match silently failed. Now compared with UTC accessors.
- **Trash list**: deleted important dates went through `new Date(str)` plus local accessors, with the same day-shift and a strict `=== 1604` check on top.

## Adjacent bugs found in review

- **February 29 birthdays never reminded in non-leap years.** The cron matched month and day by equality, so in 2026 no day ever matches Feb 29, while the dashboard's `getNextOccurrence` rolls the anniversary to March 1. The cron now projects the date into the current year the same way, so both agree: March 1 in non-leap years, February 29 in leap years. Documented in the important-dates technical details.
- **The sentinel convention was hand-rolled in nine places with two different predicates.** The person page used `=== 1604` while everything else used `<= 1604`, so a legacy row stored under 1603 (possible via the old write path near a year boundary) rendered "12/31/1603" on the person page while the rest of the app treated it as year-unknown. `lib/date-format.ts` now exports `YEAR_UNKNOWN_SENTINEL`, `yearUnknownDate()` and `isYearUnknownDate()`, and every site uses them with the inclusive form.

## Test infrastructure

The timezone-pinning harness was copy-pasted across four test files, and every copy restored with `process.env.TZ = ORIGINAL_TZ`. When `TZ` was never set (typical CI), that assigns `undefined`, which Node coerces to the string `"undefined"` and silently falls back to UTC, the one timezone where this entire bug class is invisible. Any timezone-sensitive test added later in those files would have passed vacuously.

A shared `tests/helpers/timezone.ts` now owns the zone list, the stored-date fixture builders and a restore that deletes the variable when it was originally unset. All five copies (including the pre-existing one in the CardDAV tests) are refactored onto it.

## Verification

- Every behavior fix was implemented test-first: each new test was run and observed failing in the exact timezones the review predicted (people list and dashboard catch-up in New York, cron catch-up in Madrid/London/Sydney, duplicate signal in Madrid/London, Feb 29 in non-leap years) before the fix was applied.
- Full suite: 2775 passed, 1 skipped, 0 failed. `tsc --noEmit` clean, lint clean on all changed files, docs site builds.

No schema changes, no API changes, no new configuration.

