### PR TITLE
fix(i18n): use 'today' wording for same-day reminder emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Future features and improvements, ordered by priority:
 - [ ] Add notification support [[Issue #6](https://github.com/mattogodoy/nametag/issues/6)]
 - [ ] Support multi-user groups [[Issue #37](https://github.com/mattogodoy/nametag/issues/37)]
 - [ ] Immich integration [[Issue #46](https://github.com/mattogodoy/nametag/issues/46)]
-- [ ] **[HELP NEEDED]** Additional language translations (French, Portuguese, Korean, etc.)
+- [ ] **[HELP NEEDED]** Additional language translations (Portuguese, Korean, etc.)
 
 ### Done
 

--- a/locales/de-DE.json
+++ b/locales/de-DE.json
@@ -152,7 +152,7 @@
       "description": "Vorlaufzeit für Erinnerungen und die wöchentliche Übersicht per E-Mail",
       "leadTimeTitle": "Vorlaufzeit",
       "leadTimeDescription": "Wie weit im Voraus du an ein wichtiges Datum erinnert werden möchtest. Am Tag selbst bekommst du in jedem Fall eine Erinnerung.",
-      "leadTimeDayOf": "Nur am Tag selbst",
+      "leadTimeDayOf": "Am Tag des Ereignisses",
       "leadTimeOneDay": "1 Tag vorher",
       "leadTimeDays": "{days, plural, one {# Tag vorher} other {# Tage vorher}}",
       "leadTimeSummaryDayOf": "Du bekommst eine E-Mail am Tag jedes Termins.",
@@ -1868,8 +1868,8 @@
       "note": "Wenn du kein Konto erstellt hast, kannst du diese E-Mail ignorieren."
     },
     "importantDateReminder": {
-      "subject": "Erinnerung: {personName}s {eventType} steht bevor",
-      "heading": "Erinnerung an bevorstehenden Termin",
+      "subject": "Erinnerung: Heute ist {personName}s {eventType}",
+      "heading": "Termin-Erinnerung",
       "infoBox": "{personName}s {eventType} ist am {date}.",
       "body": "Vergiss nicht, dich zu melden und den Tag besonders zu machen!",
       "button": "Nametag öffnen",

--- a/locales/en.json
+++ b/locales/en.json
@@ -152,7 +152,7 @@
       "description": "Reminder timing and the weekly summary email",
       "leadTimeTitle": "Advance notice",
       "leadTimeDescription": "How far ahead of an important date you would like to hear about it. You will always get a reminder on the day itself.",
-      "leadTimeDayOf": "On the day only",
+      "leadTimeDayOf": "On the event day",
       "leadTimeOneDay": "1 day before",
       "leadTimeDays": "{days, plural, one {# day before} other {# days before}}",
       "leadTimeSummaryDayOf": "You will get an email on the day of each event.",
@@ -1868,8 +1868,8 @@
       "note": "If you didn't create an account, you can safely ignore this email."
     },
     "importantDateReminder": {
-      "subject": "Reminder: {personName}'s {eventType} is coming up",
-      "heading": "Upcoming Event Reminder",
+      "subject": "Reminder: Today is {personName}'s {eventType}",
+      "heading": "Event Reminder",
       "infoBox": "{personName}'s {eventType} is on {date}.",
       "body": "Don't forget to reach out and make their day special!",
       "button": "Open Nametag",

--- a/locales/es-ES.json
+++ b/locales/es-ES.json
@@ -152,7 +152,7 @@
       "description": "El aviso previo y el resumen semanal por correo",
       "leadTimeTitle": "Aviso previo",
       "leadTimeDescription": "Con cuánta antelación quieres que se te avise de una fecha importante. Siempre recibirás un recordatorio el mismo día.",
-      "leadTimeDayOf": "Solo el mismo día",
+      "leadTimeDayOf": "El día del evento",
       "leadTimeOneDay": "1 día antes",
       "leadTimeDays": "{days, plural, one {# día antes} other {# días antes}}",
       "leadTimeSummaryDayOf": "Recibirás un correo el día de cada evento.",
@@ -1868,8 +1868,8 @@
       "note": "Si no creaste una cuenta, puedes ignorar este correo de forma segura."
     },
     "importantDateReminder": {
-      "subject": "Recordatorio: {eventType} de {personName} se acerca",
-      "heading": "Recordatorio de Evento Próximo",
+      "subject": "Recordatorio: Hoy es el {eventType} de {personName}",
+      "heading": "Recordatorio de Evento",
       "infoBox": "El {eventType} de {personName} es el {date}.",
       "body": "¡No olvides comunicarte y hacer que su día sea especial!",
       "button": "Abrir Nametag",

--- a/locales/fr-FR.json
+++ b/locales/fr-FR.json
@@ -152,7 +152,7 @@
       "description": "Rappels et résumé hebdomadaire par e-mail",
       "leadTimeTitle": "Délai de rappel",
       "leadTimeDescription": "Combien de temps avant une date importante souhaitez-vous être prévenu. Vous recevrez toujours un rappel le jour même.",
-      "leadTimeDayOf": "Le jour même uniquement",
+      "leadTimeDayOf": "Le jour de l'événement",
       "leadTimeOneDay": "1 jour avant",
       "leadTimeDays": "{days, plural, one {# jour avant} other {# jours avant}}",
       "leadTimeSummaryDayOf": "Vous recevrez un e-mail le jour de chaque événement.",
@@ -1868,8 +1868,8 @@
       "note": "Si vous n'avez pas créé de compte, vous pouvez ignorer cet e-mail."
     },
     "importantDateReminder": {
-      "subject": "Rappel : le {eventType} de {personName} approche",
-      "heading": "Rappel d'événement à venir",
+      "subject": "Rappel : aujourd'hui c'est le {eventType} de {personName}",
+      "heading": "Rappel d'événement",
       "infoBox": "Le {eventType} de {personName} a lieu le {date}.",
       "body": "N'oubliez pas de prendre contact pour lui faire plaisir.",
       "button": "Ouvrir Nametag",

--- a/locales/it-IT.json
+++ b/locales/it-IT.json
@@ -152,7 +152,7 @@
       "description": "Il preavviso e il riepilogo settimanale via email",
       "leadTimeTitle": "Preavviso",
       "leadTimeDescription": "Con quanto anticipo vuoi essere avvisato di una data importante. Riceverai sempre un promemoria il giorno stesso.",
-      "leadTimeDayOf": "Solo il giorno stesso",
+      "leadTimeDayOf": "Il giorno dell'evento",
       "leadTimeOneDay": "1 giorno prima",
       "leadTimeDays": "{days, plural, one {# giorno prima} other {# giorni prima}}",
       "leadTimeSummaryDayOf": "Riceverai un'email il giorno di ogni evento.",
@@ -1868,8 +1868,8 @@
       "note": "Se non hai creato un account, puoi ignorare questa email."
     },
     "importantDateReminder": {
-      "subject": "Promemoria: {eventType} di {personName} sta arrivando",
-      "heading": "Promemoria evento in arrivo",
+      "subject": "Promemoria: oggi è il/la {eventType} di {personName}",
+      "heading": "Promemoria evento",
       "infoBox": "Il/la {eventType} di {personName} è il {date}.",
       "body": "Non dimenticare di contattarlo/a per rendergli la giornata speciale!",
       "button": "Apri Nametag",

--- a/locales/ja-JP.json
+++ b/locales/ja-JP.json
@@ -152,7 +152,7 @@
       "description": "事前通知のタイミングと週間まとめメール",
       "leadTimeTitle": "事前通知",
       "leadTimeDescription": "重要な日付をどのくらい前に知りたいかを設定します。当日のリマインダーは必ず届きます。",
-      "leadTimeDayOf": "当日のみ",
+      "leadTimeDayOf": "イベント当日",
       "leadTimeOneDay": "1日前",
       "leadTimeDays": "{days, plural, other {#日前}}",
       "leadTimeSummaryDayOf": "各イベントの当日にメールが届きます。",
@@ -1868,7 +1868,7 @@
       "note": "もしアカウントを作成していない場合はこのメールは無視して構いません。"
     },
     "importantDateReminder": {
-      "subject": "リマインダー: {personName}の {eventType}が近づいています",
+      "subject": "リマインダー: 今日は{personName}の{eventType}です",
       "heading": "イベントリマインダー",
       "infoBox": "{personName}の {eventType}は {date}です。",
       "body": "忘れずに連絡して、その日を特別なものにしましょう！",

--- a/locales/nb-NO.json
+++ b/locales/nb-NO.json
@@ -152,7 +152,7 @@
       "description": "Forhåndsvarsel og den ukentlige oppsummeringen på e-post",
       "leadTimeTitle": "Forhåndsvarsel",
       "leadTimeDescription": "Hvor langt i forveien du vil bli varslet om en viktig dato. Du får alltid en påminnelse selve dagen.",
-      "leadTimeDayOf": "Bare på selve dagen",
+      "leadTimeDayOf": "På dagen for hendelsen",
       "leadTimeOneDay": "1 dag før",
       "leadTimeDays": "{days, plural, one {# dag før} other {# dager før}}",
       "leadTimeSummaryDayOf": "Du får en e-post på selve dagen for hver hendelse.",
@@ -1868,8 +1868,8 @@
       "note": "Hvis du ikke opprettet en konto, kan du trygt ignorere denne e-posten."
     },
     "importantDateReminder": {
-      "subject": "Påminnelse: {personName}s {eventType} nærmer seg",
-      "heading": "Påminnelse om kommende hendelse",
+      "subject": "Påminnelse: I dag er {personName}s {eventType}",
+      "heading": "Hendelsespåminnelse",
       "infoBox": "{personName}s {eventType} er {date}.",
       "body": "Ikke glem å ta kontakt og gjøre dagen deres spesiell!",
       "button": "Åpne Nametag",

--- a/locales/nl-NL.json
+++ b/locales/nl-NL.json
@@ -152,7 +152,7 @@
       "description": "Tijdstip van herinneringen en het wekelijkse overzicht per e-mail",
       "leadTimeTitle": "Vooraankondiging",
       "leadTimeDescription": "Hoe ver van tevoren u herinnerd wilt worden aan een belangrijke datum. U krijgt altijd een herinnering op de dag zelf.",
-      "leadTimeDayOf": "Alleen op de dag zelf",
+      "leadTimeDayOf": "Op de dag van het evenement",
       "leadTimeOneDay": "1 dag van tevoren",
       "leadTimeDays": "{days, plural, one {# dag van tevoren} other {# dagen van tevoren}}",
       "leadTimeSummaryDayOf": "U ontvangt een e-mail op de dag van elke gebeurtenis.",
@@ -1868,8 +1868,8 @@
       "note": "Als u geen account heeft aangemaakt, kunt u deze e-mail veilig negeren."
     },
     "importantDateReminder": {
-      "subject": "Herinnering: {personName}'s {eventType} komt eraan",
-      "heading": "Aankomende gebeurtenis herinnering",
+      "subject": "Herinnering: Vandaag is {personName}'s {eventType}",
+      "heading": "Gebeurtenisherinnering",
       "infoBox": "{personName}'s {eventType} is op {date}.",
       "body": "Vergeet niet contact op te nemen en maak hun dag speciaal!",
       "button": "Nametag openen",

--- a/locales/ru-RU.json
+++ b/locales/ru-RU.json
@@ -152,7 +152,7 @@
       "description": "Время напоминаний и еженедельная сводка по почте",
       "leadTimeTitle": "Заблаговременное уведомление",
       "leadTimeDescription": "За сколько дней до важной даты вы хотите получить уведомление. Напоминание в день события вы получите в любом случае.",
-      "leadTimeDayOf": "Только в день события",
+      "leadTimeDayOf": "В день события",
       "leadTimeOneDay": "За 1 день",
       "leadTimeDays": "{days, plural, one {За # день} few {За # дня} many {За # дней} other {За # дня}}",
       "leadTimeSummaryDayOf": "Вы будете получать письмо в день каждого события.",
@@ -1868,8 +1868,8 @@
       "note": "Если вы не создавали аккаунт, можете спокойно игнорировать это письмо."
     },
     "importantDateReminder": {
-      "subject": "Напоминание: скоро {eventType} ({personName})",
-      "heading": "Напоминание о предстоящем событии",
+      "subject": "Напоминание: сегодня {eventType} ({personName})",
+      "heading": "Напоминание о событии",
       "infoBox": "{eventType} ({personName}) - {date}.",
       "body": "Не забудьте поздравить и сделать этот день особенным!",
       "button": "Открыть Nametag",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -152,7 +152,7 @@
       "description": "提前提醒的时间以及每周摘要邮件",
       "leadTimeTitle": "提前提醒",
       "leadTimeDescription": "您希望提前多久收到重要日期的提醒。当天的提醒始终会发送。",
-      "leadTimeDayOf": "仅当天",
+      "leadTimeDayOf": "在事件当天",
       "leadTimeOneDay": "提前 1 天",
       "leadTimeDays": "{days, plural, other {提前 # 天}}",
       "leadTimeSummaryDayOf": "您将在每个事件当天收到一封邮件。",
@@ -1868,8 +1868,8 @@
       "note": "如果您没有创建账户，可以安全地忽略此邮箱。"
     },
     "importantDateReminder": {
-      "subject": "提醒：{personName} 的 {eventType} 即将到来",
-      "heading": "即将发生的事件提醒",
+      "subject": "提醒：今天是 {personName} 的 {eventType}",
+      "heading": "事件提醒",
       "infoBox": "{personName} 的 {eventType} 在 {date}。",
       "body": "不要忘记伸出援手，让他们的一天变得特别！",
       "button": "打开 Nametag",

--- a/tests/lib/email-unsubscribe.test.ts
+++ b/tests/lib/email-unsubscribe.test.ts
@@ -322,7 +322,7 @@ describe('Email Templates - Unsubscribe Functionality', () => {
       );
 
       // Should still have the main heading
-      expect(template.html).toContain('Upcoming Event Reminder');
+      expect(template.html).toContain('Event Reminder');
       // Should still have the main content
       expect(template.html).toContain("John Doe");
       expect(template.html).toContain('Birthday');
@@ -343,7 +343,7 @@ describe('Email Templates - Unsubscribe Functionality', () => {
         'en'
       );
 
-      expect(template.subject).toBe("Reminder: John Doe's Birthday is coming up");
+      expect(template.subject).toBe("Reminder: Today is John Doe's Birthday");
     });
 
     it('should include DOCTYPE and proper HTML structure', async () => {


### PR DESCRIPTION
## Summary
- Same-day event reminder emails incorrectly said the event was "coming up" or "approaching" when it is actually today. Updated the subject line (e.g. "Reminder: Today is John's Birthday") and heading (e.g. "Event Reminder") across all 10 locales.
- Updated the `leadTimeDayOf` setting label from "on the day only" to "on the event day" across all 10 locales for clearer meaning in the notifications settings page.
- Updated 2 test assertions in `email-unsubscribe.test.ts` to match the new English strings.

## Test plan
- [x] `vitest run tests/lib/email-unsubscribe.test.ts` passes (21/21)
- [ ] Trigger a same-day important date reminder and verify the email subject/heading reflects "today"
- [ ] Check the notifications settings page in Spanish and English to verify the lead time label reads correctly