### PR TITLE
fix(people): redirect to newly created person when known-through is not You

### DIFF
--- a/components/person-form/PersonForm.tsx
+++ b/components/person-form/PersonForm.tsx
@@ -469,10 +469,6 @@ export default function PersonForm({
         window.location.href = queryString
           ? `/people/new?${queryString}`
           : '/people/new';
-      } else if (mode === 'create' && knownThroughId !== 'user') {
-        router.push(`/people/${knownThroughId}`);
-        router.refresh();
-        refreshIndex();
       } else if (mode === 'create' && data.person?.id) {
         router.push(`/people/${data.person.id}`);
         router.refresh();


### PR DESCRIPTION
## Summary

- When creating a person with a "Known through" subject other than "You", the post-creation redirect went to the known-through person's page instead of the newly created person's page
- Removed the special-case redirect branch; the existing `data.person.id` branch already handles all create cases correctly

Fixes #418

## Test plan

- [ ] Create a new person with "Known through" set to "You" - should redirect to the new person's page
- [ ] Create a new person with "Known through" set to another person (Person B) - should redirect to the new person's page (not Person B)
- [ ] Create a new person with "Add another" checked - should redirect to the new person form
- [ ] Edit an existing person - should redirect back to that person's page