### PR TITLE
fix(unsubscribe): disable reminder before burning token

### DIFF
--- a/lib/unsubscribe-tokens.ts
+++ b/lib/unsubscribe-tokens.ts
@@ -110,16 +110,8 @@ export async function consumeUnsubscribeToken(
     return { success: false, error: 'EXPIRED' };
   }
 
-  // Mark token as used
-  await prisma.unsubscribeToken.update({
-    where: { id: unsubToken.id },
-    data: {
-      used: true,
-      usedAt: new Date(),
-    },
-  });
-
-  // Disable the specific reminder
+  // Disable the reminder first, then burn the token. If the token
+  // update fails the link stays retryable, which is the safer direction.
   if (unsubToken.reminderType === 'IMPORTANT_DATE') {
     await prisma.importantDate.update({
       where: { id: unsubToken.entityId },
@@ -131,12 +123,19 @@ export async function consumeUnsubscribeToken(
       data: { contactReminderEnabled: false },
     });
   } else if (unsubToken.reminderType === 'WEEKLY_DIGEST') {
-    // For weekly digest tokens, entityId holds the user id rather than an entity id
     await prisma.user.update({
       where: { id: unsubToken.entityId },
       data: { weeklyDigestEnabled: false },
     });
   }
+
+  await prisma.unsubscribeToken.update({
+    where: { id: unsubToken.id },
+    data: {
+      used: true,
+      usedAt: new Date(),
+    },
+  });
 
   return {
     success: true,


### PR DESCRIPTION
## Summary

- Reorders the two writes in `consumeUnsubscribeToken` so the reminder is disabled before the token is marked as used
- If the token-burn fails after the reminder is already off, the link stays retryable (clicking again just disables an already-disabled reminder, then burns the token)
- Covers all three branches: `IMPORTANT_DATE`, `CONTACT`, and `WEEKLY_DIGEST`

Closes #409

## Test plan

- [x] Existing unit tests pass (41/41 across three test files)
- [ ] Verify unsubscribe link works for each reminder type (important date, contact, weekly digest)
- [ ] Verify already-used and expired tokens still return the correct error