### PR TITLE
chore: restore the dropped 0.58.5 changelog entry and guard the parse

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,37 @@
+name: Commit Message
+
+# Kept out of pr-checks.yml on purpose: this needs to re-run when the pull
+# request description is edited, and adding "edited" to that workflow's triggers
+# would re-run lint, typecheck, tests and build on every wording tweak.
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-commit:
+    name: Conventional Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Check the squash commit message parses
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: npx tsx scripts/check-pr-commit-message.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * **carddav:** stop re-importing contacts when only the ETag moved ([#401](https://github.com/mattogodoy/nametag/issues/401)) ([84b9af9](https://github.com/mattogodoy/nametag/commit/84b9af9bb94d83032f281ee0be81f038686dfad9))
 * **dates:** finish the calendar-date sweep across every read site ([#404](https://github.com/mattogodoy/nametag/issues/404)) ([1dda0cd](https://github.com/mattogodoy/nametag/commit/1dda0cd3530fad5a06f07b3a0e81f5188f06cb70))
+* **dates:** keep year-unknown dates on the day they were saved ([#402](https://github.com/mattogodoy/nametag/issues/402)) ([15f92ee](https://github.com/mattogodoy/nametag/commit/15f92eefd20f799bcae2c8c77c1c0f4ae603fd2f))
 
 ## [0.58.4](https://github.com/mattogodoy/nametag/compare/v0.58.3...v0.58.4) (2026-08-07)
 

--- a/docs/src/content/docs/contributing/guidelines.md
+++ b/docs/src/content/docs/contributing/guidelines.md
@@ -160,7 +160,7 @@ ESLint and Prettier catch most formatting issues automatically.
 
 - Keep PRs focused on a single feature or fix.
 - Link related issues.
-- Add a clear description of what changed and why.
+- Add a clear description of what changed and why. It becomes the commit body on merge, so it has to parse as part of a conventional commit. Avoid nested parentheses like `foo(bar(baz))`, even inside backticks. See [Versioning & Releases](/contributing/versioning/#the-whole-message-has-to-parse-not-just-the-header).
 - Include screenshots for UI changes.
 - Make sure all checks pass (lint, typecheck, tests, build). These run automatically via GitHub Actions.
 - Run `npm run verify` locally before pushing to catch issues early.

--- a/docs/src/content/docs/contributing/versioning.md
+++ b/docs/src/content/docs/contributing/versioning.md
@@ -53,6 +53,27 @@ feat!: redesign authentication system
 BREAKING CHANGE: Users must re-authenticate after upgrade
 ```
 
+### The whole message has to parse, not just the header
+
+release-please runs the entire commit message through a strict grammar. On a squash merge that message is the pull request title with the number appended, followed by the pull request description, so the body counts too.
+
+If the parse fails, release-please skips the commit and still exits green. That commit then contributes nothing at all: no changelog entry, and no version bump either. Nothing turns red, the change simply goes missing from the release.
+
+The usual cause is **nested parentheses**, because the grammar uses them for the commit scope:
+
+```text
+fix(dates): keep year-unknown dates on the day they were saved
+
+Asserts formatDateWithoutYear(parseCalendarDate(stored)) across five zones.
+                                                ^ second "(" before the first closes
+```
+
+Backticks and code fences do not exempt it. Rewrite the nesting as two flat calls, for example `formatDateWithoutYear()` over `parseCalendarDate()`.
+
+Whether a given nesting actually trips the grammar depends on where in the line it sits, so a nested call mid-sentence sometimes slips through. Avoid it everywhere rather than trying to predict which ones are safe.
+
+The **Commit Message** workflow checks this on every pull request, using the same parser version release-please uses, and re-runs when the title or description is edited. `scripts/check-pr-commit-message.ts` prints the offending line and column.
+
 ## How releases work
 
 Nametag uses [release-please](https://github.com/googleapis/release-please) for automated, PR-based releases.
@@ -117,7 +138,7 @@ The current version is shown in:
 ## Best practices
 
 1. Write good commit messages. They become your changelog.
-2. Use conventional commits. This is what enables the automation.
+2. Use conventional commits, and keep the description parseable too. Avoid nested parentheses.
 3. Tag breaking changes explicitly, with `!` or `BREAKING CHANGE:`.
 4. Don't commit directly to `master`. Use PRs.
 5. Squash related commits, one feature per commit.

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "zod": "^4.1.13"
       },
       "devDependencies": {
+        "@conventional-commits/parser": "^0.4.1",
         "@playwright/test": "^1.57.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1131,6 +1132,66 @@
       "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
       "devOptional": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@conventional-commits/parser": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@conventional-commits/parser/-/parser-0.4.1.tgz",
+      "integrity": "sha512-H2ZmUVt6q+KBccXfMBhbBF14NlANeqHTXL4qCL6QGbMzrc4HDXyzWuxPxPNbz71f/5UkR5DrycP5VO9u7crahg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unist-util-visit": "^2.0.3",
+        "unist-util-visit-parents": "^3.1.1"
+      }
+    },
+    "node_modules/@conventional-commits/parser/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@conventional-commits/parser/node_modules/unist-util-is": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
+      "integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@conventional-commits/parser/node_modules/unist-util-visit": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz",
+      "integrity": "sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0",
+        "unist-util-visit-parents": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/@conventional-commits/parser/node_modules/unist-util-visit-parents": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-3.1.1.tgz",
+      "integrity": "sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "unist-util-is": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "zod": "^4.1.13"
   },
   "devDependencies": {
+    "@conventional-commits/parser": "^0.4.1",
     "@playwright/test": "^1.57.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",

--- a/scripts/check-pr-commit-message.ts
+++ b/scripts/check-pr-commit-message.ts
@@ -1,0 +1,56 @@
+/**
+ * Fails the build when a pull request's title and description would squash into
+ * a commit message release-please cannot parse. See scripts/conventional-commit.ts
+ * for why a bad parse is worth blocking a merge over.
+ *
+ * Reads PR_TITLE, PR_BODY and PR_NUMBER from the environment rather than argv so
+ * that nothing in the untrusted text is ever interpreted by the shell.
+ */
+import { buildSquashCommitMessage, findParseError } from './conventional-commit';
+
+const title = process.env.PR_TITLE;
+const prNumber = Number(process.env.PR_NUMBER);
+
+if (!title || !Number.isInteger(prNumber)) {
+  console.error('PR_TITLE and PR_NUMBER are required.');
+  process.exit(1);
+}
+
+const message = buildSquashCommitMessage(title, process.env.PR_BODY, prNumber);
+const error = findParseError(message);
+
+if (!error) {
+  console.log('Commit message parses as a conventional commit.');
+  process.exit(0);
+}
+
+const [line, column] = (error.match(/(\d+):(\d+)/)?.slice(1) ?? []).map(Number);
+const offendingLine = line ? message.split('\n')[line - 1] : undefined;
+
+console.error(`This pull request's commit message cannot be parsed.
+
+  ${error}
+`);
+
+if (offendingLine !== undefined) {
+  console.error(`Line ${line}:
+
+  ${offendingLine}
+  ${' '.repeat(Math.max(0, column - 1))}^
+`);
+}
+
+console.error(`release-please parses the whole commit message, which on a squash
+merge is this pull request's title plus its description. When the parse fails it
+skips the commit silently: no changelog entry, and no version bump. Nothing in
+the release turns red, the change just goes missing.
+
+The usual cause is nested parentheses, since the grammar uses them for the
+commit scope. Whether a given nesting trips it depends on where in the line it
+sits, so treat the position above as the answer and avoid nesting anywhere.
+Rewrite "foo(bar(baz))" as "foo() over bar()" or similar, in the description as
+well as the title. Backticks and code fences do not exempt it.
+
+Edit the title or the description and this check will re-run.`);
+
+process.exit(1);

--- a/scripts/conventional-commit.ts
+++ b/scripts/conventional-commit.ts
@@ -1,0 +1,53 @@
+/**
+ * Checks that a pull request would produce a commit message release-please can
+ * parse.
+ *
+ * release-please runs the whole commit message, not just the header, through the
+ * strict PEG grammar in `@conventional-commits/parser`. When that parse throws,
+ * release-please logs "commit could not be parsed" at debug level, skips the
+ * commit, and still exits green. The commit then contributes nothing: no
+ * changelog entry, and no version bump either.
+ *
+ * That is how #402 shipped in 0.58.5 with no changelog line. Its body contained
+ * `formatDateWithoutYear(parseCalendarDate(stored))`, and the grammar uses
+ * parentheses for the scope, so a second `(` opening before the first one closes
+ * is a parse error even 98 lines below the header, inside backticks, in prose.
+ *
+ * The parser version here must track the one release-please depends on, so that
+ * this check accepts and rejects exactly what release-please does.
+ */
+import { parser } from '@conventional-commits/parser';
+
+/**
+ * Recomposes the commit message that a squash merge will produce. GitHub uses
+ * the pull request title with the number appended, then the description as the
+ * body.
+ */
+export function buildSquashCommitMessage(
+  title: string,
+  body: string | null | undefined,
+  prNumber: number
+): string {
+  const header = `${title.trim()} (#${prNumber})`;
+  // The API returns CRLF, git stores LF.
+  const trimmedBody = (body ?? '').replace(/\r\n/g, '\n').trim();
+
+  return trimmedBody ? `${header}\n\n${trimmedBody}` : header;
+}
+
+/**
+ * Returns the parser's complaint, or null when the message parses cleanly.
+ */
+export function findParseError(message: string): string | null {
+  try {
+    parser(message);
+    return null;
+  } catch (error) {
+    if (error instanceof Error) {
+      // The parser's message carries a rendered snippet of the offending line
+      // after the first line. The first line has the position and is enough.
+      return error.message.split('\n')[0];
+    }
+    return String(error);
+  }
+}

--- a/tests/scripts/conventional-commit.test.ts
+++ b/tests/scripts/conventional-commit.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import {
+  buildSquashCommitMessage,
+  findParseError,
+} from '@/scripts/conventional-commit';
+
+/**
+ * These fixtures are the real commit messages of #402 and #404.
+ *
+ * #402 was silently dropped from the 0.58.5 changelog because release-please
+ * could not parse it, so it is the regression case this guard exists for. It is
+ * kept as a file rather than an inline string so nothing reformats it: the
+ * failure depends on the exact characters, and a helpful editor rewrapping a
+ * line would quietly turn this into a test that passes for the wrong reason.
+ */
+function fixture(name: string): string {
+  return readFileSync(
+    path.join(__dirname, 'fixtures', `${name}.commit.txt`),
+    'utf8'
+  );
+}
+
+describe('findParseError', () => {
+  it('rejects the #402 message that release-please dropped', () => {
+    const error = findParseError(fixture('402-dropped'));
+
+    expect(error).not.toBeNull();
+    // Same failure release-please logged in CI, to the line and column.
+    expect(error).toContain("unexpected token '('");
+    expect(error).toContain('98:41');
+  });
+
+  it('accepts the #404 message that release-please released', () => {
+    expect(findParseError(fixture('404-released'))).toBeNull();
+  });
+
+  it('rejects nested parentheses in the body', () => {
+    expect(
+      findParseError('fix(dates): subject\n\nfoo(bar(baz)) then done')
+    ).not.toBeNull();
+  });
+
+  it('accepts an ordinary message with flat parentheses', () => {
+    expect(
+      findParseError(
+        'fix(dates): subject\n\nAnchors the value with parseCalendarDate(stored).'
+      )
+    ).toBeNull();
+  });
+
+  it('accepts a breaking change footer', () => {
+    expect(
+      findParseError(
+        'feat!: redesign authentication\n\nBREAKING CHANGE: users must re-authenticate'
+      )
+    ).toBeNull();
+  });
+
+  it('rejects a title that is not a conventional commit', () => {
+    expect(findParseError('Update the readme')).not.toBeNull();
+  });
+});
+
+describe('buildSquashCommitMessage', () => {
+  it('appends the PR number to the title the way a squash merge does', () => {
+    expect(buildSquashCommitMessage('fix: a thing', 'The body.', 402)).toBe(
+      'fix: a thing (#402)\n\nThe body.'
+    );
+  });
+
+  it('handles an empty body', () => {
+    expect(buildSquashCommitMessage('fix: a thing', '', 7)).toBe(
+      'fix: a thing (#7)'
+    );
+    expect(buildSquashCommitMessage('fix: a thing', null, 7)).toBe(
+      'fix: a thing (#7)'
+    );
+  });
+
+  it('normalises the CRLF line endings the API returns', () => {
+    expect(
+      buildSquashCommitMessage('fix: a thing', 'One.\r\n\r\nTwo.\r\n', 7)
+    ).toBe('fix: a thing (#7)\n\nOne.\n\nTwo.');
+  });
+});

--- a/tests/scripts/fixtures/402-dropped.commit.txt
+++ b/tests/scripts/fixtures/402-dropped.commit.txt
@@ -1,0 +1,131 @@
+fix(dates): keep year-unknown dates on the day they were saved (#402)
+
+A birthday saved as **August 10** with "unknown year" checked displayed
+as **August 9**, while the edit form kept showing August 10. Re-saving
+changed nothing. Later the same day it started showing August 10 on its
+own.
+
+Nothing was ever wrong with the stored value.
+
+## What was happening
+
+Nametag stores calendar dates as UTC midnight. `parseAsLocalDate`
+anchors the calendar day when given a **string**, but passes **`Date`
+objects through untouched**, and the formatters then read them with
+`getDate()`, which reports the previous day anywhere west of UTC.
+
+Three server-side paths hand it raw Prisma values:
+
+- `app/people/[id]/page.tsx` (person detail)
+- `lib/upcoming-events.ts` (dashboard)
+- `app/api/cron/send-reminders/route.ts` (reminder scheduling)
+
+The edit form is a client component, so the same value arrives as a JSON
+string, takes the string branch, and reads correctly. One value, two
+readings, which is why the list and the form disagreed.
+
+## Why only year-unknown dates broke
+
+Year 1604 predates standard time zones, so JavaScript falls back to
+Local Mean Time:
+
+```
+Europe/Madrid   1604: -0:14:44   today: +2:00
+Europe/London   1604: -0:01:15   today: +1:00
+```
+
+Madrid and London are east of UTC today but west of it in 1604. So
+known-year birthdays render correctly and only the year-unknown ones
+slip back a day. London is caught by 75 seconds.
+
+## The fix
+
+Adds `parseCalendarDate` for values read from the database, and routes
+the three paths through it.
+
+`parseAsLocalDate` keeps its `Date` pass-through deliberately.
+Locally-built dates do flow into it (the settings date-format example,
+and `getNextOccurrence` results on the dashboard) and those are already
+on the right calendar day, so re-anchoring them from UTC would break
+them. Making the distinction explicit at the call site is what actually
+removes the footgun.
+
+### Reminders fired a day early
+
+Same root cause, worse consequence: `send-reminders` read the date the
+same way, so year-unknown birthday emails went out on the wrong day. Now
+covered across five timezones. Reverting just that line fails in Madrid,
+London and New York, and passes in UTC and Sydney, exactly as the Local
+Mean Time offsets predict.
+
+### Two write paths disagreed
+
+`mapImportantDate` rewrote the year with `setFullYear`, which operates
+in local time, so the person form stored a different instant than the
+important-dates API and the CardDAV importer did for the same calendar
+day:
+
+```
+important-dates route   new Date('1604-08-10')  -> 1604-08-10T00:00:00Z
+person form             setFullYear(1604)       -> 1604-08-10T02:14:44Z
+CardDAV import          Date.UTC(1604, 7, 10)   -> 1604-08-10T00:00:00Z
+```
+
+All three now agree on UTC midnight. This is also the likely reason the
+date appeared to correct itself: a save through the person-form path
+rewrote the instant to one that happened to display correctly.
+
+## Verification
+
+- New `tests/lib/calendar-date-timezone.test.ts` and
+`tests/lib/upcoming-events-timezone.test.ts`, both pinning the process
+timezone across UTC, Madrid, London, New York and Sydney. The bug is
+invisible under UTC, which is why the existing suite passed.
+- New timezone coverage for the reminder cron and for the year-unknown
+write path.
+- Every fix was reverted individually to confirm its tests fail without
+it.
+- The reminder cron fixtures were building local-midnight dates, which
+production never writes, so they were pinning the wrong storage
+convention. Corrected rather than worked around.
+- Full suite: 2704 passed, 1 skipped, 0 failed. `tsc --noEmit` clean,
+lint clean on changed files, docs site builds.
+
+## Note
+
+The person detail page itself has no direct test (it is a React server
+component), but the exact composition it uses,
+`formatDateWithoutYear(parseCalendarDate(stored))`, is asserted across
+all five timezones.
+
+## Post-review additions
+
+Two gaps surfaced in review, both now covered here:
+
+### The email body printed the wrong date
+
+The send-day fix made the reminder fire on the right day, but
+`formatDateForEmail` still read the raw stored value with local
+accessors, so the text of the email named the previous day in the same
+timezones, and year-unknown dates printed the 1604 sentinel year. It now
+goes through `parseCalendarDate`, and year-unknown dates render as month
+and day only, matching the UI. Covered across the same five timezones
+for both important dates and the last-contact date in contact reminders.
+
+### Backfill for rows written by the old setFullYear path
+
+The old write path stored instants offset from UTC midnight on servers
+whose 1604 Local Mean Time differs from their modern offset (Sydney
+wrote `1604-08-09T23:55:08Z` for August 10). Those legacy rows would
+regress under the new UTC read, permanently showing a day early until
+re-saved. A data-only migration rounds them to the nearest UTC midnight,
+which recovers the picked day since the write error is always well under
+twelve hours. Rows that round across the year boundary to 1605-01-01 are
+clamped back to 1604-01-01 to keep the sentinel. Correct rows sit
+exactly on UTC midnight and match nothing in the `WHERE` clause. The
+migration logic was validated row-by-row against fixtures reproducing
+Sydney, Paris, New York, Brisbane and Azores writes, plus untouched
+clean and known-year rows.
+
+No action needed from self-hosters: the migration runs automatically via
+`prisma migrate deploy` in the Docker entrypoint.

--- a/tests/scripts/fixtures/404-released.commit.txt
+++ b/tests/scripts/fixtures/404-released.commit.txt
@@ -1,0 +1,76 @@
+fix(dates): finish the calendar-date sweep across every read site (#404)
+
+Follow-up to #402, now rebased onto master after that PR merged.
+
+The UTC-anchoring fix in #402 covered the person page, the dashboard and
+the reminder send day. Review of that PR found the same raw-Date read
+pattern surviving in four more places, plus two adjacent bugs in the
+touched code. This PR closes out all of them.
+
+## Same bug, remaining read sites
+
+All of these read a stored UTC-midnight calendar date with local
+accessors, and all are now covered across the same five timezones as
+#402 (UTC, Madrid, London, New York, Sydney):
+
+- **People list**: `lastContact` crosses the RSC boundary as a real
+`Date`, so the list showed the previous day west of UTC while the detail
+page showed the right one. The same person had two different
+last-contact dates depending on which screen you looked at.
+- **Contact reminders, both consumers**: the dashboard computed the
+catch-up date from the raw stored instant (a day early west of UTC), and
+the cron compared raw milliseconds (a day late east of UTC). Both now
+anchor the calendar day first and do arithmetic in whole days, which
+also removes a latent DST wobble in the old millisecond math.
+- **Duplicate detection**: birthdays were compared with local accessors.
+A year-unknown birthday sits in year 1604 where Local Mean Time applies,
+so in Madrid it read as August 9 while a known-year birthday on the same
+day read as August 10, and the month/day match silently failed. Now
+compared with UTC accessors.
+- **Trash list**: deleted important dates went through `new Date(str)`
+plus local accessors, with the same day-shift and a strict `=== 1604`
+check on top.
+
+## Adjacent bugs found in review
+
+- **February 29 birthdays never reminded in non-leap years.** The cron
+matched month and day by equality, so in 2026 no day ever matches Feb
+29, while the dashboard's `getNextOccurrence` rolls the anniversary to
+March 1. The cron now projects the date into the current year the same
+way, so both agree: March 1 in non-leap years, February 29 in leap
+years. Documented in the important-dates technical details.
+- **The sentinel convention was hand-rolled in nine places with two
+different predicates.** The person page used `=== 1604` while everything
+else used `<= 1604`, so a legacy row stored under 1603 (possible via the
+old write path near a year boundary) rendered "12/31/1603" on the person
+page while the rest of the app treated it as year-unknown.
+`lib/date-format.ts` now exports `YEAR_UNKNOWN_SENTINEL`,
+`yearUnknownDate()` and `isYearUnknownDate()`, and every site uses them
+with the inclusive form.
+
+## Test infrastructure
+
+The timezone-pinning harness was copy-pasted across four test files, and
+every copy restored with `process.env.TZ = ORIGINAL_TZ`. When `TZ` was
+never set (typical CI), that assigns `undefined`, which Node coerces to
+the string `"undefined"` and silently falls back to UTC, the one
+timezone where this entire bug class is invisible. Any
+timezone-sensitive test added later in those files would have passed
+vacuously.
+
+A shared `tests/helpers/timezone.ts` now owns the zone list, the
+stored-date fixture builders and a restore that deletes the variable
+when it was originally unset. All five copies (including the
+pre-existing one in the CardDAV tests) are refactored onto it.
+
+## Verification
+
+- Every behavior fix was implemented test-first: each new test was run
+and observed failing in the exact timezones the review predicted (people
+list and dashboard catch-up in New York, cron catch-up in
+Madrid/London/Sydney, duplicate signal in Madrid/London, Feb 29 in
+non-leap years) before the fix was applied.
+- Full suite: 2775 passed, 1 skipped, 0 failed. `tsc --noEmit` clean,
+lint clean on all changed files, docs site builds.
+
+No schema changes, no API changes, no new configuration.


### PR DESCRIPTION
Release 0.58.5 shipped with two changelog entries for three commits. #402 was
missing from `CHANGELOG.md` and from the release PR body, even though it was on
master and tagged into the release.

## Why it went missing

release-please could not parse the commit message, so it skipped the commit. From
the workflow log of the run that built the release PR:

```
✔ Splitting 3 commits by path
❯ commit could not be parsed: 15f92eef... fix(dates): keep year-unknown dates on the day they were saved (#402)
❯ commits: 2
✔ Considering: 2 commits
```

release-please parses the whole commit message, not just the header, with the
strict PEG grammar in `@conventional-commits/parser`. When that throws it logs
`commit could not be parsed` at debug level, drops the commit, and exits green.
The commit contributes nothing after that: no changelog entry, and no version
bump either. Here that cost only a changelog line, since #401 and #404 were both
`fix`. A dropped `feat!` would silently cost a major bump.

The trigger was one line, 98 lines into the body of #402, quoted here with square
brackets standing in for the parentheses so that this description stays parseable
itself:

```
`formatDateWithoutYear[parseCalendarDate[stored]]`, is asserted across
```

The grammar uses parentheses for the commit scope, so a second `(` opening before
the first one closes is a parse error, 98 lines below the header, inside
backticks, in prose. Patching only that line makes the same message parse. The
body of #404 has no nesting, which is why it survived.

Worth noting the GitHub release description does describe the date fix, because
the AI summary step reads merged pull requests rather than parsed commits. Only
`CHANGELOG.md` and the release PR body lost it.

## What this changes

**Restores the entry.** Added to the `0.58.5` section, in the position
release-please would have generated it. Sections for released versions are never
rewritten, so this is stable.

**Blocks the next one.** A new `Commit Message` workflow reconstructs the commit
message a squash merge would produce, title plus number plus description, and
runs it through the same parser version release-please depends on, `^0.4.1`. The
check lives in its own workflow rather than in `pr-checks.yml` because it needs
the `edited` trigger to re-run when a description changes, and adding that to
`pr-checks.yml` would re-run lint, typecheck, tests and build on every wording
tweak.

On failure it prints the parser error, the offending line and a caret under the
column, plus what to do about it. Run against the real content of #402:

```
This pull request's commit message cannot be parsed.

  unexpected token '(' at 98:41, valid tokens [)]

Line 98:

  `formatDateWithoutYear[parseCalendarDate[stored]]`, is asserted across
                                          ^
```

(brackets again standing in for the real parentheses)

The title and body arrive as environment variables, never interpolated into a
shell command.

## Verification

- The parse failure was reproduced locally against the real commit message,
  matching the CI error string to the line and column, before anything was
  written.
- Tests came first, and the fixtures are the real commit messages of #402 and
  #404, kept as files so no editor rewraps them into passing for the wrong
  reason. Mutating the guard to never report an error fails 3 of the 9 tests,
  confirmed by running it.
- The CLI was exercised against the real content of both pull requests: exit 1
  with the caret above, exit 0 for #404.
- Full suite: 2784 passed, 1 skipped, 0 failed. `tsc --noEmit` clean, lint clean,
  docs site builds.

No app code, no schema changes, no API changes, no new configuration. Nothing for
self-hosters to do.
