### PR TITLE
fix(a11y): raise settings message contrast to WCAG AA

### DIFF
--- a/components/DateFormatSelector.tsx
+++ b/components/DateFormatSelector.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { getDateFormatExample } from '@/lib/date-format';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface DateFormatSelectorProps {
   userId: string;
@@ -100,11 +101,7 @@ export default function DateFormatSelector({ currentFormat }: DateFormatSelector
         ))}
       </div>
 
-      {message && (
-        <p className={`mt-4 text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} className="mt-4" />
     </div>
   );
 }

--- a/components/GeocodingToggle.tsx
+++ b/components/GeocodingToggle.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface GeocodingToggleProps {
   currentEnabled: boolean;
@@ -64,11 +65,7 @@ export default function GeocodingToggle({ currentEnabled }: GeocodingToggleProps
           />
         </button>
       </label>
-      {message && (
-        <p className={`text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`} role="status">
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} />
     </div>
   );
 }

--- a/components/GraphDisplaySelector.tsx
+++ b/components/GraphDisplaySelector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 type Mode = 'individuals' | 'bubbles';
 
@@ -69,11 +70,7 @@ export default function GraphDisplaySelector({ currentMode }: Props) {
         ))}
       </div>
 
-      {message && (
-        <p className={`text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} />
     </div>
   );
 }

--- a/components/NameDisplayFormatSelector.tsx
+++ b/components/NameDisplayFormatSelector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface NameDisplayFormatSelectorProps {
   currentFormat: 'FULL' | 'NICKNAME_PREFERRED' | 'SHORT';
@@ -92,11 +93,7 @@ export default function NameDisplayFormatSelector({ currentFormat }: NameDisplay
         ))}
       </div>
 
-      {message && (
-        <p className={`mt-4 text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} className="mt-4" />
     </div>
   );
 }

--- a/components/NameOrderSelector.tsx
+++ b/components/NameOrderSelector.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface NameOrderSelectorProps {
   currentOrder: 'WESTERN' | 'EASTERN';
@@ -91,11 +92,7 @@ export default function NameOrderSelector({ currentOrder }: NameOrderSelectorPro
         ))}
       </div>
 
-      {message && (
-        <p className={`mt-4 text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} className="mt-4" />
     </div>
   );
 }

--- a/components/ReminderLeadTimeSelector.tsx
+++ b/components/ReminderLeadTimeSelector.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { getLeadTimeLabel, getLeadTimeSelectOptions } from '@/lib/reminders/lead-time-options';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface ReminderLeadTimeSelectorProps {
   currentLeadDays: number;
@@ -104,14 +105,7 @@ export default function ReminderLeadTimeSelector({ currentLeadDays, disabled }: 
         {leadDays === 0 ? t('leadTimeSummaryDayOf') : t('leadTimeSummary', { days: leadDays })}
       </p>
 
-      {message && (
-        <p
-          className={`mt-2 text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
-          role="status"
-        >
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} className="mt-2" />
     </div>
   );
 }

--- a/components/RetryGeocodeButton.tsx
+++ b/components/RetryGeocodeButton.tsx
@@ -52,7 +52,7 @@ export default function RetryGeocodeButton({ addressId }: RetryGeocodeButtonProp
       </button>
       {message && (
         <span
-          className={`text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
+          className={`text-sm ${isSuccess ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}
           role="status"
         >
           {message}

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useTheme } from './ThemeProvider';
 import { useTranslations } from 'next-intl';
 import styles from './ThemeToggle.module.css';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface ThemeToggleProps {
   userId: string;
@@ -100,11 +101,7 @@ export default function ThemeToggle({}: ThemeToggleProps) {
         </label>
       </div>
 
-      {message && (
-        <p className={`mt-4 text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} className="mt-4" />
     </div>
   );
 }

--- a/components/WeeklyDigestSettings.tsx
+++ b/components/WeeklyDigestSettings.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import SettingsMessage from '@/components/ui/SettingsMessage';
 
 interface WeeklyDigestSettingsProps {
   currentEnabled: boolean;
@@ -128,14 +129,7 @@ export default function WeeklyDigestSettings({ currentEnabled, currentWeekday, d
         </div>
       )}
 
-      {message && (
-        <p
-          className={`text-sm ${isSuccess ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}
-          role="status"
-        >
-          {message}
-        </p>
-      )}
+      <SettingsMessage message={message} isSuccess={isSuccess} />
     </div>
   );
 }

--- a/components/ui/SettingsMessage.tsx
+++ b/components/ui/SettingsMessage.tsx
@@ -1,0 +1,18 @@
+interface SettingsMessageProps {
+  message: string | null;
+  isSuccess: boolean;
+  className?: string;
+}
+
+export default function SettingsMessage({ message, isSuccess, className = '' }: SettingsMessageProps) {
+  if (!message) return null;
+
+  return (
+    <p
+      className={`text-sm ${isSuccess ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'} ${className}`}
+      role="status"
+    >
+      {message}
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary

- Extract `SettingsMessage` component (`components/ui/SettingsMessage.tsx`) to centralize the success/error message pattern duplicated across settings components
- Bump light-mode text colors from `green-600`/`red-600` to `green-700`/`red-700`, raising contrast on `#FFFFFF` from ~3.3:1 and ~4.8:1 to ~5.1:1 and ~6.5:1 (WCAG AA requires 4.5:1)
- Normalize `role="status"` on all instances so screen readers announce save confirmations and errors
- Fixes 8 settings components (3 more than originally reported in the issue) plus `RetryGeocodeButton`

## Test plan

- [ ] Open settings pages in light mode, change a setting, confirm the success message is visibly readable
- [ ] Repeat with an error scenario (e.g. network offline), confirm the error message is readable
- [ ] Check dark mode is unchanged
- [ ] Screen reader: verify the status message is announced on save

Closes #411