### PR TITLE
fix(ui): remove descriptions from mobile settings dropdown

### DIFF
--- a/components/SettingsNav.tsx
+++ b/components/SettingsNav.tsx
@@ -167,7 +167,7 @@ export default function SettingsNav({ isSaasMode }: { isSaasMode: boolean }) {
           >
             {settingsNavItems.map((item) => (
               <option key={item.href} value={item.href}>
-                {t(item.labelKey)}{item.badgeKey ? ` (${t(item.badgeKey)})` : ''} - {t(item.descriptionKey)}
+                {t(item.labelKey)}{item.badgeKey ? ` (${t(item.badgeKey)})` : ''}
               </option>
             ))}
           </select>


### PR DESCRIPTION
## Summary
- Removed the long description text from each option in the mobile settings dropdown
- Options now show only the page name (e.g. "Perfil" instead of "Perfil - Nombre, correo y datos personales")
- Reduces visual noise and prevents text overflow on narrow screens
- Desktop sidebar is unchanged

## Test plan
- [ ] Open settings on a narrow viewport or mobile device
- [ ] Verify the dropdown shows only page names without descriptions
- [ ] Verify the desktop sidebar still shows both name and description
- [ ] Check all settings pages are still navigable from the dropdown