### PR TITLE
refactor(reminders): introduce notification channel abstraction

### DIFF
--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { sendEmailBatch, emailTemplates } from '@/lib/email';
-import type { SendBatchEmailItem } from '@/lib/email';
+import { dispatchAll } from '@/lib/notifications/dispatch';
+import type { NotificationEnvelope, StampTarget } from '@/lib/notifications/types';
 import { formatGraphName } from '@/lib/nameUtils';
 import { env, getAppUrl } from '@/lib/env';
 import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
@@ -88,14 +88,7 @@ export const GET = withLogging(async function GET(request: Request) {
       },
     });
 
-    interface PendingReminder {
-      email: SendBatchEmailItem;
-      type: 'important_date' | 'important_date_lead' | 'contact' | 'weekly_digest';
-      entityId: string;
-      logMeta: Record<string, string>;
-    }
-
-    const pendingReminders: PendingReminder[] = [];
+    const envelopes: NotificationEnvelope[] = [];
 
     // Collect important date reminders
     for (const importantDate of importantDates) {
@@ -123,24 +116,22 @@ export const GET = withLogging(async function GET(request: Request) {
 
         const tDates = await getTranslationsForLocale(userLanguage, 'people.form.importantDates');
         const dateTitle = getDateDisplayTitle(importantDate, tDates);
-        const template = await emailTemplates.importantDateReminder(
-          personName,
-          dateTitle,
-          formattedDate,
-          unsubscribeUrl,
-          userLanguage
-        );
 
-        pendingReminders.push({
-          email: {
-            to: userEmail,
-            subject: template.subject,
-            html: template.html,
-            text: template.text,
-            from: 'reminders',
+        envelopes.push({
+          userId: person.userId,
+          userEmail,
+          locale: userLanguage,
+          notification: {
+            kind: 'important_date',
+            personId: person.id,
+            personName,
+            dateTitle,
+            formattedDate,
+            dateType: importantDate.type,
           },
-          type: 'important_date',
-          entityId: importantDate.id,
+          unsubscribeUrl,
+          deepLink: `${getAppUrl()}/people/${person.id}`,
+          stamp: { model: 'importantDate', id: importantDate.id, field: 'lastReminderSent' },
           logMeta: { personName, dateTitle, userEmail },
         });
       }
@@ -208,25 +199,22 @@ export const GET = withLogging(async function GET(request: Request) {
             'people.form.importantDates'
           );
           const dateTitle = getDateDisplayTitle(importantDate, tDates);
-          const template = await emailTemplates.importantDateLeadReminder(
-            personName,
-            dateTitle,
-            formattedDate,
-            daysUntil,
-            `${getAppUrl()}/unsubscribe?token=${unsubscribeToken}`,
-            userLanguage
-          );
 
-          pendingReminders.push({
-            email: {
-              to: person.user.email,
-              subject: template.subject,
-              html: template.html,
-              text: template.text,
-              from: 'reminders',
+          envelopes.push({
+            userId: person.userId,
+            userEmail: person.user.email,
+            locale: userLanguage,
+            notification: {
+              kind: 'important_date_lead',
+              personId: person.id,
+              personName,
+              dateTitle,
+              formattedDate,
+              daysUntil,
             },
-            type: 'important_date_lead',
-            entityId: importantDate.id,
+            unsubscribeUrl: `${getAppUrl()}/unsubscribe?token=${unsubscribeToken}`,
+            deepLink: `${getAppUrl()}/people/${person.id}`,
+            stamp: { model: 'importantDate', id: importantDate.id, field: 'lastLeadReminderSent' },
             logMeta: { personName, dateTitle, daysUntil: String(daysUntil) },
           });
         }
@@ -276,24 +264,20 @@ export const GET = withLogging(async function GET(request: Request) {
 
         const unsubscribeUrl = `${getAppUrl()}/unsubscribe?token=${unsubscribeToken}`;
 
-        const template = await emailTemplates.contactReminder(
-          personName,
-          lastContactFormatted,
-          intervalText,
-          unsubscribeUrl,
-          userLanguage
-        );
-
-        pendingReminders.push({
-          email: {
-            to: person.user.email,
-            subject: template.subject,
-            html: template.html,
-            text: template.text,
-            from: 'reminders',
+        envelopes.push({
+          userId: person.userId,
+          userEmail: person.user.email,
+          locale: userLanguage,
+          notification: {
+            kind: 'contact',
+            personId: person.id,
+            personName,
+            lastContactFormatted,
+            intervalText,
           },
-          type: 'contact',
-          entityId: person.id,
+          unsubscribeUrl,
+          deepLink: `${getAppUrl()}/people/${person.id}`,
+          stamp: { model: 'person', id: person.id, field: 'lastContactReminderSent' },
           logMeta: { personName, userEmail: person.user.email },
         });
       }
@@ -306,7 +290,7 @@ export const GET = withLogging(async function GET(request: Request) {
     // The outer try/catch here only guards genuine setup failure (mainly the
     // candidate query itself): a problem here must not take down the
     // day-of, lead, and contact reminders collected above, which still need
-    // to reach sendEmailBatch below. Once we have a list of digest users,
+    // to reach dispatchAll below. Once we have a list of digest users,
     // each user is handled in its own inner try/catch, so one bad record
     // (a malformed row, one failing getUpcomingEvents/token/template call)
     // costs exactly that one user's digest, not everyone queued after them.
@@ -368,23 +352,18 @@ export const GET = withLogging(async function GET(request: Request) {
               entityId: user.id,
             });
 
-            const template = await emailTemplates.weeklyDigest(
-              rows,
-              overflowCount,
-              `${getAppUrl()}/unsubscribe?token=${unsubscribeToken}`,
-              userLanguage
-            );
-
-            pendingReminders.push({
-              email: {
-                to: user.email,
-                subject: template.subject,
-                html: template.html,
-                text: template.text,
-                from: 'reminders',
+            envelopes.push({
+              userId: user.id,
+              userEmail: user.email,
+              locale: userLanguage,
+              notification: {
+                kind: 'weekly_digest',
+                rows,
+                overflowCount,
               },
-              type: 'weekly_digest',
-              entityId: user.id,
+              unsubscribeUrl: `${getAppUrl()}/unsubscribe?token=${unsubscribeToken}`,
+              deepLink: `${getAppUrl()}/dashboard`,
+              stamp: { model: 'user', id: user.id, field: 'lastWeeklyDigestSent' },
               logMeta: { userEmail: user.email, eventCount: String(rows.length) },
             });
           } catch (userDigestError) {
@@ -417,67 +396,53 @@ export const GET = withLogging(async function GET(request: Request) {
     let skippedCount = 0;
     let digestsSent = 0;
 
-    if (pendingReminders.length > 0) {
-      const batchResult = await sendEmailBatch(pendingReminders.map(r => r.email));
+    if (envelopes.length > 0) {
+      const results = await dispatchAll(envelopes);
 
-      for (let i = 0; i < pendingReminders.length; i++) {
-        const reminder = pendingReminders[i];
-        const result = batchResult.results[i];
+      for (let i = 0; i < envelopes.length; i++) {
+        const envelope = envelopes[i];
+        const result = results[i];
 
-        // No email provider configured: sendEmailBatch reports success with
-        // `skipped` so the cron still completes cleanly. Nothing was delivered,
-        // so nothing may be stamped. Stamping here would burn the send for good:
-        // the day-of reminder would be marked sent for that occurrence, the
-        // digest for that week, and the advance notice for its whole lead
-        // window, none of which are recoverable once email is configured.
-        if (result.skipped) {
-          skippedCount++;
+        if (!result.shouldStamp) {
+          // Nothing was delivered on any channel. Stamping here would burn the
+          // send for good: the day-of reminder would be marked sent for that
+          // occurrence, the digest for that week, and the advance notice for its
+          // whole lead window, none of which are recoverable.
+          if (result.failed > 0) {
+            errorCount++;
+            log.error({ ...envelope.logMeta, kind: envelope.notification.kind }, 'Failed to send reminder');
+          } else {
+            skippedCount++;
+          }
           continue;
         }
 
-        if (result.success) {
-          try {
-            if (reminder.type === 'important_date') {
-              await prisma.importantDate.update({
-                where: { id: reminder.entityId },
-                data: { lastReminderSent: new Date() },
-              });
-              log.info({ ...reminder.logMeta }, 'Reminder sent');
-            } else if (reminder.type === 'important_date_lead') {
-              await prisma.importantDate.update({
-                where: { id: reminder.entityId },
-                data: { lastLeadReminderSent: new Date() },
-              });
-              log.info({ ...reminder.logMeta }, 'Lead reminder sent');
-            } else if (reminder.type === 'weekly_digest') {
-              await prisma.user.update({
-                where: { id: reminder.entityId },
-                data: { lastWeeklyDigestSent: new Date() },
-              });
-              log.info({ ...reminder.logMeta }, 'Weekly digest sent');
-              digestsSent++;
-            } else {
-              await prisma.person.update({
-                where: { id: reminder.entityId },
-                data: { lastContactReminderSent: new Date() },
-              });
-              log.info({ ...reminder.logMeta }, 'Contact reminder sent');
-            }
-          } catch (stampError) {
-            log.error(
-              {
-                ...reminder.logMeta,
-                entityId: reminder.entityId,
-                type: reminder.type,
-                errorMessage: stampError instanceof Error ? stampError.message : 'Unknown error',
-              },
-              'Failed to stamp reminder as sent (email was delivered, may duplicate on next run)'
-            );
-          }
-          sentCount++;
-        } else {
-          errorCount++;
-          log.error({ ...reminder.logMeta, errorMessage: result.error }, `Failed to send ${reminder.type} reminder`);
+        try {
+          await stampSent(envelope.stamp);
+          log.info({ ...envelope.logMeta, kind: envelope.notification.kind }, 'Reminder sent');
+        } catch (stampError) {
+          log.error(
+            {
+              ...envelope.logMeta,
+              entityId: envelope.stamp.id,
+              kind: envelope.notification.kind,
+              errorMessage: stampError instanceof Error ? stampError.message : 'Unknown error',
+            },
+            'Failed to stamp reminder as sent (it was delivered, may duplicate on next run)'
+          );
+        }
+
+        if (envelope.notification.kind === 'weekly_digest') {
+          digestsSent++;
+        }
+        sentCount++;
+
+        // A partial success still stamps, so surface the channels that failed.
+        if (result.failed > 0) {
+          log.warn(
+            { ...envelope.logMeta, failedChannels: result.failed },
+            'Reminder delivered on some channels but not all'
+          );
         }
       }
     }
@@ -531,6 +496,42 @@ export const GET = withLogging(async function GET(request: Request) {
     return handleApiError(error, 'cron-send-reminders');
   }
 });
+
+/**
+ * Record that a notification was delivered.
+ *
+ * StampTarget is a discriminated union, so each branch narrows to a concrete
+ * Prisma column and no cast is needed to satisfy the generated input types.
+ */
+async function stampSent(stamp: StampTarget): Promise<void> {
+  const now = new Date();
+
+  switch (stamp.model) {
+    case 'importantDate':
+      await prisma.importantDate.update({
+        where: { id: stamp.id },
+        data:
+          stamp.field === 'lastReminderSent'
+            ? { lastReminderSent: now }
+            : { lastLeadReminderSent: now },
+      });
+      return;
+
+    case 'person':
+      await prisma.person.update({
+        where: { id: stamp.id },
+        data: { lastContactReminderSent: now },
+      });
+      return;
+
+    case 'user':
+      await prisma.user.update({
+        where: { id: stamp.id },
+        data: { lastWeeklyDigestSent: now },
+      });
+      return;
+  }
+}
 
 function formatInterval(interval: number, unit: string): string {
   const unitLower = unit.toLowerCase();

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -292,8 +292,10 @@ export const GET = withLogging(async function GET(request: Request) {
     // day-of, lead, and contact reminders collected above, which still need
     // to reach dispatchAll below. Once we have a list of digest users,
     // each user is handled in its own inner try/catch, so one bad record
-    // (a malformed row, one failing getUpcomingEvents/token/template call)
-    // costs exactly that one user's digest, not everyone queued after them.
+    // (a malformed row, one failing getUpcomingEvents/token call) costs
+    // exactly that one user's digest, not everyone queued after them. A
+    // template rendering failure is not caught here: it surfaces later, per
+    // envelope, inside dispatchEmail's Promise.allSettled.
     try {
       const digestCandidates = await prisma.user.findMany({
         where: { weeklyDigestEnabled: true },

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -513,15 +513,29 @@ async function stampSent(stamp: StampTarget): Promise<void> {
   const now = new Date();
 
   switch (stamp.model) {
-    case 'importantDate':
-      await prisma.importantDate.update({
-        where: { id: stamp.id },
-        data:
-          stamp.field === 'lastReminderSent'
-            ? { lastReminderSent: now }
-            : { lastLeadReminderSent: now },
-      });
-      return;
+    case 'importantDate': {
+      const importantDateId = stamp.id;
+      const field = stamp.field;
+
+      switch (field) {
+        case 'lastReminderSent':
+          await prisma.importantDate.update({
+            where: { id: importantDateId },
+            data: { lastReminderSent: now },
+          });
+          return;
+        case 'lastLeadReminderSent':
+          await prisma.importantDate.update({
+            where: { id: importantDateId },
+            data: { lastLeadReminderSent: now },
+          });
+          return;
+        default: {
+          const unhandled: never = field;
+          throw new Error(`Unhandled importantDate stamp field: ${JSON.stringify(unhandled)}`);
+        }
+      }
+    }
 
     case 'person':
       await prisma.person.update({
@@ -536,6 +550,11 @@ async function stampSent(stamp: StampTarget): Promise<void> {
         data: { lastWeeklyDigestSent: now },
       });
       return;
+
+    default: {
+      const unhandled: never = stamp;
+      throw new Error(`Unhandled stamp target: ${JSON.stringify(unhandled)}`);
+    }
   }
 }
 

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -420,6 +420,13 @@ export const GET = withLogging(async function GET(request: Request) {
         try {
           await stampSent(envelope.stamp);
           log.info({ ...envelope.logMeta, kind: envelope.notification.kind }, 'Reminder sent');
+
+          // Inside the try, matching the pre-refactor behaviour: a digest whose
+          // stamp write failed was never counted as a digest sent, even though it
+          // still counted toward sentCount.
+          if (envelope.notification.kind === 'weekly_digest') {
+            digestsSent++;
+          }
         } catch (stampError) {
           log.error(
             {
@@ -432,9 +439,6 @@ export const GET = withLogging(async function GET(request: Request) {
           );
         }
 
-        if (envelope.notification.kind === 'weekly_digest') {
-          digestsSent++;
-        }
         sentCount++;
 
         // A partial success still stamps, so surface the channels that failed.

--- a/lib/notifications/channels/email.ts
+++ b/lib/notifications/channels/email.ts
@@ -1,0 +1,61 @@
+import { emailTemplates } from '@/lib/email';
+import type { SendBatchEmailItem } from '@/lib/email';
+import type { NotificationEnvelope } from '../types';
+
+/**
+ * Turn an envelope into an email message.
+ *
+ * This is the only place email rendering happens. The templates themselves are
+ * untouched: this function exists to map the channel-agnostic envelope onto
+ * the argument list each template already expects, so that adding a channel
+ * never means editing a template.
+ */
+export async function renderEmail(envelope: NotificationEnvelope): Promise<SendBatchEmailItem> {
+  const { notification, locale, unsubscribeUrl, userEmail } = envelope;
+
+  switch (notification.kind) {
+    case 'important_date': {
+      const template = await emailTemplates.importantDateReminder(
+        notification.personName,
+        notification.dateTitle,
+        notification.formattedDate,
+        unsubscribeUrl,
+        locale
+      );
+      return { to: userEmail, subject: template.subject, html: template.html, text: template.text, from: 'reminders' };
+    }
+
+    case 'important_date_lead': {
+      const template = await emailTemplates.importantDateLeadReminder(
+        notification.personName,
+        notification.dateTitle,
+        notification.formattedDate,
+        notification.daysUntil,
+        unsubscribeUrl,
+        locale
+      );
+      return { to: userEmail, subject: template.subject, html: template.html, text: template.text, from: 'reminders' };
+    }
+
+    case 'contact': {
+      const template = await emailTemplates.contactReminder(
+        notification.personName,
+        notification.lastContactFormatted,
+        notification.intervalText,
+        unsubscribeUrl,
+        locale
+      );
+      return { to: userEmail, subject: template.subject, html: template.html, text: template.text, from: 'reminders' };
+    }
+
+    case 'weekly_digest': {
+      const template = await emailTemplates.weeklyDigest(
+        notification.rows,
+        notification.overflowCount,
+        unsubscribeUrl,
+        locale
+      );
+      return { to: userEmail, subject: template.subject, html: template.html, text: template.text, from: 'reminders' };
+    }
+  }
+}

--- a/lib/notifications/dispatch.ts
+++ b/lib/notifications/dispatch.ts
@@ -1,0 +1,82 @@
+import { isEmailConfigured, sendEmailBatch } from '@/lib/email';
+import { createModuleLogger } from '@/lib/logger';
+import { renderEmail } from './channels/email';
+import type { ChannelOutcome, DispatchResult, NotificationEnvelope } from './types';
+
+const log = createModuleLogger('notifications');
+
+/**
+ * Deliver a batch of envelopes across every channel the recipient has enabled.
+ *
+ * Email is handled as one batch rather than per envelope. Resend's batch
+ * endpoint is a single HTTP call for up to 100 messages, and dispatching
+ * envelope by envelope would turn one request into hundreds. Channels added in
+ * later phases are per envelope and run through mapWithConcurrency instead.
+ */
+export async function dispatchAll(
+  envelopes: readonly NotificationEnvelope[]
+): Promise<DispatchResult[]> {
+  if (envelopes.length === 0) {
+    return [];
+  }
+
+  const emailOutcomes = await dispatchEmail(envelopes);
+
+  return envelopes.map((_envelope, index) => summarize([emailOutcomes[index]]));
+}
+
+/**
+ * Render and send every envelope's email in one batch.
+ *
+ * Returns one outcome per envelope, positionally aligned with the input.
+ */
+async function dispatchEmail(
+  envelopes: readonly NotificationEnvelope[]
+): Promise<ChannelOutcome[]> {
+  if (!isEmailConfigured()) {
+    return envelopes.map(() => ({ status: 'skipped' }));
+  }
+
+  const items = await Promise.all(envelopes.map((envelope) => renderEmail(envelope)));
+
+  try {
+    const batch = await sendEmailBatch(items);
+
+    return envelopes.map((_envelope, index) => {
+      const result = batch.results[index];
+
+      if (!result) {
+        return { status: 'failed', error: 'No result returned for this message' };
+      }
+
+      // `skipped` means the provider never attempted delivery. Treating it as
+      // success would stamp a reminder that nobody received, and the stamp is
+      // not recoverable once email is configured later.
+      if (result.skipped) {
+        return { status: 'skipped' };
+      }
+
+      return result.success
+        ? { status: 'delivered' }
+        : { status: 'failed', error: result.error ?? 'Unknown email error' };
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    log.error({ errorMessage: message, count: envelopes.length }, 'Email batch send threw');
+    return envelopes.map(() => ({ status: 'failed', error: message }));
+  }
+}
+
+function summarize(outcomes: readonly ChannelOutcome[]): DispatchResult {
+  let delivered = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const outcome of outcomes) {
+    if (outcome.status === 'delivered') delivered++;
+    else if (outcome.status === 'failed') failed++;
+    else skipped++;
+  }
+
+  return { delivered, failed, skipped, shouldStamp: delivered > 0 };
+}

--- a/lib/notifications/dispatch.ts
+++ b/lib/notifications/dispatch.ts
@@ -12,7 +12,9 @@ const log = createModuleLogger('notifications');
  * Email is handled as one batch rather than per envelope. Resend's batch
  * endpoint is a single HTTP call for up to 100 messages, and dispatching
  * envelope by envelope would turn one request into hundreds. Channels added in
- * later phases are per envelope and run through mapWithConcurrency instead.
+ * later phases (web push, ntfy, webhooks) deliver per envelope instead, and
+ * will need their own concurrency limit so one slow user does not stall the
+ * whole run.
  */
 export async function dispatchAll(
   envelopes: readonly NotificationEnvelope[]
@@ -59,7 +61,7 @@ async function dispatchEmail(
 
     const message = result.reason instanceof Error ? result.reason.message : 'Unknown render error';
     log.error(
-      { errorMessage: message, kind: envelopes[index].notification.kind },
+      { ...envelopes[index].logMeta, errorMessage: message, kind: envelopes[index].notification.kind },
       'Failed to render reminder email'
     );
     outcomes[index] = { status: 'failed', error: message };
@@ -117,9 +119,21 @@ function summarize(outcomes: readonly ChannelOutcome[]): DispatchResult {
   let skipped = 0;
 
   for (const outcome of outcomes) {
-    if (outcome.status === 'delivered') delivered++;
-    else if (outcome.status === 'failed') failed++;
-    else skipped++;
+    switch (outcome.status) {
+      case 'delivered':
+        delivered++;
+        break;
+      case 'failed':
+        failed++;
+        break;
+      case 'skipped':
+        skipped++;
+        break;
+      default: {
+        const unhandled: never = outcome;
+        throw new Error(`Unhandled channel outcome: ${JSON.stringify(unhandled)}`);
+      }
+    }
   }
 
   return { delivered, failed, skipped, shouldStamp: delivered > 0 };

--- a/lib/notifications/dispatch.ts
+++ b/lib/notifications/dispatch.ts
@@ -88,9 +88,17 @@ async function dispatchEmail(
         return;
       }
 
-      outcomes[envelopeIndex] = result.success
-        ? { status: 'delivered' }
-        : { status: 'failed', error: result.error ?? 'Unknown email error' };
+      if (result.success) {
+        outcomes[envelopeIndex] = { status: 'delivered' };
+        return;
+      }
+
+      const error = result.error ?? 'Unknown email error';
+      log.error(
+        { ...envelopes[envelopeIndex].logMeta, errorMessage: error, kind: envelopes[envelopeIndex].notification.kind },
+        'Email delivery failed for one reminder'
+      );
+      outcomes[envelopeIndex] = { status: 'failed', error };
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';

--- a/lib/notifications/dispatch.ts
+++ b/lib/notifications/dispatch.ts
@@ -1,4 +1,5 @@
 import { isEmailConfigured, sendEmailBatch } from '@/lib/email';
+import type { SendBatchEmailItem } from '@/lib/email';
 import { createModuleLogger } from '@/lib/logger';
 import { renderEmail } from './channels/email';
 import type { ChannelOutcome, DispatchResult, NotificationEnvelope } from './types';
@@ -37,34 +38,69 @@ async function dispatchEmail(
     return envelopes.map(() => ({ status: 'skipped' }));
   }
 
-  const items = await Promise.all(envelopes.map((envelope) => renderEmail(envelope)));
+  const outcomes: ChannelOutcome[] = envelopes.map(() => ({ status: 'skipped' }));
+
+  // Rendered per envelope rather than as one all-or-nothing batch. A locale or
+  // template failure on a single reminder must not stop every other user's
+  // reminder from going out that night.
+  const rendered = await Promise.allSettled(envelopes.map((envelope) => renderEmail(envelope)));
+
+  // Only successfully rendered envelopes go in the batch, so batch positions no
+  // longer line up with envelope positions and have to be mapped back.
+  const indexes: number[] = [];
+  const items: SendBatchEmailItem[] = [];
+
+  rendered.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      indexes.push(index);
+      items.push(result.value);
+      return;
+    }
+
+    const message = result.reason instanceof Error ? result.reason.message : 'Unknown render error';
+    log.error(
+      { errorMessage: message, kind: envelopes[index].notification.kind },
+      'Failed to render reminder email'
+    );
+    outcomes[index] = { status: 'failed', error: message };
+  });
+
+  if (items.length === 0) {
+    return outcomes;
+  }
 
   try {
     const batch = await sendEmailBatch(items);
 
-    return envelopes.map((_envelope, index) => {
-      const result = batch.results[index];
+    indexes.forEach((envelopeIndex, batchIndex) => {
+      const result = batch.results[batchIndex];
 
       if (!result) {
-        return { status: 'failed', error: 'No result returned for this message' };
+        outcomes[envelopeIndex] = { status: 'failed', error: 'No result returned for this message' };
+        return;
       }
 
       // `skipped` means the provider never attempted delivery. Treating it as
-      // success would stamp a reminder that nobody received, and the stamp is
-      // not recoverable once email is configured later.
+      // success would stamp a reminder nobody received, and the stamp is not
+      // recoverable once email is configured later.
       if (result.skipped) {
-        return { status: 'skipped' };
+        outcomes[envelopeIndex] = { status: 'skipped' };
+        return;
       }
 
-      return result.success
+      outcomes[envelopeIndex] = result.success
         ? { status: 'delivered' }
         : { status: 'failed', error: result.error ?? 'Unknown email error' };
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error';
-    log.error({ errorMessage: message, count: envelopes.length }, 'Email batch send threw');
-    return envelopes.map(() => ({ status: 'failed', error: message }));
+    log.error({ errorMessage: message, count: items.length }, 'Email batch send threw');
+    indexes.forEach((envelopeIndex) => {
+      outcomes[envelopeIndex] = { status: 'failed', error: message };
+    });
   }
+
+  return outcomes;
 }
 
 function summarize(outcomes: readonly ChannelOutcome[]): DispatchResult {

--- a/lib/notifications/types.ts
+++ b/lib/notifications/types.ts
@@ -1,0 +1,96 @@
+import type { DigestEmailRow } from '@/lib/email';
+import type { SupportedLocale } from '@/lib/i18n-utils';
+
+/**
+ * What happened, stated without reference to how it will be delivered.
+ *
+ * Every field here is already formatted for display (dates rendered in the
+ * user's date format, names run through formatGraphName) because the cron is
+ * the only place with the context to do that correctly. Channels choose
+ * wording and layout, not data.
+ */
+export type ReminderNotification =
+  | {
+      kind: 'important_date';
+      personId: string;
+      personName: string;
+      dateTitle: string;
+      formattedDate: string;
+      /** Predefined key ("birthday", "anniversary", "nameday", "memorial") or null for custom dates. */
+      dateType: string | null;
+    }
+  | {
+      kind: 'important_date_lead';
+      personId: string;
+      personName: string;
+      dateTitle: string;
+      formattedDate: string;
+      daysUntil: number;
+    }
+  | {
+      kind: 'contact';
+      personId: string;
+      personName: string;
+      lastContactFormatted: string | null;
+      intervalText: string;
+    }
+  | {
+      kind: 'weekly_digest';
+      rows: DigestEmailRow[];
+      overflowCount: number;
+    };
+
+/**
+ * Which row and column record that this notification was sent.
+ *
+ * A discriminated union rather than a flat {model, field} record, so that an
+ * impossible pair such as {model: 'person', field: 'lastWeeklyDigestSent'}
+ * cannot be constructed, and so the field can be handed to Prisma without a
+ * cast.
+ */
+export type StampTarget =
+  | { model: 'importantDate'; id: string; field: 'lastReminderSent' | 'lastLeadReminderSent' }
+  | { model: 'person'; id: string; field: 'lastContactReminderSent' }
+  | { model: 'user'; id: string; field: 'lastWeeklyDigestSent' };
+
+export interface NotificationEnvelope {
+  userId: string;
+  userEmail: string;
+  locale: SupportedLocale;
+  notification: ReminderNotification;
+  /** Absolute one-click unsubscribe URL. Email-only, but computed once per envelope. */
+  unsubscribeUrl: string;
+  /** Absolute deep link, /people/<id> or /dashboard. */
+  deepLink: string;
+  stamp: StampTarget;
+  /** Structured fields for the cron's log lines. */
+  logMeta: Record<string, string>;
+}
+
+/**
+ * Outcome of one channel attempting one envelope.
+ *
+ * `skipped` means there was nothing to deliver to (no email provider
+ * configured, no push subscriptions, no endpoints), which is different from
+ * a delivery that was attempted and failed. Only the latter is an error.
+ */
+export type ChannelOutcome =
+  | { status: 'delivered' }
+  | { status: 'failed'; error: string }
+  | { status: 'skipped' };
+
+export interface DispatchResult {
+  delivered: number;
+  failed: number;
+  skipped: number;
+  /**
+   * True when at least one channel delivered.
+   *
+   * Drives whether the cron writes the "sent" timestamp. False must mean
+   * nothing was delivered anywhere, because stamping an undelivered
+   * notification burns it permanently: the day-of reminder is marked sent for
+   * that occurrence, the digest for that week, and the lead reminder for its
+   * whole lead window.
+   */
+  shouldStamp: boolean;
+}

--- a/tests/api/cron-reminders-unsubscribe.test.ts
+++ b/tests/api/cron-reminders-unsubscribe.test.ts
@@ -42,12 +42,27 @@ vi.mock('../../lib/prisma', () => ({
   },
 }));
 
-// Mock email
+// Mock email. dispatch.ts imports isEmailConfigured from this module, and
+// renderEmail may reach for emailTemplates.importantDateLeadReminder or
+// emailTemplates.weeklyDigest depending on the fixture, so both are supplied
+// here even though this file's fixtures only exercise the important-date and
+// contact templates today.
 vi.mock('../../lib/email', () => ({
   sendEmailBatch: mocks.sendEmailBatch,
+  isEmailConfigured: () => true,
   emailTemplates: {
     importantDateReminder: mocks.importantDateReminderTemplate,
     contactReminder: mocks.contactReminderTemplate,
+    importantDateLeadReminder: vi.fn(() => ({
+      subject: 'lead reminder',
+      html: '<p>lead reminder</p>',
+      text: 'lead reminder',
+    })),
+    weeklyDigest: vi.fn(() => ({
+      subject: 'weekly digest',
+      html: '<p>weekly digest</p>',
+      text: 'weekly digest',
+    })),
   },
 }));
 

--- a/tests/api/cron-weekly-digest.test.ts
+++ b/tests/api/cron-weekly-digest.test.ts
@@ -164,6 +164,18 @@ describe('send-reminders weekly digest', () => {
     expect(mocks.userUpdate).not.toHaveBeenCalled();
   });
 
+  it('counts a digest toward sent but not digestsSent when its stamp write throws', async () => {
+    mocks.userFindMany.mockResolvedValue([digestUser()]);
+    mocks.getUpcomingEvents.mockResolvedValue([upcoming(2)]);
+    mocks.userUpdate.mockRejectedValue(new Error('connection reset'));
+
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(body.sent).toBe(1);
+    expect(body.digestsSent).toBe(0);
+  });
+
   it('leaves overdue contact reminders out of the email', async () => {
     const overdue: UpcomingEvent = {
       ...upcoming(-40, 'e-overdue'),

--- a/tests/lib/notifications/channel-email.test.ts
+++ b/tests/lib/notifications/channel-email.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { renderEmail } from '../../../lib/notifications/channels/email';
+import type { NotificationEnvelope } from '../../../lib/notifications/types';
+
+function envelope(
+  notification: NotificationEnvelope['notification'],
+  stamp: NotificationEnvelope['stamp']
+): NotificationEnvelope {
+  return {
+    userId: 'user-1',
+    userEmail: 'user@example.com',
+    locale: 'en',
+    notification,
+    unsubscribeUrl: 'https://app.test/unsubscribe?token=tok-123',
+    deepLink: 'https://app.test/people/person-1',
+    stamp,
+    logMeta: {},
+  };
+}
+
+describe('renderEmail', () => {
+  it('renders an important date reminder addressed to the user from the reminders sender', async () => {
+    const item = await renderEmail(
+      envelope(
+        {
+          kind: 'important_date',
+          personId: 'person-1',
+          personName: 'Ana Torres',
+          dateTitle: 'Birthday',
+          formattedDate: 'August 26, 2026',
+          dateType: 'birthday',
+        },
+        { model: 'importantDate', id: 'date-1', field: 'lastReminderSent' }
+      )
+    );
+
+    expect(item.to).toBe('user@example.com');
+    expect(item.from).toBe('reminders');
+    expect(item.subject).toContain('Ana Torres');
+    expect(item.html).toContain('Ana Torres');
+    expect(item.html).toContain('https://app.test/unsubscribe?token=tok-123');
+  });
+
+  it('renders a lead reminder that mentions the number of days', async () => {
+    const item = await renderEmail(
+      envelope(
+        {
+          kind: 'important_date_lead',
+          personId: 'person-1',
+          personName: 'Ana Torres',
+          dateTitle: 'Birthday',
+          formattedDate: 'September 2, 2026',
+          daysUntil: 7,
+        },
+        { model: 'importantDate', id: 'date-1', field: 'lastLeadReminderSent' }
+      )
+    );
+
+    expect(item.subject).toContain('Ana Torres');
+    expect(item.html).toContain('7');
+  });
+
+  it('renders a contact reminder', async () => {
+    const item = await renderEmail(
+      envelope(
+        {
+          kind: 'contact',
+          personId: 'person-1',
+          personName: 'Ana Torres',
+          lastContactFormatted: 'June 1, 2026',
+          intervalText: '3 months',
+        },
+        { model: 'person', id: 'person-1', field: 'lastContactReminderSent' }
+      )
+    );
+
+    expect(item.to).toBe('user@example.com');
+    expect(item.html).toContain('Ana Torres');
+  });
+
+  it('renders a weekly digest with one row per event', async () => {
+    const item = await renderEmail(
+      envelope(
+        {
+          kind: 'weekly_digest',
+          rows: [
+            { personName: 'Ana Torres', eventTitle: 'Birthday', formattedDate: 'August 28, 2026', daysUntil: 2 },
+            { personName: 'Bo Lin', eventTitle: 'Anniversary', formattedDate: 'August 30, 2026', daysUntil: 4 },
+          ],
+          overflowCount: 3,
+        },
+        { model: 'user', id: 'user-1', field: 'lastWeeklyDigestSent' }
+      )
+    );
+
+    expect(item.html).toContain('Ana Torres');
+    expect(item.html).toContain('Bo Lin');
+  });
+
+  it('renders in the envelope locale rather than always English', async () => {
+    const en = await renderEmail(
+      envelope(
+        {
+          kind: 'contact',
+          personId: 'person-1',
+          personName: 'Ana Torres',
+          lastContactFormatted: null,
+          intervalText: '3 months',
+        },
+        { model: 'person', id: 'person-1', field: 'lastContactReminderSent' }
+      )
+    );
+
+    const es = await renderEmail({
+      ...envelope(
+        {
+          kind: 'contact',
+          personId: 'person-1',
+          personName: 'Ana Torres',
+          lastContactFormatted: null,
+          intervalText: '3 meses',
+        },
+        { model: 'person', id: 'person-1', field: 'lastContactReminderSent' }
+      ),
+      locale: 'es-ES',
+    });
+
+    expect(es.subject).not.toBe(en.subject);
+  });
+});

--- a/tests/lib/notifications/dispatch.test.ts
+++ b/tests/lib/notifications/dispatch.test.ts
@@ -4,6 +4,7 @@ import type { NotificationEnvelope } from '../../../lib/notifications/types';
 const mocks = vi.hoisted(() => ({
   isEmailConfigured: vi.fn(),
   sendEmailBatch: vi.fn(),
+  renderEmail: vi.fn(),
 }));
 
 vi.mock('../../../lib/email', async () => {
@@ -14,6 +15,8 @@ vi.mock('../../../lib/email', async () => {
     sendEmailBatch: mocks.sendEmailBatch,
   };
 });
+
+vi.mock('../../../lib/notifications/channels/email', () => ({ renderEmail: mocks.renderEmail }));
 
 import { dispatchAll } from '../../../lib/notifications/dispatch';
 
@@ -40,7 +43,9 @@ describe('dispatchAll', () => {
   beforeEach(() => {
     mocks.isEmailConfigured.mockReset();
     mocks.sendEmailBatch.mockReset();
+    mocks.renderEmail.mockReset();
     mocks.isEmailConfigured.mockReturnValue(true);
+    mocks.renderEmail.mockResolvedValue({ to: 'user@example.com', subject: 'test', html: '<p>test</p>' });
   });
 
   it('sends every email in a single batch call so Resend batching is preserved', async () => {
@@ -120,5 +125,31 @@ describe('dispatchAll', () => {
     const results = await dispatchAll([envelope('1'), envelope('2')]);
 
     expect(results.every((r) => r.failed === 1 && r.shouldStamp === false)).toBe(true);
+  });
+
+  it('a single failing render does not stop the others', async () => {
+    mocks.renderEmail.mockResolvedValueOnce({ to: 'user-1@example.com', subject: 'test', html: '<p>test</p>' });
+    mocks.renderEmail.mockRejectedValueOnce(new Error('Template not found'));
+    mocks.renderEmail.mockResolvedValueOnce({ to: 'user-3@example.com', subject: 'test', html: '<p>test</p>' });
+
+    mocks.sendEmailBatch.mockResolvedValue({
+      success: true,
+      results: [{ success: true }, { success: true }],
+    });
+
+    const results = await dispatchAll([envelope('1'), envelope('2'), envelope('3')]);
+
+    expect(mocks.sendEmailBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.sendEmailBatch.mock.calls[0][0]).toHaveLength(2);
+    expect(results.map((r) => r.shouldStamp)).toEqual([true, false, true]);
+  });
+
+  it('a failed render is reported failed and never stamped', async () => {
+    mocks.renderEmail.mockRejectedValue(new Error('Locale not supported'));
+
+    const [result] = await dispatchAll([envelope('1')]);
+
+    expect(result).toEqual({ delivered: 0, failed: 1, skipped: 0, shouldStamp: false });
+    expect(mocks.sendEmailBatch).not.toHaveBeenCalled();
   });
 });

--- a/tests/lib/notifications/dispatch.test.ts
+++ b/tests/lib/notifications/dispatch.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { NotificationEnvelope } from '../../../lib/notifications/types';
+
+const mocks = vi.hoisted(() => ({
+  isEmailConfigured: vi.fn(),
+  sendEmailBatch: vi.fn(),
+}));
+
+vi.mock('../../../lib/email', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/email')>('../../../lib/email');
+  return {
+    ...actual,
+    isEmailConfigured: mocks.isEmailConfigured,
+    sendEmailBatch: mocks.sendEmailBatch,
+  };
+});
+
+import { dispatchAll } from '../../../lib/notifications/dispatch';
+
+function envelope(id: string): NotificationEnvelope {
+  return {
+    userId: `user-${id}`,
+    userEmail: `user-${id}@example.com`,
+    locale: 'en',
+    notification: {
+      kind: 'contact',
+      personId: `person-${id}`,
+      personName: 'Ana Torres',
+      lastContactFormatted: null,
+      intervalText: '3 months',
+    },
+    unsubscribeUrl: 'https://app.test/unsubscribe?token=tok',
+    deepLink: `https://app.test/people/person-${id}`,
+    stamp: { model: 'person', id: `person-${id}`, field: 'lastContactReminderSent' },
+    logMeta: {},
+  };
+}
+
+describe('dispatchAll', () => {
+  beforeEach(() => {
+    mocks.isEmailConfigured.mockReset();
+    mocks.sendEmailBatch.mockReset();
+    mocks.isEmailConfigured.mockReturnValue(true);
+  });
+
+  it('sends every email in a single batch call so Resend batching is preserved', async () => {
+    mocks.sendEmailBatch.mockResolvedValue({
+      success: true,
+      results: [{ success: true }, { success: true }, { success: true }],
+    });
+
+    await dispatchAll([envelope('1'), envelope('2'), envelope('3')]);
+
+    expect(mocks.sendEmailBatch).toHaveBeenCalledTimes(1);
+    expect(mocks.sendEmailBatch.mock.calls[0][0]).toHaveLength(3);
+  });
+
+  it('marks a delivered envelope as stampable', async () => {
+    mocks.sendEmailBatch.mockResolvedValue({ success: true, results: [{ success: true }] });
+
+    const [result] = await dispatchAll([envelope('1')]);
+
+    expect(result).toEqual({ delivered: 1, failed: 0, skipped: 0, shouldStamp: true });
+  });
+
+  it('does NOT stamp when email is not configured, so the send is not burned', async () => {
+    mocks.isEmailConfigured.mockReturnValue(false);
+
+    const [result] = await dispatchAll([envelope('1')]);
+
+    expect(result).toEqual({ delivered: 0, failed: 0, skipped: 1, shouldStamp: false });
+    expect(mocks.sendEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it('does NOT stamp when the provider reports the send as skipped', async () => {
+    mocks.sendEmailBatch.mockResolvedValue({
+      success: true,
+      results: [{ success: true, skipped: true, message: 'Email not configured' }],
+    });
+
+    const [result] = await dispatchAll([envelope('1')]);
+
+    expect(result.shouldStamp).toBe(false);
+    expect(result.skipped).toBe(1);
+    expect(result.delivered).toBe(0);
+  });
+
+  it('does NOT stamp a failed send', async () => {
+    mocks.sendEmailBatch.mockResolvedValue({
+      success: false,
+      results: [{ success: false, error: 'smtp refused' }],
+    });
+
+    const [result] = await dispatchAll([envelope('1')]);
+
+    expect(result).toEqual({ delivered: 0, failed: 1, skipped: 0, shouldStamp: false });
+  });
+
+  it('returns one result per envelope in input order', async () => {
+    mocks.sendEmailBatch.mockResolvedValue({
+      success: false,
+      results: [{ success: true }, { success: false, error: 'nope' }, { success: true }],
+    });
+
+    const results = await dispatchAll([envelope('1'), envelope('2'), envelope('3')]);
+
+    expect(results.map((r) => r.shouldStamp)).toEqual([true, false, true]);
+  });
+
+  it('returns an empty array and sends nothing for no envelopes', async () => {
+    const results = await dispatchAll([]);
+
+    expect(results).toEqual([]);
+    expect(mocks.sendEmailBatch).not.toHaveBeenCalled();
+  });
+
+  it('treats a thrown batch send as a failure for every envelope rather than crashing the cron', async () => {
+    mocks.sendEmailBatch.mockRejectedValue(new Error('connection reset'));
+
+    const results = await dispatchAll([envelope('1'), envelope('2')]);
+
+    expect(results.every((r) => r.failed === 1 && r.shouldStamp === false)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Groundwork for delivering reminders somewhere other than email. The nightly cron no longer builds and sends emails inline; it builds channel-agnostic envelopes and hands them to a dispatcher.

**Email remains the only channel and there is no user-visible change.** Later phases add web push, ntfy, and signed outgoing webhooks on this seam.

### What changed

- New `lib/notifications/`: `types.ts` (the envelope), `channels/email.ts` (wraps the existing `emailTemplates` untouched), `dispatch.ts` (target resolution and result merge).
- `app/api/cron/send-reminders/route.ts`: the four collection loops now push envelopes instead of rendered emails. The send-and-stamp block became a `dispatchAll` call plus a data-driven update.
- The four-branch stamping `if/else` is replaced by a `StampTarget` discriminated union, so an impossible model and column pair cannot be constructed, and adding one is a compile error rather than a silent no-op stamp.

### Why it is safe

The pre-refactor behaviour is the specification here, and it was checked case by case against `master`:

- The stamp predicate is unchanged. Old: `!result.skipped && result.success`. New: `shouldStamp`, which is `delivered > 0`, which with one channel is the same predicate. This matters because a reminder stamped as sent when nothing was delivered is unrecoverable: it burns the day-of reminder for that occurrence, the digest for that week, or the lead reminder for its whole lead window.
- All four stamp target columns, all four counters (`sentCount`, `errorCount`, `skippedCount`, `digestsSent`), and all four envelope field mappings match.
- Resend batching is preserved: emails still go out in one `sendEmailBatch` call.
- The entire existing cron test suite passes.

### Two robustness improvements over master

- A template that throws for one user no longer aborts delivery for everyone else in that run. Rendering uses `Promise.allSettled`, so exactly one envelope degrades to a failure.
- A short `batch.results` array no longer crashes the run with a `TypeError` partway through, after some reminders have already been stamped.

### Deliberate deviations worth knowing about

- `tests/api/cron-reminders-unsubscribe.test.ts` is modified, in a PR that otherwise promises none. It mocks `lib/email` by wholesale replacement rather than spreading `...actual`, so it lacked members the new code path imports. **Only members were added; no assertion was changed, weakened, or removed.**
- Per-kind log messages (`Lead reminder sent`, `Weekly digest sent`, `Contact reminder sent`) are consolidated into `Reminder sent` plus a `kind` field. Structured logging is the better shape, but it will break any log-based alert grepping the old strings.
- Weekly digest render failures now count toward `errorCount` instead of being silently skipped. Better signal, but it is a counter-semantics change.

### Follow-ups, deliberately not in this PR

- `cronJobLog` reports `completed` even when `errorCount > 0`. This is pre-existing (master does it too) and is worth its own change emitting `completed_with_errors`, matching what `cron-geocode` already does.
- Stale `docs/dist/` and `docs/.astro/` build output can break `npm run lint`. Those paths should be added to the lint ignore config.

## Checklist

- [x] I've run tests locally (or explain why not)
- [x] I've updated documentation where needed
- [x] I've added/updated tests for the change (if applicable)
- [x] I've considered backwards compatibility / migrations (if applicable)
- [x] **I've added/updated translations in ALL locale files** for any new or modified user-facing strings

Notes on the checklist:

- `npm run verify` is green: lint, typecheck, 219 test files / 3055 tests, and a production build. Sixteen new tests, covering the email driver, the dispatcher's stamp matrix, render-failure isolation, and the `digestsSent` invariant.
- No documentation change is owed. There is no user-facing behaviour change, no configuration change, and no API change, so CLAUDE.md rules 6 and 8 are not triggered.
- No locale change is owed. This PR introduces no user-facing strings.
- No migration. The schema is untouched.

## Screenshots (if UI changes)

None. No UI change.

## Related issues

None.