### PR TITLE
docs(api): fix the OpenAPI spec link and the hosted base URL

### DIFF
--- a/docs/src/content/docs/api/overview.md
+++ b/docs/src/content/docs/api/overview.md
@@ -15,7 +15,7 @@ All paths in this reference are relative to your Nametag instance:
 https://your-instance.example.com
 ```
 
-If you're using the hosted service, that's `https://nametag.one`. If you're self-hosting, it's whatever domain you've configured.
+If you're using the hosted service, that's `https://app.nametag.one`. Note that `nametag.one` itself is the marketing site and doesn't serve the API. If you're self-hosting, it's whatever domain you've configured.
 
 ## Authentication
 
@@ -40,7 +40,7 @@ API tokens work on nearly every endpoint that accepts a session cookie. A few re
 - `/api/billing/*`, so subscription and payment changes stay tied to an interactive session
 - `/api/carddav/connection`, `/api/carddav/connection/test`, and `/api/carddav/backup`, which read or replace stored CardDAV credentials, and where the last two dial whatever host the caller supplies
 
-Requests to those with a bearer token return `401`. Each endpoint's accepted schemes are listed in the [OpenAPI spec](/api/openapi.json), and see [API Tokens](/api/tokens/) for scopes, expiry, and full examples.
+Requests to those with a bearer token return `401`. Each endpoint's accepted schemes are listed in the [OpenAPI spec](#interactive-docs), and see [API Tokens](/api/tokens/) for scopes, expiry, and full examples.
 
 ## Response format
 


### PR DESCRIPTION
## Summary

Fixes two broken references in the API overview.

**1. The OpenAPI spec link 404s (the reported issue)**

`overview.md` linked the spec as `[OpenAPI spec](/api/openapi.json)`. That path is root-relative to the *docs site*, so it resolved to `docs.nametag.one/api/openapi.json` and 404'd. As Markdown on GitHub it was equally broken.

The underlying mistake is an origin mix-up: `/api/` means two different things in these docs.

| Base | What `/api/...` means | Example |
| --- | --- | --- |
| Docs site | A Starlight page | `/api/tokens/` |
| The reader's instance | A real HTTP endpoint | `/api/openapi.json` |

Line 43 wrote an instance-relative path using docs-site link syntax. It's the only one of the 11 `/api/*` links in the docs that isn't a real page.

I went with linking to the **Interactive docs** section rather than hardcoding an absolute URL. That section already documents `/api/openapi.json` correctly, as a path relative to the reader's own instance. Hardcoding `https://app.nametag.one/api/openapi.json` would send self-hosters to the hosted instance's spec, and since the spec is version-stamped from `package.json` (`generateOpenAPISpec()`), someone on an older release would be reading endpoints their build doesn't have. Vendoring a copy into `docs/public/` has the same drift problem. The anchor keeps the docs portable and works on GitHub too.

**2. The hosted base URL is wrong**

While confirming the right host, the Base URL section turned out to be incorrect as well. It told hosted users their base URL is `https://nametag.one`, but that's the marketing site, and it serves the landing page for *every* path:

```
https://nametag.one/api/openapi.json      200  text/html          <- landing page
https://app.nametag.one/api/openapi.json  200  application/json   <- the actual spec
```

`nametag.one/api/people`, `/login`, and `/this-path-does-not-exist-xyz` all return HTTP 200 with `<title>Nametag - Your Personal Relationships Manager</title>`, so it soft-404s instead of failing loudly. The app is on `app.nametag.one` (`/` there 307s to `/login`, `/api/people` correctly 401s as JSON), which is also where the marketing site's own Sign In and Start for Free buttons point.

This one silently misleads every hosted user following the API guide, so it seemed worth fixing in the same PR, five lines above the reported line.

## Verification

- `yarn astro build` in `docs/` passes, 49 pages built
- Built HTML contains `<a href="#interactive-docs">OpenAPI spec</a>` and a matching `id="interactive-docs"`
- No remaining `href` to `openapi.json` anywhere in the output
- Checked the other 10 `/api/*` links: all resolve to real Starlight pages
- Checked the other `nametag.one` mentions across the docs: all refer to the brand or marketing site and are correct as-is

## Note for maintainers

Nothing would have caught this. `.github/workflows/docs.yml` only runs `astro build`, and `pr-checks.yml` filters `docs/` out entirely, so docs links get no validation at all.

[`starlight-links-validator`](https://www.npmjs.com/package/starlight-links-validator) would fail the build on exactly this class of bug: `/api/openapi.json` matches no page and no file in `docs/public/`. Happy to send that as a follow-up PR if you want it, keeping this one reviewable on its own.

## Checklist

- [x] I've run tests locally (or explain why not) - docs-only change, verified with `astro build`
- [x] I've updated documentation where needed - this *is* the documentation change
- [ ] I've added/updated tests for the change (if applicable) - n/a, prose fix
- [x] I've considered backwards compatibility / migrations (if applicable) - n/a
- [x] I've added/updated translations in ALL locale files - n/a, the docs site isn't localized

## Related issues

Closes #416
