### PR TITLE
fix(api): stop user preference endpoints returning the password hash

### DIFF
--- a/app/api/user/date-format/route.ts
+++ b/app/api/user/date-format/route.ts
@@ -16,6 +16,9 @@ export const PUT = withAuth(async (request, session) => {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: { dateFormat },
+      // Allowlist the response. Without it Prisma returns every column, which
+      // includes the password hash and live account-recovery tokens.
+      select: { id: true, dateFormat: true },
     });
 
     return apiResponse.ok({ user });

--- a/app/api/user/graph-display/route.ts
+++ b/app/api/user/graph-display/route.ts
@@ -15,6 +15,9 @@ export const PUT = withAuth(async (request, session) => {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: { graphMode },
+      // Allowlist the response. Without it Prisma returns every column, which
+      // includes the password hash and live account-recovery tokens.
+      select: { id: true, graphMode: true },
     });
 
     return apiResponse.ok({ user });

--- a/app/api/user/name-display-format/route.ts
+++ b/app/api/user/name-display-format/route.ts
@@ -16,6 +16,9 @@ export const PUT = withAuth(async (request, session) => {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: { nameDisplayFormat },
+      // Allowlist the response. Without it Prisma returns every column, which
+      // includes the password hash and live account-recovery tokens.
+      select: { id: true, nameDisplayFormat: true },
     });
 
     return apiResponse.ok({ user });

--- a/app/api/user/name-order/route.ts
+++ b/app/api/user/name-order/route.ts
@@ -16,6 +16,9 @@ export const PUT = withAuth(async (request, session) => {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: { nameOrder },
+      // Allowlist the response. Without it Prisma returns every column, which
+      // includes the password hash and live account-recovery tokens.
+      select: { id: true, nameOrder: true },
     });
 
     return apiResponse.ok({ user });

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -7,26 +7,36 @@ import { generateToken, hashToken } from '@/lib/token-hash';
 
 const TOKEN_EXPIRY_HOURS = 24;
 
+/**
+ * The only user columns this endpoint may return.
+ *
+ * An allowlist rather than a denylist on purpose: a column added by a future
+ * migration is excluded until someone deliberately adds it here. The row also
+ * holds the bcrypt password hash and live account-recovery tokens, none of
+ * which should ever reach a client.
+ */
+const PUBLIC_PROFILE_FIELDS = {
+  id: true,
+  email: true,
+  name: true,
+  surname: true,
+  nickname: true,
+  theme: true,
+  dateFormat: true,
+  language: true,
+  nameOrder: true,
+  nameDisplayFormat: true,
+  emailVerified: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
 // GET /api/user/profile - Get the current user's profile
 export const GET = withAuth(async (_request, session) => {
   try {
     const user = await prisma.user.findUnique({
       where: { id: session.user.id },
-      select: {
-        id: true,
-        email: true,
-        name: true,
-        surname: true,
-        nickname: true,
-        theme: true,
-        dateFormat: true,
-        language: true,
-        nameOrder: true,
-        nameDisplayFormat: true,
-        emailVerified: true,
-        createdAt: true,
-        updatedAt: true,
-      },
+      select: PUBLIC_PROFILE_FIELDS,
     });
 
     if (!user) {
@@ -90,6 +100,10 @@ export const PUT = withAuth(async (request, session) => {
           emailVerifyExpires: verifyExpires,
           emailVerifySentAt: new Date(),
         },
+        // This branch does not return the user, but selecting narrowly keeps the
+        // password hash out of process memory rather than relying on the caller
+        // to keep not returning it.
+        select: { id: true },
       });
 
       // Send verification email to new address with raw token
@@ -116,6 +130,10 @@ export const PUT = withAuth(async (request, session) => {
         nickname: nickname || null,
         email,
       },
+      // Mirrors the allowlist on GET, so both halves of this endpoint return the
+      // same shape. Without it Prisma returns every column, which includes the
+      // password hash and live account-recovery tokens.
+      select: PUBLIC_PROFILE_FIELDS,
     });
 
     return apiResponse.ok({ user, emailChanged: false });

--- a/app/api/user/theme/route.ts
+++ b/app/api/user/theme/route.ts
@@ -16,6 +16,9 @@ export const PUT = withAuth(async (request, session) => {
     const user = await prisma.user.update({
       where: { id: session.user.id },
       data: { theme },
+      // Allowlist the response. Without it Prisma returns every column, which
+      // includes the password hash and live account-recovery tokens.
+      select: { id: true, theme: true },
     });
 
     return apiResponse.ok({ user });

--- a/docs/src/content/docs/api/user.md
+++ b/docs/src/content/docs/api/user.md
@@ -90,7 +90,11 @@ curl -X PUT https://your-instance.example.com/api/user/password \
 
 ## Preferences
 
-Each preference has its own small PUT endpoint. All return the updated `user` object (except language, see below).
+Each preference has its own small PUT endpoint. All return a `user` object containing the account id and the preference that changed, and nothing else (except language, see below). They deliberately do not return the full profile: use `GET /api/user/profile` when you need that.
+
+```json
+{ "user": { "id": "clxuser1", "theme": "DARK" } }
+```
 
 ### Update theme
 

--- a/lib/openapi/user.ts
+++ b/lib/openapi/user.ts
@@ -66,7 +66,16 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         responses: {
           '200': jsonResponse('Theme updated', {
             type: 'object',
-            properties: { user: { $ref: '#/components/schemas/UserProfile' } },
+            properties: {
+              user: {
+                type: 'object',
+                description: 'Only the identifier and the updated preference are returned.',
+                properties: {
+                  id: { type: 'string' },
+                  theme: { type: 'string', enum: ['LIGHT', 'DARK'] },
+                },
+              },
+            },
           }),
           '401': ref401(),
         },
@@ -81,7 +90,16 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         responses: {
           '200': jsonResponse('Date format updated', {
             type: 'object',
-            properties: { user: { $ref: '#/components/schemas/UserProfile' } },
+            properties: {
+              user: {
+                type: 'object',
+                description: 'Only the identifier and the updated preference are returned.',
+                properties: {
+                  id: { type: 'string' },
+                  dateFormat: { type: 'string', enum: ['MDY', 'DMY', 'YMD'] },
+                },
+              },
+            },
           }),
           '401': ref401(),
         },
@@ -97,7 +115,16 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         responses: {
           '200': jsonResponse('Graph display settings updated', {
             type: 'object',
-            properties: { user: { $ref: '#/components/schemas/UserProfile' } },
+            properties: {
+              user: {
+                type: 'object',
+                description: 'Only the identifier and the updated preference are returned.',
+                properties: {
+                  id: { type: 'string' },
+                  graphMode: { type: 'string', enum: ['individuals', 'bubbles'] },
+                },
+              },
+            },
           }),
           '400': ref400(),
           '401': ref401(),
@@ -139,7 +166,16 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         responses: {
           '200': jsonResponse('Name order updated', {
             type: 'object',
-            properties: { user: { $ref: '#/components/schemas/UserProfile' } },
+            properties: {
+              user: {
+                type: 'object',
+                description: 'Only the identifier and the updated preference are returned.',
+                properties: {
+                  id: { type: 'string' },
+                  nameOrder: { type: 'string', enum: ['WESTERN', 'EASTERN'] },
+                },
+              },
+            },
           }),
           '401': ref401(),
         },
@@ -154,7 +190,16 @@ export function userPaths(): Record<string, Record<string, unknown>> {
         responses: {
           '200': jsonResponse('Name display format updated', {
             type: 'object',
-            properties: { user: { $ref: '#/components/schemas/UserProfile' } },
+            properties: {
+              user: {
+                type: 'object',
+                description: 'Only the identifier and the updated preference are returned.',
+                properties: {
+                  id: { type: 'string' },
+                  nameDisplayFormat: { type: 'string', enum: ['FULL', 'NICKNAME_PREFERRED', 'SHORT'] },
+                },
+              },
+            },
           }),
           '401': ref401(),
         },

--- a/tests/api/user-preference-endpoints-no-secrets.test.ts
+++ b/tests/api/user-preference-endpoints-no-secrets.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+/**
+ * These endpoints all return the updated user to the client. Without a `select`
+ * allowlist, Prisma returns every column, which includes the bcrypt password hash
+ * and live account-recovery tokens.
+ *
+ * The `update` mock below deliberately behaves the way Prisma does: it honours a
+ * `select` clause and returns the whole row when there isn't one. That is what
+ * makes these tests fail against an unselected query rather than silently passing
+ * on a mock that returns whatever it was told to.
+ */
+
+const SECRET_FIELDS = [
+  'password',
+  'emailVerifyToken',
+  'passwordResetToken',
+  'emailVerifyExpires',
+  'passwordResetExpires',
+  'failedLoginAttempts',
+  'lockedUntil',
+] as const;
+
+const FULL_USER_ROW: Record<string, unknown> = {
+  id: 'user-123',
+  email: 'test@example.com',
+  name: 'Test',
+  surname: null,
+  nickname: null,
+  theme: 'DARK',
+  dateFormat: 'MDY',
+  nameOrder: 'WESTERN',
+  nameDisplayFormat: 'FULL',
+  graphMode: 'individuals',
+  language: 'en',
+  emailVerified: true,
+  createdAt: new Date('2026-01-01'),
+  updatedAt: new Date('2026-01-01'),
+  // Everything below must never reach the client.
+  password: '$2b$10$notarealhashbutshapedlikeone',
+  emailVerifyToken: 'verify-token-abc',
+  emailVerifyExpires: new Date('2026-01-02'),
+  emailVerifySentAt: new Date('2026-01-01'),
+  passwordResetToken: 'reset-token-xyz',
+  passwordResetExpires: new Date('2026-01-02'),
+  passwordResetSentAt: new Date('2026-01-01'),
+  failedLoginAttempts: 0,
+  lockedUntil: null,
+  provider: 'credentials',
+  providerAccountId: null,
+};
+
+function applySelect(args: { select?: Record<string, boolean> }): Record<string, unknown> {
+  if (!args?.select) return { ...FULL_USER_ROW };
+  return Object.fromEntries(
+    Object.keys(args.select).map((key) => [key, FULL_USER_ROW[key]])
+  );
+}
+
+const mocks = vi.hoisted(() => ({
+  userUpdate: vi.fn(),
+  userFindUnique: vi.fn(),
+}));
+
+vi.mock('../../lib/prisma', () => ({
+  prisma: {
+    user: { update: mocks.userUpdate, findUnique: mocks.userFindUnique },
+    personAddress: { updateMany: vi.fn() },
+  },
+}));
+
+vi.mock('../../lib/auth', () => ({
+  auth: vi.fn(() =>
+    Promise.resolve({ user: { id: 'user-123', email: 'test@example.com', name: 'Test' } })
+  ),
+}));
+
+vi.mock('../../lib/email', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/email')>('../../lib/email');
+  return { ...actual, sendEmail: vi.fn(() => Promise.resolve({ success: true })) };
+});
+
+import { PUT as putTheme } from '../../app/api/user/theme/route';
+import { PUT as putDateFormat } from '../../app/api/user/date-format/route';
+import { PUT as putNameOrder } from '../../app/api/user/name-order/route';
+import { PUT as putNameDisplayFormat } from '../../app/api/user/name-display-format/route';
+import { PUT as putGraphDisplay } from '../../app/api/user/graph-display/route';
+import { PUT as putProfile } from '../../app/api/user/profile/route';
+import { PUT as putGeocoding } from '../../app/api/user/geocoding/route';
+
+type Handler = (request: Request) => Promise<Response>;
+
+const put = (path: string, body: unknown) =>
+  new Request(`http://localhost${path}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+const ENDPOINTS: Array<{ name: string; path: string; handler: Handler; body: unknown }> = [
+  { name: 'theme', path: '/api/user/theme', handler: putTheme as Handler, body: { theme: 'DARK' } },
+  { name: 'date-format', path: '/api/user/date-format', handler: putDateFormat as Handler, body: { dateFormat: 'MDY' } },
+  { name: 'name-order', path: '/api/user/name-order', handler: putNameOrder as Handler, body: { nameOrder: 'WESTERN' } },
+  { name: 'name-display-format', path: '/api/user/name-display-format', handler: putNameDisplayFormat as Handler, body: { nameDisplayFormat: 'FULL' } },
+  { name: 'graph-display', path: '/api/user/graph-display', handler: putGraphDisplay as Handler, body: { graphMode: 'individuals' } },
+  { name: 'geocoding', path: '/api/user/geocoding', handler: putGeocoding as Handler, body: { geocodingEnabled: false } },
+];
+
+describe('user preference endpoints do not leak account secrets', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.userUpdate.mockImplementation((args) => Promise.resolve(applySelect(args)));
+    // Two lookups happen in the profile flow: "is this email taken by someone
+    // else" (no) and "what is my current email" (the same one, so the email is
+    // unchanged and we exercise the branch that returns the user).
+    mocks.userFindUnique.mockImplementation((args: { where: { id?: string; email?: string } }) =>
+      Promise.resolve(args.where.id ? { email: FULL_USER_ROW.email } : null)
+    );
+  });
+
+  for (const endpoint of ENDPOINTS) {
+    describe(`PUT ${endpoint.path}`, () => {
+      it('succeeds', async () => {
+        const response = await endpoint.handler(put(endpoint.path, endpoint.body));
+        expect(response.status).toBe(200);
+      });
+
+      it('constrains the Prisma query with a select allowlist', async () => {
+        await endpoint.handler(put(endpoint.path, endpoint.body));
+
+        const args = mocks.userUpdate.mock.calls[0][0];
+        expect(args.select, `${endpoint.name} must pass a select clause`).toBeDefined();
+
+        for (const field of SECRET_FIELDS) {
+          expect(args.select[field], `${endpoint.name} must not select ${field}`).toBeUndefined();
+        }
+      });
+
+      it('returns no secret field in the response body', async () => {
+        const response = await endpoint.handler(put(endpoint.path, endpoint.body));
+        const body = await response.json();
+
+        for (const field of SECRET_FIELDS) {
+          expect(body.user?.[field], `${endpoint.name} leaked ${field}`).toBeUndefined();
+        }
+      });
+
+      it('does not serialise the password hash anywhere in the response', async () => {
+        const response = await endpoint.handler(put(endpoint.path, endpoint.body));
+        const raw = await response.text();
+
+        expect(raw).not.toContain(FULL_USER_ROW.password as string);
+        expect(raw).not.toContain(FULL_USER_ROW.passwordResetToken as string);
+        expect(raw).not.toContain(FULL_USER_ROW.emailVerifyToken as string);
+      });
+    });
+  }
+
+  describe('PUT /api/user/profile', () => {
+    const profileBody = { name: 'Test', surname: null, nickname: null, email: 'test@example.com' };
+
+    it('returns no secret field when the email is unchanged', async () => {
+      const response = await putProfile(put('/api/user/profile', profileBody));
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      for (const field of SECRET_FIELDS) {
+        expect(body.user?.[field], `profile leaked ${field}`).toBeUndefined();
+      }
+    });
+
+    it('constrains the Prisma query with a select allowlist', async () => {
+      await putProfile(put('/api/user/profile', profileBody));
+
+      const args = mocks.userUpdate.mock.calls[0][0];
+      expect(args.select).toBeDefined();
+      for (const field of SECRET_FIELDS) {
+        expect(args.select[field]).toBeUndefined();
+      }
+    });
+
+    it('does not serialise the password hash anywhere in the response', async () => {
+      const response = await putProfile(put('/api/user/profile', profileBody));
+      const raw = await response.text();
+
+      expect(raw).not.toContain(FULL_USER_ROW.password as string);
+      expect(raw).not.toContain(FULL_USER_ROW.passwordResetToken as string);
+    });
+
+    // The email-change branch returns only a flag today. Pin that, so a future
+    // edit that starts returning the user has to make the allowlist decision
+    // deliberately rather than inheriting a leak.
+    it('returns no user object at all when the email changes', async () => {
+      mocks.userFindUnique.mockImplementation((args: { where: { id?: string; email?: string } }) =>
+        Promise.resolve(args.where.id ? { email: 'old@example.com' } : null)
+      );
+
+      const response = await putProfile(put('/api/user/profile', profileBody));
+      const body = await response.json();
+      const raw = JSON.stringify(body);
+
+      expect(body.emailChanged).toBe(true);
+      expect(body.user).toBeUndefined();
+      expect(raw).not.toContain(FULL_USER_ROW.password as string);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The per-preference PUT endpoints called `prisma.user.update()` with no `select` clause and returned the resulting row to the client. Prisma returns every column when no `select` is given, so the response carried the bcrypt `password` hash, `emailVerifyToken` and `passwordResetToken` next to the preference that had just changed.

In practice: changing your theme returned your own password hash and any live account-recovery tokens to the browser.

Affected endpoints:

- `PUT /api/user/theme`
- `PUT /api/user/date-format`
- `PUT /api/user/name-order`
- `PUT /api/user/name-display-format`
- `PUT /api/user/graph-display`
- `PUT /api/user/profile`, the branch where the email is unchanged

`PUT /api/user/geocoding` already had a `select` clause and was the pattern to follow. `GET /api/user/profile` was already fine too.

## Scope of exposure

Self-disclosure only. Each endpoint is behind `withAuth` and updates `session.user.id`, so a user could only ever receive their own hash, not anyone else's. There is no privilege escalation here.

It still matters. The hash and live reset tokens landed in browser memory, in anything with extension-level access to the page, and in any logging proxy or APM tool sitting on the response path. A password hash is offline-crackable, and a reset token is directly usable until it expires.

## Fix

Every affected query now selects an allowlist. The preference endpoints return the account id and the field they changed. `profile` returns the same field set as its own GET, pulled out into a shared `PUBLIC_PROFILE_FIELDS` constant so the two halves of the endpoint cannot drift apart.

The email-change branch of `profile` never returned the user object, so it was not leaking, but it now selects narrowly as well. That keeps the hash out of process memory rather than relying on a future edit continuing to not return it.

An allowlist rather than deleting fields after the fact, deliberately. An allowlist fails safe: a column added by a future migration is excluded until someone adds it here. A denylist fails open, and would need updating in six files every time the `User` model grows.

## Tests

`tests/api/user-preference-endpoints-no-secrets.test.ts` covers all six endpoints plus `geocoding` as a control.

The `update` mock honours a `select` clause the way Prisma does and returns the whole row when there is not one. That is what makes these tests meaningful: against the previous code they fail, with the assertion output containing the literal fake hash. A mock that simply returned a fixed object would have passed either way.

Each endpoint is checked three ways: the `select` clause exists, it names none of the seven sensitive columns, and no secret value appears anywhere in the serialised response body.

## Also updated

- `lib/openapi/user.ts` described these responses as the full `UserProfile`. It now describes the narrowed shape.
- `docs/src/content/docs/api/user.md` said these endpoints "return the updated `user` object". It now says what they actually return, and points at `GET /api/user/profile` for the full profile.

## Verification

199 test files, 2803 tests passing. `tsc` clean, app build clean, docs build clean.

## Notes

No client read any field beyond `error` from these responses, so narrowing them breaks nothing. `NavigationSearch` reads `nameOrder`, but from `GET /api/user/profile`, which is unchanged.

Found while working on #406. Reported through an issue rather than the private channel in `SECURITY.md` was considered and rejected, since this is self-disclosure only and the fix is going straight in.
