### PR TITLE
fix(reminders): unify next-occurrence logic between dashboard and day-of email

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -162,28 +162,6 @@ export const GET = withLogging(async function GET(request: Request) {
                 importantDate.lastReminderSent
               );
 
-        // Guard against promising an email the day-of path will never send.
-        // getNextOccurrence() and shouldSendImportantDateReminder() answer
-        // "when does this recur" independently and can disagree (multi-year
-        // intervals, a recurring date stored in the future, Feb 29 rolling to
-        // Mar 1 in a non-leap year). Simulating the day-of predicate with
-        // `today` set to the computed occurrence tells us whether the day-of
-        // email would actually fire then. Real `lastReminderSent` is passed
-        // through unchanged: that is the reminder history the day-of path
-        // would see when it eventually reaches that date.
-        const dayOfWouldFireOnOccurrence = shouldSendImportantDateReminder(
-          {
-            date: importantDate.date,
-            reminderType: importantDate.reminderType,
-            reminderInterval: importantDate.reminderInterval,
-            reminderIntervalUnit: importantDate.reminderIntervalUnit,
-            lastReminderSent: importantDate.lastReminderSent,
-          },
-          nextOccurrence
-        );
-
-        // Only RECURRING dates can have overlapping lead windows, so ONCE
-        // passes no interval and keeps the full requested notice.
         const intervalDays =
           importantDate.reminderType === 'RECURRING'
             ? getIntervalDays(
@@ -192,15 +170,13 @@ export const GET = withLogging(async function GET(request: Request) {
               )
             : null;
 
-        const leadDue =
-          dayOfWouldFireOnOccurrence &&
-          shouldSendLeadReminder({
-            nextOccurrence,
-            today,
-            leadDays,
-            lastLeadReminderSent: importantDate.lastLeadReminderSent,
-            intervalDays,
-          });
+        const leadDue = shouldSendLeadReminder({
+          nextOccurrence,
+          today,
+          leadDays,
+          lastLeadReminderSent: importantDate.lastLeadReminderSent,
+          intervalDays,
+        });
 
         if (leadDue) {
           const { person } = importantDate;

--- a/lib/reminders/due-dates.ts
+++ b/lib/reminders/due-dates.ts
@@ -1,4 +1,7 @@
-import { parseCalendarDate, YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
+import { parseCalendarDate } from '@/lib/date-format';
+import { getNextOccurrence, getIntervalMs } from '@/lib/upcoming-events';
+
+export { getIntervalMs };
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -50,110 +53,32 @@ export function shouldSendImportantDateReminder(
   }
 
   if (importantDate.reminderType === 'RECURRING') {
-    // For recurring reminders, check based on the interval from the event date
     const interval = importantDate.reminderInterval || 1;
     const intervalUnit = importantDate.reminderIntervalUnit || 'YEARS';
 
-    // Normalize the event date
-    const eventDateNormalized = startOfDay(eventDate);
+    const next = getNextOccurrence(
+      eventDate,
+      today,
+      interval,
+      intervalUnit,
+      importantDate.lastReminderSent
+    );
 
-    // Don't send reminders before the event date
-    if (today.getTime() < eventDateNormalized.getTime()) {
+    if (startOfDay(next).getTime() !== today.getTime()) {
       return false;
     }
 
-    // Special handling for YEARS to avoid leap year drift
-    if (intervalUnit === 'YEARS') {
-      // Project the anniversary into the current year the same way the
-      // dashboard's getNextOccurrence does: a February 29 birthday has no
-      // matching day in non-leap years, and the Date constructor rolls it to
-      // March 1. A plain month/day equality check would never fire that year.
-      const thisYearOccurrence = startOfDay(
-        new Date(
-          today.getFullYear(),
-          eventDateNormalized.getMonth(),
-          eventDateNormalized.getDate()
-        )
-      );
-
-      // Check if today is the anniversary
-      if (thisYearOccurrence.getTime() !== today.getTime()) {
-        return false;
-      }
-
-      // If we've sent before, check if enough years have passed
-      if (importantDate.lastReminderSent) {
-        const lastSent = new Date(importantDate.lastReminderSent);
-        const lastSentYear = lastSent.getFullYear();
-        const todayYear = today.getFullYear();
-        const yearsSinceLastSent = todayYear - lastSentYear;
-
-        return yearsSinceLastSent >= interval;
-      }
-
-      // Never sent before - it's the anniversary, so send
-      return true;
-    }
-
-    // For other intervals (DAYS, WEEKS, MONTHS), use millisecond calculations
-    const intervalMs = getIntervalMs(interval, intervalUnit);
-
-    // If we've sent before, check if enough time has passed
     if (importantDate.lastReminderSent) {
       const lastSent = startOfDay(importantDate.lastReminderSent);
-
-      const timeSinceLastSent = today.getTime() - lastSent.getTime();
-
-      // Not enough time has passed since last reminder
-      if (timeSinceLastSent < intervalMs) {
+      if (lastSent.getTime() === today.getTime()) {
         return false;
       }
-
-      // Calculate the next scheduled reminder date from last sent
-      const intervalsPassed = Math.floor(timeSinceLastSent / intervalMs);
-      const nextReminderDate = startOfDay(new Date(lastSent.getTime() + (intervalsPassed * intervalMs)));
-
-      return nextReminderDate.getTime() === today.getTime();
     }
 
-    // Never sent before - check if we should send based on event date
-    // For unknown-year dates, normalize to current year to avoid
-    // DST drift over centuries breaking the interval math
-    if (eventDateNormalized.getFullYear() <= YEAR_UNKNOWN_SENTINEL) {
-      const currentYear = today.getFullYear();
-      eventDateNormalized.setFullYear(currentYear);
-      // If the normalized date is in the future, use previous year
-      if (eventDateNormalized.getTime() > today.getTime()) {
-        eventDateNormalized.setFullYear(currentYear - 1);
-      }
-    }
-    const timeSinceEvent = today.getTime() - eventDateNormalized.getTime();
-
-    // Calculate which occurrence this is
-    const intervalsPassed = Math.floor(timeSinceEvent / intervalMs);
-    const nextReminderDate = startOfDay(new Date(eventDateNormalized.getTime() + (intervalsPassed * intervalMs)));
-
-    return nextReminderDate.getTime() === today.getTime();
+    return true;
   }
 
   return false;
-}
-
-export function getIntervalMs(interval: number, unit: string): number {
-  const msPerDay = MS_PER_DAY;
-
-  switch (unit) {
-    case 'DAYS':
-      return interval * msPerDay;
-    case 'WEEKS':
-      return interval * 7 * msPerDay;
-    case 'MONTHS':
-      return interval * 30 * msPerDay; // Approximate
-    case 'YEARS':
-      return interval * 365 * msPerDay; // Approximate
-    default:
-      return 365 * msPerDay;
-  }
 }
 
 /** The same interval as whole days. MONTHS and YEARS stay approximate. */

--- a/lib/reminders/due-dates.ts
+++ b/lib/reminders/due-dates.ts
@@ -64,7 +64,7 @@ export function shouldSendImportantDateReminder(
       importantDate.lastReminderSent
     );
 
-    if (startOfDay(next).getTime() !== today.getTime()) {
+    if (next.getTime() !== today.getTime()) {
       return false;
     }
 

--- a/lib/upcoming-events.ts
+++ b/lib/upcoming-events.ts
@@ -31,8 +31,14 @@ export function getNextOccurrence(
   const todayNormalized = new Date(today);
   todayNormalized.setHours(0, 0, 0, 0);
 
-  // Special handling for YEARS to get the next anniversary
   if (intervalUnit === 'YEARS') {
+    const eventYear = eventDate.getFullYear();
+    const isUnknownYear = eventYear <= YEAR_UNKNOWN_SENTINEL;
+
+    const anchorYear = isUnknownYear
+      ? (lastReminderSent ? lastReminderSent.getFullYear() : eventYear)
+      : eventYear;
+
     const thisYearOccurrence = new Date(
       today.getFullYear(),
       eventDate.getMonth(),
@@ -40,34 +46,74 @@ export function getNextOccurrence(
     );
     thisYearOccurrence.setHours(0, 0, 0, 0);
 
-    if (thisYearOccurrence.getTime() >= todayNormalized.getTime()) {
-      return thisYearOccurrence;
+    let candidateYear = thisYearOccurrence.getTime() >= todayNormalized.getTime()
+      ? today.getFullYear()
+      : today.getFullYear() + 1;
+
+    // Don't return before interval years have elapsed since lastReminderSent
+    if (lastReminderSent) {
+      const minYear = lastReminderSent.getFullYear() + interval;
+      if (candidateYear < minYear) {
+        candidateYear = minYear;
+      }
     }
 
-    return new Date(
-      today.getFullYear() + 1,
+    // Advance to the next year on the interval grid
+    const yearsSinceAnchor = candidateYear - anchorYear;
+    const remainder = ((yearsSinceAnchor % interval) + interval) % interval;
+    if (remainder !== 0) {
+      candidateYear += interval - remainder;
+    }
+
+    // Don't return a date before a known future event
+    if (!isUnknownYear && candidateYear < eventYear) {
+      candidateYear = eventYear;
+    }
+
+    const result = new Date(
+      candidateYear,
       eventDate.getMonth(),
       eventDate.getDate()
     );
+    result.setHours(0, 0, 0, 0);
+    return result;
   }
 
-  // For other intervals (DAYS, WEEKS, MONTHS), calculate from event date or last sent
-  const intervalMs = getIntervalMs(interval, intervalUnit);
-  const referenceDate = lastReminderSent
-    ? new Date(lastReminderSent)
-    : eventDateNormalized;
+  // For other intervals (DAYS, WEEKS, MONTHS):
+  // Normalize unknown-year sentinel to the current year to avoid centuries of
+  // 30-day-month approximation compounding into multi-day drift.
+  let referenceDate: Date;
+  if (lastReminderSent) {
+    referenceDate = new Date(lastReminderSent);
+  } else if (eventDateNormalized.getFullYear() <= YEAR_UNKNOWN_SENTINEL) {
+    referenceDate = new Date(eventDateNormalized);
+    referenceDate.setFullYear(today.getFullYear());
+    if (referenceDate.getTime() > todayNormalized.getTime()) {
+      referenceDate.setFullYear(today.getFullYear() - 1);
+    }
+  } else {
+    referenceDate = new Date(eventDateNormalized);
+  }
   referenceDate.setHours(0, 0, 0, 0);
 
-  // If reference date is in the future, return it
   if (referenceDate.getTime() > todayNormalized.getTime()) {
     return referenceDate;
   }
 
-  // Calculate how many intervals have passed since reference date
+  const intervalMs = getIntervalMs(interval, intervalUnit);
   const timeSinceReference = todayNormalized.getTime() - referenceDate.getTime();
   const intervalsPassed = Math.floor(timeSinceReference / intervalMs);
 
-  // Calculate next occurrence (add one more interval to get the next one)
+  // The event date itself is an occurrence; lastReminderSent is not (already sent)
+  if (!lastReminderSent && referenceDate.getTime() === todayNormalized.getTime()) {
+    return todayNormalized;
+  }
+
+  // Return today when it falls exactly on a later interval boundary
+  if (timeSinceReference === intervalsPassed * intervalMs && intervalsPassed > 0) {
+    return todayNormalized;
+  }
+
   const nextOccurrence = new Date(referenceDate.getTime() + ((intervalsPassed + 1) * intervalMs));
   nextOccurrence.setHours(0, 0, 0, 0);
 

--- a/lib/upcoming-events.ts
+++ b/lib/upcoming-events.ts
@@ -101,20 +101,27 @@ export function getNextOccurrence(
   }
 
   const intervalMs = getIntervalMs(interval, intervalUnit);
-  const timeSinceReference = todayNormalized.getTime() - referenceDate.getTime();
-  const intervalsPassed = Math.floor(timeSinceReference / intervalMs);
+
+  // Compare in whole days so DST transitions (which shift local midnight by
+  // up to 1 hour) cannot cause the boundary check to miss.
+  const daysSinceReference = Math.round(
+    (todayNormalized.getTime() - referenceDate.getTime()) / MS_PER_DAY
+  );
+  const intervalDays = Math.round(intervalMs / MS_PER_DAY);
 
   // The event date itself is an occurrence; lastReminderSent is not (already sent)
-  if (!lastReminderSent && referenceDate.getTime() === todayNormalized.getTime()) {
+  if (!lastReminderSent && daysSinceReference === 0) {
     return todayNormalized;
   }
 
   // Return today when it falls exactly on a later interval boundary
-  if (timeSinceReference === intervalsPassed * intervalMs && intervalsPassed > 0) {
+  if (daysSinceReference > 0 && daysSinceReference % intervalDays === 0) {
     return todayNormalized;
   }
 
-  const nextOccurrence = new Date(referenceDate.getTime() + ((intervalsPassed + 1) * intervalMs));
+  const nextBoundaryDays = (Math.floor(daysSinceReference / intervalDays) + 1) * intervalDays;
+  const nextOccurrence = new Date(referenceDate);
+  nextOccurrence.setDate(nextOccurrence.getDate() + nextBoundaryDays);
   nextOccurrence.setHours(0, 0, 0, 0);
 
   return nextOccurrence;

--- a/tests/lib/next-occurrence.test.ts
+++ b/tests/lib/next-occurrence.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from 'vitest';
+import { getNextOccurrence } from '@/lib/upcoming-events';
+import { YEAR_UNKNOWN_SENTINEL } from '@/lib/date-format';
+
+/** A local calendar day. */
+const d = (iso: string) => new Date(`${iso}T00:00:00`);
+
+/**
+ * A stored calendar date (UTC midnight), matching how the database stores them.
+ * parseCalendarDate reads UTC components and projects to local midnight, so
+ * to simulate that in unit tests we build local-midnight dates directly.
+ */
+const stored = (y: number, monthIndex: number, day: number) =>
+  new Date(y, monthIndex, day);
+
+describe('getNextOccurrence, YEARS branch with interval > 1', () => {
+  it('returns an on-grid year when interval is 2 (event year 2020, today 2026)', () => {
+    // 2026 - 2020 = 6, 6 % 2 = 0 => 2026 is on-grid
+    // But 2026-05-15 has passed (today is Aug 25), so next is 2028
+    const result = getNextOccurrence(
+      stored(2020, 4, 15), d('2026-08-25'), 2, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2028);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('skips off-grid years (interval 2, event 2020, candidate 2027 is off-grid)', () => {
+    // 2027 - 2020 = 7, 7 % 2 = 1 => 2027 is off-grid, next on-grid is 2028
+    const result = getNextOccurrence(
+      stored(2020, 4, 15), d('2027-01-01'), 2, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2028);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('returns this year when it is on-grid and the date has not passed', () => {
+    // 2026 - 2020 = 6, 6 % 2 = 0 => on-grid, and May 15 hasn't passed in March
+    const result = getNextOccurrence(
+      stored(2020, 4, 15), d('2026-03-01'), 2, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('returns today when today is exactly on-grid', () => {
+    const result = getNextOccurrence(
+      stored(2020, 4, 15), d('2026-05-15'), 2, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('handles interval 3 correctly', () => {
+    // 2020 + 3k: 2020, 2023, 2026, 2029...
+    // Today 2027-01-01: 2027 off-grid, next is 2029
+    const result = getNextOccurrence(
+      stored(2020, 4, 15), d('2027-01-01'), 3, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2029);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+});
+
+describe('getNextOccurrence, YEARS branch with lastReminderSent', () => {
+  it('skips an on-grid year when lastReminderSent is too recent', () => {
+    // Event 1990, interval 2. Grid: even years. lastReminderSent = 2025.
+    // 2026 is on-grid but only 1 year after last send. Next valid: 2028.
+    const result = getNextOccurrence(
+      stored(1990, 4, 15), d('2026-03-01'), 2, 'YEARS', d('2025-05-15')
+    );
+    expect(result.getFullYear()).toBe(2028);
+  });
+
+  it('returns the on-grid year when enough time has passed since lastReminderSent', () => {
+    // lastReminderSent = 2024, interval 2. 2026 - 2024 = 2 >= 2. On-grid.
+    const result = getNextOccurrence(
+      stored(1990, 4, 15), d('2026-03-01'), 2, 'YEARS', d('2024-05-15')
+    );
+    expect(result.getFullYear()).toBe(2026);
+  });
+});
+
+describe('getNextOccurrence, YEARS branch with future-dated event', () => {
+  it('does not return a date before a future event date', () => {
+    const result = getNextOccurrence(
+      stored(2030, 5, 15), d('2026-08-25'), 1, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2030);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('does not return a date before a future event date with interval > 1', () => {
+    // Event in 2030, interval 2: grid is 2030, 2032, 2034...
+    const result = getNextOccurrence(
+      stored(2030, 5, 15), d('2026-08-25'), 2, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2030);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('returns the event date itself when today is the event date', () => {
+    const result = getNextOccurrence(
+      stored(2030, 5, 15), d('2030-06-15'), 1, 'YEARS', null
+    );
+    expect(result.getFullYear()).toBe(2030);
+    expect(result.getMonth()).toBe(5);
+    expect(result.getDate()).toBe(15);
+  });
+});
+
+describe('getNextOccurrence, non-YEARS with unknown-year sentinel', () => {
+  it('returns today when today is the normalized sentinel anchor', () => {
+    // "May 15, unknown year" with monthly reminders. Today IS May 15.
+    // The sentinel is normalized to this year, and since the event date is
+    // itself an occurrence, it returns today.
+    const result = getNextOccurrence(
+      stored(YEAR_UNKNOWN_SENTINEL, 4, 15), d('2026-05-15'), 1, 'MONTHS', null
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(4);
+    expect(result.getDate()).toBe(15);
+  });
+
+  it('normalizes to the current year, not 1604, preventing century-scale drift', () => {
+    // Without normalization: anchor = 1604-05-15, and centuries of 30-day
+    // approximation produce a wildly wrong date. With normalization: anchor =
+    // 2025-05-15 (prev year since May hasn't passed), and 12 * 30 = 360 days
+    // later = 2026-05-10. The 5-day drift is inherent to the 30-day
+    // approximation, but the result is within a week of the actual anniversary,
+    // not months off as it would be without normalization.
+    const result = getNextOccurrence(
+      stored(YEAR_UNKNOWN_SENTINEL, 4, 15), d('2026-03-01'), 1, 'MONTHS', null
+    );
+    // The anchor is 2025-05-15 (previous year). From March 1, 2026 that's about
+    // 290 days, which is floor(290/30)=9 intervals. Next boundary: 10*30=300
+    // days from 2025-05-15 = 2026-03-11, which is reasonable and close to
+    // today rather than decades off.
+    const diffFromToday = result.getTime() - d('2026-03-01').getTime();
+    const diffDays = Math.round(diffFromToday / (24 * 60 * 60 * 1000));
+    expect(diffDays).toBeGreaterThanOrEqual(0);
+    expect(diffDays).toBeLessThanOrEqual(30);
+  });
+});
+
+describe('getNextOccurrence, non-YEARS inclusive of today', () => {
+  it('returns today when today falls exactly on an interval boundary', () => {
+    // Event: Jan 1, interval 30 days, today = Jan 31 (30 days later)
+    const result = getNextOccurrence(
+      stored(2026, 0, 1), d('2026-01-31'), 30, 'DAYS', null
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(31);
+  });
+
+  it('returns today when today matches a boundary from lastReminderSent', () => {
+    const result = getNextOccurrence(
+      stored(2025, 0, 1), d('2026-01-30'), 30, 'DAYS', d('2025-12-31')
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(30);
+  });
+
+  it('still returns the next future date when today is not on a boundary', () => {
+    // Event: Jan 1, interval 30 days, today = Jan 15
+    const result = getNextOccurrence(
+      stored(2026, 0, 1), d('2026-01-15'), 30, 'DAYS', null
+    );
+    expect(result.getFullYear()).toBe(2026);
+    expect(result.getMonth()).toBe(0);
+    expect(result.getDate()).toBe(31);
+  });
+});

--- a/tests/lib/reminders/due-dates.test.ts
+++ b/tests/lib/reminders/due-dates.test.ts
@@ -203,27 +203,89 @@ describe('shouldSendImportantDateReminder, RECURRING non-YEARS interval, unknown
     ).toBe(false);
   });
 
-  it('fires 5 days early because 1 MONTH is approximated as 30 days, drifting off the true May 15 anniversary', () => {
-    // Surprising and worth flagging: when today is still before this year's
-    // May 15, the code anchors to last year's May 15 (2025) and counts
-    // forward in fixed 30-day steps. 12 steps of 30 days is 360 days, five
-    // days short of the real 365-day gap to this year's May 15, so the count
-    // lands on May 10, 2026, not May 15. shouldSendImportantDateReminder
-    // returns true on May 10 for this never-sent reminder, meaning the
-    // sentinel path fires a genuinely different day than the actual
-    // anniversary. Because both May 10 (via the drifted, reduced-year
-    // anchor) and May 15 (via the fresh, non-reduced anchor evaluated on
-    // that exact day, see the test above) return true, the interval math has
-    // two distinct "hit" days within the same yearly cycle for this
-    // never-sent reminder. In production, whichever day the cron job first
-    // observes as true wins and populates lastReminderSent, after which
-    // subsequent checks compare against that lastReminderSent date instead
-    // of re-deriving the anchor, so the reminder does not fire twice in the
-    // same cycle. But every future occurrence keeps counting in 30-day steps
-    // from whatever day it first fired, so the drift compounds year over
-    // year rather than resyncing to the calendar day of the actual event.
+  it('fires 5 days early because 1 MONTH is approximated as 30 days', () => {
+    // When today is before this year's May 15, getNextOccurrence normalizes
+    // the sentinel to last year's May 15 (2025) and counts forward in fixed
+    // 30-day steps. 12 * 30 = 360 days, five days short of the real 365-day
+    // gap, so the occurrence lands on May 10, not May 15. In production the
+    // cron fires on the first hit (May 10), sets lastReminderSent, and
+    // subsequent checks use that as the reference, preventing a second fire
+    // on May 15. The 30-day approximation is inherent to MONTHS arithmetic.
     expect(
       shouldSendImportantDateReminder({ ...base, date: unknownYearDate }, d('2026-05-10'))
+    ).toBe(true);
+  });
+});
+
+describe('shouldSendImportantDateReminder, RECURRING yearly with interval > 1', () => {
+  const base = {
+    reminderType: 'RECURRING' as const,
+    reminderInterval: 2,
+    reminderIntervalUnit: 'YEARS' as const,
+    lastReminderSent: null,
+  };
+
+  it('sends on the anniversary when the year is on-grid', () => {
+    // Event 1990, interval 2 => grid: 1990, 1992, ..., 2024, 2026, 2028
+    expect(
+      shouldSendImportantDateReminder({ ...base, date: stored(1990, 4, 12) }, d('2026-05-12'))
+    ).toBe(true);
+  });
+
+  it('does not send when the year is off-grid', () => {
+    // 2027 - 1990 = 37, 37 % 2 = 1 => off-grid
+    expect(
+      shouldSendImportantDateReminder({ ...base, date: stored(1990, 4, 12) }, d('2027-05-12'))
+    ).toBe(false);
+  });
+
+  it('sends again after the correct interval from lastReminderSent', () => {
+    expect(
+      shouldSendImportantDateReminder(
+        { ...base, date: stored(1990, 4, 12), lastReminderSent: d('2024-05-12') },
+        d('2026-05-12')
+      )
+    ).toBe(true);
+  });
+
+  it('does not send one year after lastReminderSent when interval is 2', () => {
+    expect(
+      shouldSendImportantDateReminder(
+        { ...base, date: stored(1990, 4, 12), lastReminderSent: d('2026-05-12') },
+        d('2027-05-12')
+      )
+    ).toBe(false);
+  });
+});
+
+describe('shouldSendImportantDateReminder, RECURRING with future event date', () => {
+  it('does not send before a future-dated recurring event', () => {
+    expect(
+      shouldSendImportantDateReminder(
+        {
+          date: stored(2030, 5, 15),
+          reminderType: 'RECURRING',
+          reminderInterval: 1,
+          reminderIntervalUnit: 'YEARS',
+          lastReminderSent: null,
+        },
+        d('2026-06-15')
+      )
+    ).toBe(false);
+  });
+
+  it('sends on the event date itself once it arrives', () => {
+    expect(
+      shouldSendImportantDateReminder(
+        {
+          date: stored(2030, 5, 15),
+          reminderType: 'RECURRING',
+          reminderInterval: 1,
+          reminderIntervalUnit: 'YEARS',
+          lastReminderSent: null,
+        },
+        d('2030-06-15')
+      )
     ).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Make `getNextOccurrence` the single source of truth for "when does this event next occur," fixing the three open cases from #407 where it diverged from `shouldSendImportantDateReminder`
- Simplify `shouldSendImportantDateReminder` to delegate to `getNextOccurrence` for its RECURRING branch, removing ~80 lines of duplicated logic
- Remove the `dayOfWouldFireOnOccurrence` guard in the send-reminders cron since the two paths can no longer disagree

### Fixed cases

| Case | Before | After |
|------|--------|-------|
| Multi-year intervals | YEARS branch ignored `interval`, showed every year in dashboard | Computes on-grid years via modular arithmetic, respects `lastReminderSent` |
| Future-dated recurring | Returned this year's date for events stored in the future | Clamps to event year for known future dates |
| Unknown-year sentinel (non-YEARS) | Centuries of 30-day approximation compounded into multi-day drift | Normalizes the 1604 sentinel to current year before interval math |

### Additional improvements

- Non-YEARS branch is now inclusive of today (returns today when it falls on an interval boundary), consistent with the YEARS branch
- Deduplicated `getIntervalMs` (was defined in both files with different defaults)

## Test plan

- [ ] New `tests/lib/next-occurrence.test.ts` (15 tests) covers all fixed cases: multi-year intervals, lastReminderSent constraint, future-dated events, sentinel normalization, and non-YEARS inclusivity
- [ ] New tests in `tests/lib/reminders/due-dates.test.ts` for multi-year interval and future-dated event cases in `shouldSendImportantDateReminder`
- [ ] All 2987 existing tests pass, including the cron lead-reminder integration tests
- [ ] TypeScript type check passes with no errors