### PR TITLE
fix(i18n): replace 12 en-dashes in de-DE and nb-NO locale files

### DIFF
--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -248,9 +248,9 @@
       "interval24hours": "Alle 24 Stunden",
       "importModeLabel": "Importmodus für neue Kontakte",
       "importModeHelp": "Wie sollen neue Kontakte vom CardDAV-Server behandelt werden",
-      "importModeManual": "Manuell – Vor dem Import überprüfen",
-      "importModeNotify": "Benachrichtigen – Benachrichtigung bei neuen Kontakten anzeigen",
-      "importModeAuto": "Automatisch – Neue Kontakte automatisch importieren",
+      "importModeManual": "Manuell - Vor dem Import überprüfen",
+      "importModeNotify": "Benachrichtigen - Benachrichtigung bei neuen Kontakten anzeigen",
+      "importModeAuto": "Automatisch - Neue Kontakte automatisch importieren",
       "cardDavNameFormatLabel": "Kontaktnamensformat",
       "cardDavNameFormatHelp": "Bestimmt, wie Namen auf deinem Telefon angezeigt werden. Die vollstaendigen Namensdaten bleiben immer erhalten.",
       "cardDavNameFormat_FULL": "Vollstaendiger Name",
@@ -757,7 +757,7 @@
   "customFields": {
     "settings": {
       "title": "Benutzerdefinierte Felder",
-      "description": "Definiere eigene typisierte Felder und wende sie auf alle deine Personen an. Nutze sie, um dein Netzwerk zu filtern – z. B. «wer ist Vegetarier» oder «wer hat Haustiere».",
+      "description": "Definiere eigene typisierte Felder und wende sie auf alle deine Personen an. Nutze sie, um dein Netzwerk zu filtern, z. B. «wer ist Vegetarier» oder «wer hat Haustiere».",
       "newButton": "Neues Feld",
       "emptyTitle": "Noch keine benutzerdefinierten Felder",
       "emptyDescription": "Füge Felder wie Ernährungsgewohnheiten, Hobbys oder Haustiere hinzu und nutze sie zum Filtern deiner Personen.",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -37,9 +37,9 @@
     "veryStrong": "Svært sterk",
     "requirements": {
       "minLength": "Minst 8 tegn",
-      "uppercase": "Én stor bokstav (A–Z)",
-      "lowercase": "Én liten bokstav (a–z)",
-      "number": "Ett tall (0–9)",
+      "uppercase": "Én stor bokstav (A-Z)",
+      "lowercase": "Én liten bokstav (a-z)",
+      "number": "Ett tall (0-9)",
       "specialChar": "Ett spesialtegn (!@#$%^&*)"
     }
   },
@@ -248,9 +248,9 @@
       "interval24hours": "Hver 24. time",
       "importModeLabel": "Importmodus for nye kontakter",
       "importModeHelp": "Hvordan nye kontakter fra CardDAV-serveren skal håndteres",
-      "importModeManual": "Manuell – Gjennomgå før import",
-      "importModeNotify": "Varsle – Vis varsel når nye kontakter finnes",
-      "importModeAuto": "Automatisk – Importer nye kontakter automatisk",
+      "importModeManual": "Manuell - Gjennomgå før import",
+      "importModeNotify": "Varsle - Vis varsel når nye kontakter finnes",
+      "importModeAuto": "Automatisk - Importer nye kontakter automatisk",
       "cardDavNameFormatLabel": "Kontaktnavnformat",
       "cardDavNameFormatHelp": "Bestemmer hvordan navn vises pa telefonen din. De fullstendige navnedataene bevares alltid.",
       "cardDavNameFormat_FULL": "Fullt navn",
@@ -919,7 +919,7 @@
     "retryGeocodeFailed": "Adressen kunne fortsatt ikke lokaliseres",
     "createFirst": "Opprett din første person",
     "searchPeople": "Søk etter personer",
-    "showing": "Viser {start}–{end} av {total} personer",
+    "showing": "Viser {start}-{end} av {total} personer",
     "limitReached": "Du har nådd grensen på {limit} personer.",
     "upgradePlan": "Oppgrader abonnementet ditt",
     "noPeopleYet": "Ingen personer ennå",
@@ -1508,7 +1508,7 @@
     "createFirstGroup": "Opprett din første gruppe",
     "limitReached": "Du har nådd grensen på {limit} grupper.",
     "upgradePlan": "Oppgrader abonnementet ditt",
-    "showing": "Viser {start}–{end} av {total} grupper",
+    "showing": "Viser {start}-{end} av {total} grupper",
     "noMembersYet": "Ingen medlemmer ennå",
     "oneMember": "1 medlem",
     "membersCount": "{count} medlemmer"


### PR DESCRIPTION
## Summary

- Replace all 12 en-dash characters (U+2013) in `locales/de-DE.json` (4) and `locales/nb-NO.json` (8) with regular hyphens or commas
- Ranges like `(A-Z)`, `(a-z)`, `(0-9)`, `{start}-{end}` now use plain hyphens, matching the English locale
- Label separators ("Manuell - ...") use spaced hyphens, matching the English locale
- One German sentence restructured to use a comma instead of an en-dash

## Test plan

- [x] `grep -n "–" locales/*.json` returns no matches
- [x] `grep -rn "—" locales/*.json` returns no matches
- [x] Both JSON files parse without errors

Closes #410