### PR TITLE
fix(security): resolve the client IP from a declared trusted proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,15 +185,26 @@ CRON_SECRET=your-cron-secret-here-minimum-16-characters
 # you have confirmed your proxy replaces X-Real-IP (e.g.
 # `proxy_set_header X-Real-IP $remote_addr;`) but does NOT also manage
 # X-Forwarded-For; check your proxy's own config, this cannot be guessed
-# safely. See docs/self-hosting/reverse-proxy.md for how to tell which
-# applies to you.
+# safely. Set to 'cf-connecting-ip' if Cloudflare sits in front of your
+# origin: Cloudflare overwrites CF-Connecting-IP with the visitor address on
+# every request, so there is no hop count to get wrong. That mode is only
+# safe if the origin refuses connections that did not come from Cloudflare
+# (IP allowlist, Authenticated Origin Pulls, or a Cloudflare Tunnel) --
+# without that, this setting is worse than the default, since there is no
+# chain to disagree with a forged header. Do NOT use 'x-real-ip' behind
+# Cloudflare: an origin proxy's X-Real-IP records the Cloudflare edge
+# address, not the visitor, so every visitor through the same edge would
+# share one bucket. See docs/self-hosting/reverse-proxy.md for how to tell
+# which value applies to you.
 # TRUSTED_PROXY_HEADER=x-forwarded-for
 #
 # TRUSTED_PROXY_COUNT: number of reverse proxy hops to trust. Only applies
-# when TRUSTED_PROXY_HEADER is x-forwarded-for (a single x-real-ip value has
-# no chain of hops to count). Default: 1, matching a single nginx or Caddy
-# in front of the app. Set to 0 if there is no reverse proxy at all. Set to
-# 2 if you also have a CDN or load balancer in front of that proxy.
+# when TRUSTED_PROXY_HEADER is x-forwarded-for (a single x-real-ip or
+# cf-connecting-ip value has no chain of hops to count). Default: 1,
+# matching a single nginx or Caddy in front of the app. Set to 0 if there is
+# no reverse proxy at all. Set to 2 if you also have a CDN or load balancer
+# in front of that proxy (for Cloudflare specifically, prefer
+# TRUSTED_PROXY_HEADER=cf-connecting-ip above instead of counting it).
 # TRUSTED_PROXY_COUNT=1
 
 # ===========================================

--- a/.env.example
+++ b/.env.example
@@ -165,22 +165,35 @@ CRON_SECRET=your-cron-secret-here-minimum-16-characters
 # PHOTO_QUALITY=80
 
 # ===========================================
-# Optional: Trusted Reverse Proxy Count
+# Optional: Trusted Reverse Proxy Configuration
 # ===========================================
-# Number of reverse proxy hops in front of this app that are trusted to
-# append to X-Forwarded-For. Rate limiting reads the client IP from that
-# header, which is otherwise attacker-controlled, so this count is what
-# tells the app which entry in the header chain to believe. X-Real-IP is
-# never trusted for this, even if your proxy also sets it: your proxy MUST
-# manage X-Forwarded-For (both documented configs do).
+# Rate limiting reads the client IP from a header your reverse proxy sets,
+# which is otherwise attacker-controlled. Two settings tell the app how to
+# trust it. Getting either wrong does not silently trust an attacker: it
+# degrades to a single shared rate-limit bucket and logs a warning naming
+# both settings.
+#
 # This only protects rate limiting if the app cannot be reached except
 # through that proxy. If you publish this app's port directly (the
 # docker-compose.yml default), anyone who can reach it bypasses this
 # entirely; bind to 127.0.0.1 instead once you have a proxy in front (see
 # docker-compose.yml).
-# Default: 1, which matches a single nginx or Caddy in front of the app (see
-# the reverse proxy docs). Set to 0 if there is no reverse proxy at all.
-# Set to 2 if you also have a CDN or load balancer in front of that proxy.
+#
+# TRUSTED_PROXY_HEADER: which header your proxy actually manages.
+# 'x-forwarded-for' (default) matches both documented reverse-proxy configs
+# (nginx with proxy_add_x_forwarded_for, Caddy). Set to 'x-real-ip' only if
+# you have confirmed your proxy replaces X-Real-IP (e.g.
+# `proxy_set_header X-Real-IP $remote_addr;`) but does NOT also manage
+# X-Forwarded-For; check your proxy's own config, this cannot be guessed
+# safely. See docs/self-hosting/reverse-proxy.md for how to tell which
+# applies to you.
+# TRUSTED_PROXY_HEADER=x-forwarded-for
+#
+# TRUSTED_PROXY_COUNT: number of reverse proxy hops to trust. Only applies
+# when TRUSTED_PROXY_HEADER is x-forwarded-for (a single x-real-ip value has
+# no chain of hops to count). Default: 1, matching a single nginx or Caddy
+# in front of the app. Set to 0 if there is no reverse proxy at all. Set to
+# 2 if you also have a CDN or load balancer in front of that proxy.
 # TRUSTED_PROXY_COUNT=1
 
 # ===========================================

--- a/.env.example
+++ b/.env.example
@@ -165,6 +165,18 @@ CRON_SECRET=your-cron-secret-here-minimum-16-characters
 # PHOTO_QUALITY=80
 
 # ===========================================
+# Optional: Trusted Reverse Proxy Count
+# ===========================================
+# Number of reverse proxy hops in front of this app that are trusted to set
+# X-Forwarded-For / X-Real-IP. Rate limiting reads the client IP from these
+# headers, which are otherwise attacker-controlled, so this count is what
+# tells the app which entry in the header chain to believe.
+# Default: 1, which matches a single nginx or Caddy in front of the app (see
+# the reverse proxy docs). Set to 0 if there is no reverse proxy at all.
+# Set to 2 if you also have a CDN or load balancer in front of that proxy.
+# TRUSTED_PROXY_COUNT=1
+
+# ===========================================
 # Redis (Rate Limiting & Caching)
 # ===========================================
 # OPTIONAL: Without Redis, the app falls back to in-memory rate limiting:

--- a/.env.example
+++ b/.env.example
@@ -167,10 +167,17 @@ CRON_SECRET=your-cron-secret-here-minimum-16-characters
 # ===========================================
 # Optional: Trusted Reverse Proxy Count
 # ===========================================
-# Number of reverse proxy hops in front of this app that are trusted to set
-# X-Forwarded-For / X-Real-IP. Rate limiting reads the client IP from these
-# headers, which are otherwise attacker-controlled, so this count is what
-# tells the app which entry in the header chain to believe.
+# Number of reverse proxy hops in front of this app that are trusted to
+# append to X-Forwarded-For. Rate limiting reads the client IP from that
+# header, which is otherwise attacker-controlled, so this count is what
+# tells the app which entry in the header chain to believe. X-Real-IP is
+# never trusted for this, even if your proxy also sets it: your proxy MUST
+# manage X-Forwarded-For (both documented configs do).
+# This only protects rate limiting if the app cannot be reached except
+# through that proxy. If you publish this app's port directly (the
+# docker-compose.yml default), anyone who can reach it bypasses this
+# entirely; bind to 127.0.0.1 instead once you have a proxy in front (see
+# docker-compose.yml).
 # Default: 1, which matches a single nginx or Caddy in front of the app (see
 # the reverse proxy docs). Set to 0 if there is no reverse proxy at all.
 # Set to 2 if you also have a CDN or load balancer in front of that proxy.

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -17,12 +17,6 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
-  // Check rate limit
-  const rateLimitResponse = checkRateLimit(request, 'forgotPassword');
-  if (rateLimitResponse) {
-    return rateLimitResponse;
-  }
-
   try {
     if (!isFeatureEnabled('passwordLogin')) {
       return NextResponse.json(
@@ -40,6 +34,14 @@ export const POST = withLogging(async function POST(request: Request) {
 
     // Normalize email to lowercase for case-insensitive lookup
     const email = normalizeEmail(validation.data.email);
+
+    // Rate limit by email (and, when a trusted IP is available, by IP too).
+    // This is a mail-bombing vector: an attacker who rotates the client IP
+    // still shares a bucket with every other request for the same address.
+    const rateLimitResponse = checkRateLimit(request, 'forgotPassword', email);
+    if (rateLimitResponse) {
+      return rateLimitResponse;
+    }
 
     // Find user
     const user = await prisma.user.findUnique({

--- a/app/api/auth/forgot-password/route.ts
+++ b/app/api/auth/forgot-password/route.ts
@@ -17,6 +17,17 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
+  // Unkeyed (IP-only) check before the body is parsed. There is no email to
+  // key on yet at this point, but a request that never becomes a
+  // well-formed, schema-valid body would otherwise hit no rate limit at
+  // all, since the email-keyed check below only runs after parsing
+  // succeeds. This restores the bound that existed before email keying was
+  // added.
+  const preParseRateLimitResponse = checkRateLimit(request, 'forgotPassword');
+  if (preParseRateLimitResponse) {
+    return preParseRateLimitResponse;
+  }
+
   try {
     if (!isFeatureEnabled('passwordLogin')) {
       return NextResponse.json(

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -20,6 +20,17 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
+  // Unkeyed (IP-only) check before the body is parsed. There is no email to
+  // key on yet at this point, but a request that never becomes a
+  // well-formed, schema-valid body would otherwise hit no rate limit at
+  // all, since the email-keyed check below only runs after parsing
+  // succeeds. This restores the bound that existed before email keying was
+  // added.
+  const preParseRateLimitResponse = await checkRateLimit(request, 'register');
+  if (preParseRateLimitResponse) {
+    return preParseRateLimitResponse;
+  }
+
   try {
     // Block password registration when password login is disabled
     if (!isFeatureEnabled('passwordLogin')) {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -20,12 +20,6 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
-  // Check rate limit (async with Redis)
-  const rateLimitResponse = await checkRateLimit(request, 'register');
-  if (rateLimitResponse) {
-    return rateLimitResponse;
-  }
-
   try {
     // Block password registration when password login is disabled
     if (!isFeatureEnabled('passwordLogin')) {
@@ -33,17 +27,6 @@ export const POST = withLogging(async function POST(request: Request) {
         { error: 'Password registration is disabled. Use the configured SSO provider.' },
         { status: 403 }
       );
-    }
-
-    // Check if registration is disabled
-    if (process.env.DISABLE_REGISTRATION === 'true') {
-      const userCount = await prisma.user.count();
-      if (userCount > 0) {
-        return NextResponse.json(
-          { error: 'Registration is currently disabled' },
-          { status: 403 }
-        );
-      }
     }
 
     const body = await parseRequestBody(request);
@@ -57,6 +40,25 @@ export const POST = withLogging(async function POST(request: Request) {
 
     // Normalize email to lowercase to prevent case-sensitivity issues
     const email = normalizeEmail(validation.data.email);
+
+    // Rate limit by email (and, when a trusted IP is available, by IP too).
+    // This is a mail-bombing vector: an attacker who rotates the client IP
+    // still shares a bucket with every other request for the same address.
+    const rateLimitResponse = await checkRateLimit(request, 'register', email);
+    if (rateLimitResponse) {
+      return rateLimitResponse;
+    }
+
+    // Check if registration is disabled
+    if (process.env.DISABLE_REGISTRATION === 'true') {
+      const userCount = await prisma.user.count();
+      if (userCount > 0) {
+        return NextResponse.json(
+          { error: 'Registration is currently disabled' },
+          { status: 403 }
+        );
+      }
+    }
 
     // Check if user already exists
     const existingUser = await prisma.user.findUnique({

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -16,6 +16,17 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
+  // Unkeyed (IP-only) check before the body is parsed. There is no email to
+  // key on yet at this point, but a request that never becomes a
+  // well-formed, schema-valid body would otherwise hit no rate limit at
+  // all, since the email-keyed check below only runs after parsing
+  // succeeds. This restores the bound that existed before email keying was
+  // added.
+  const preParseRateLimitResponse = checkRateLimit(request, 'resendVerification');
+  if (preParseRateLimitResponse) {
+    return preParseRateLimitResponse;
+  }
+
   try {
     const body = await parseRequestBody(request);
     const validation = validateRequest(resendVerificationSchema, body);

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -16,12 +16,6 @@ export const POST = withLogging(async function POST(request: Request) {
     return NextResponse.json({ error: 'Invalid request origin' }, { status: 403 });
   }
 
-  // Check rate limit
-  const rateLimitResponse = checkRateLimit(request, 'resendVerification');
-  if (rateLimitResponse) {
-    return rateLimitResponse;
-  }
-
   try {
     const body = await parseRequestBody(request);
     const validation = validateRequest(resendVerificationSchema, body);
@@ -32,6 +26,14 @@ export const POST = withLogging(async function POST(request: Request) {
 
     // Normalize email to lowercase for case-insensitive lookup
     const email = normalizeEmail(validation.data.email);
+
+    // Rate limit by email (and, when a trusted IP is available, by IP too).
+    // This is a mail-bombing vector: an attacker who rotates the client IP
+    // still shares a bucket with every other request for the same address.
+    const rateLimitResponse = checkRateLimit(request, 'resendVerification', email);
+    if (rateLimitResponse) {
+      return rateLimitResponse;
+    }
 
     // Find user
     const user = await prisma.user.findUnique({

--- a/app/api/cron/carddav-sync/route.ts
+++ b/app/api/cron/carddav-sync/route.ts
@@ -3,7 +3,8 @@ import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { bidirectionalSync } from '@/lib/carddav/sync';
 import { env } from '@/lib/env';
-import { handleApiError, withLogging, getClientIp } from '@/lib/api-utils';
+import { handleApiError, withLogging } from '@/lib/api-utils';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { runWithContext, updateContext } from '@/lib/logging/context';
@@ -19,7 +20,7 @@ export const GET = withLogging(async function GET(request: Request) {
 
   try {
     if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
-      securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', { endpoint: 'carddav-sync' });
+      securityLogger.authFailure(resolveTrustedClientIp(request) ?? 'unknown', 'Invalid cron secret', { endpoint: 'carddav-sync' });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/app/api/cron/geocode/route.ts
+++ b/app/api/cron/geocode/route.ts
@@ -2,7 +2,8 @@ import { NextResponse } from 'next/server';
 import { randomUUID } from 'node:crypto';
 import { prisma } from '@/lib/prisma';
 import { env } from '@/lib/env';
-import { handleApiError, withLogging, getClientIp } from '@/lib/api-utils';
+import { handleApiError, withLogging } from '@/lib/api-utils';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { updateContext } from '@/lib/logging/context';
@@ -29,7 +30,7 @@ export const GET = withLogging(async function GET(request: Request) {
 
   try {
     if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
-      securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', { endpoint: 'geocode' });
+      securityLogger.authFailure(resolveTrustedClientIp(request) ?? 'unknown', 'Invalid cron secret', { endpoint: 'geocode' });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 

--- a/app/api/cron/purge-deleted/route.ts
+++ b/app/api/cron/purge-deleted/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { prismaIncludingDeleted, prisma } from '@/lib/prisma';
 import { env } from '@/lib/env';
-import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
+import { handleApiError, withLogging } from '@/lib/api-utils';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { logger, securityLogger } from '@/lib/logger';
 import { deletePersonPhotos } from '@/lib/photo-storage';
@@ -17,7 +18,7 @@ export const GET = withLogging(async function GET(request: Request) {
   try {
     // Verify the cron secret
     if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
-      securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
+      securityLogger.authFailure(resolveTrustedClientIp(request) ?? 'unknown', 'Invalid cron secret', {
         endpoint: 'purge-deleted',
       });
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/cron/send-reminders/route.ts
+++ b/app/api/cron/send-reminders/route.ts
@@ -4,7 +4,8 @@ import { dispatchAll } from '@/lib/notifications/dispatch';
 import type { NotificationEnvelope, StampTarget } from '@/lib/notifications/types';
 import { formatGraphName } from '@/lib/nameUtils';
 import { env, getAppUrl } from '@/lib/env';
-import { handleApiError, getClientIp, withLogging } from '@/lib/api-utils';
+import { handleApiError, withLogging } from '@/lib/api-utils';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 import { createModuleLogger, securityLogger } from '@/lib/logger';
 import { createUnsubscribeToken } from '@/lib/unsubscribe-tokens';
@@ -32,7 +33,7 @@ export const GET = withLogging(async function GET(request: Request) {
   try {
     // Verify the cron secret
     if (!hasValidBearerSecret(request, env.CRON_SECRET)) {
-      securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
+      securityLogger.authFailure(resolveTrustedClientIp(request) ?? 'unknown', 'Invalid cron secret', {
         endpoint: 'send-reminders',
       });
       return NextResponse.json(

--- a/app/api/dev/clear-rate-limits/route.ts
+++ b/app/api/dev/clear-rate-limits/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getRedis } from '@/lib/redis';
 import { logger, securityLogger } from '@/lib/logger';
-import { getClientIp, withLogging } from '@/lib/api-utils';
+import { withLogging } from '@/lib/api-utils';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 import { hasValidBearerSecret } from '@/lib/shared-secret';
 
 /**
@@ -20,7 +21,7 @@ import { hasValidBearerSecret } from '@/lib/shared-secret';
  */
 export const DELETE = withLogging(async function DELETE(request: Request) {
   if (!hasValidBearerSecret(request, process.env.CRON_SECRET)) {
-    securityLogger.authFailure(getClientIp(request), 'Invalid cron secret', {
+    securityLogger.authFailure(resolveTrustedClientIp(request) ?? 'unknown', 'Invalid cron secret', {
       endpoint: 'clear-rate-limits',
     });
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,14 +47,14 @@ services:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "service": "nametag"}]'
     ports:
       - 3000:3000
-      # TRUSTED_PROXY_COUNT (see .env.example / docs/self-hosting/reverse-proxy.md)
-      # only protects rate limiting if this port cannot be reached except
-      # through your reverse proxy. Publishing it on all interfaces, as
-      # above, lets anyone who can reach the host bypass the proxy (and the
-      # header it sets) entirely. If you run a reverse proxy in front of
-      # Nametag (recommended for any instance reachable from outside your
-      # own network), bind this to localhost instead so only the proxy on
-      # the same host can reach it:
+      # TRUSTED_PROXY_HEADER / TRUSTED_PROXY_COUNT (see .env.example /
+      # docs/self-hosting/reverse-proxy.md) only protect rate limiting if
+      # this port cannot be reached except through your reverse proxy.
+      # Publishing it on all interfaces, as above, lets anyone who can reach
+      # the host bypass the proxy (and the header it sets) entirely. If you
+      # run a reverse proxy in front of Nametag (recommended for any
+      # instance reachable from outside your own network), bind this to
+      # localhost instead so only the proxy on the same host can reach it:
       #   - "127.0.0.1:3000:3000"
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,15 @@ services:
       com.datadoghq.ad.logs: '[{"source": "nodejs", "service": "nametag"}]'
     ports:
       - 3000:3000
+      # TRUSTED_PROXY_COUNT (see .env.example / docs/self-hosting/reverse-proxy.md)
+      # only protects rate limiting if this port cannot be reached except
+      # through your reverse proxy. Publishing it on all interfaces, as
+      # above, lets anyone who can reach the host bypass the proxy (and the
+      # header it sets) entirely. If you run a reverse proxy in front of
+      # Nametag (recommended for any instance reachable from outside your
+      # own network), bind this to localhost instead so only the proxy on
+      # the same host can reach it:
+      #   - "127.0.0.1:3000:3000"
     env_file:
       - .env
     volumes:

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -97,6 +97,7 @@ If `DATABASE_URL` is set, it takes precedence over the individual `DB_*` variabl
 | `VAPID_PUBLIC_KEY` | Public key for browser push notifications | Not set |
 | `VAPID_PRIVATE_KEY` | Private key for browser push notifications | Not set |
 | `VAPID_SUBJECT` | Contact URI for push services, must be a `mailto:` address | Not set |
+| `TRUSTED_PROXY_COUNT` | Number of trusted reverse proxy hops in front of the app, used to pick the real client IP out of `X-Forwarded-For` for rate limiting | `1` |
 
 ## Web push notifications (VAPID)
 
@@ -115,6 +116,19 @@ Leave all three unset and the push channel stays hidden in Settings. Email remin
 Replacing the keys later invalidates every existing browser subscription at once. Each device has to turn push back on from Settings to start receiving notifications again, so only rotate them when you mean to force that.
 
 The old subscription rows are not removed automatically when you do this. A push service reports a genuinely dead subscription differently from one that just has the wrong key, so the cleanup that prunes dead subscriptions does not fire on a key mismatch. Each device still needs to re-subscribe. After 10 consecutive failed nightly runs against the same device, Nametag stops attempting delivery to it automatically instead of retrying forever. The row is not deleted: re-subscribing that device, or removing it from Settings, are still the only ways to clear it out.
+
+## Trusted proxy count and rate limiting
+
+Every rate limit in Nametag (login, registration, password reset, and more) keys on the client's IP address. A Web `Request` handler has no direct access to the TCP peer address, so the only source for that IP is the `X-Forwarded-For` or `X-Real-IP` header set by whatever reverse proxy sits in front of the app. Both headers can be set by the client itself, so the app has to know how many proxy hops to trust before it can tell a proxy-set value apart from a client-forged one.
+
+`TRUSTED_PROXY_COUNT` is that number. With `X-Forwarded-For`, the app counts from the right: the client's real address is the Nth entry from the end, where N is `TRUSTED_PROXY_COUNT`, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Reading from the left, which looks like the natural choice, is exactly what an attacker-supplied value would occupy.
+
+The default of `1` matches both reverse-proxy configurations in these docs: a single nginx or Caddy instance terminating TLS directly in front of the app. See [Reverse Proxy](/self-hosting/reverse-proxy/) for the concrete number to use with additional layers such as a CDN or load balancer.
+
+Getting this wrong fails in one of two directions:
+
+- **Too low** (for example `0` with a proxy actually in front): the app cannot find a trustworthy header value at all, so every unauthenticated request with no other identifier collapses into one shared rate-limit bucket instance-wide. A single warning is logged the first time this happens; watch for it after changing your proxy setup.
+- **Too high** (for example `2` with only one proxy): the app reads a header entry that is still attacker-controlled, which reintroduces the original problem: an attacker can rotate that value to get a fresh rate-limit bucket on every request.
 
 ## Rotating NEXTAUTH_SECRET
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -97,7 +97,8 @@ If `DATABASE_URL` is set, it takes precedence over the individual `DB_*` variabl
 | `VAPID_PUBLIC_KEY` | Public key for browser push notifications | Not set |
 | `VAPID_PRIVATE_KEY` | Private key for browser push notifications | Not set |
 | `VAPID_SUBJECT` | Contact URI for push services, must be a `mailto:` address | Not set |
-| `TRUSTED_PROXY_COUNT` | Number of trusted reverse proxy hops in front of the app, used to pick the real client IP out of `X-Forwarded-For` for rate limiting | `1` |
+| `TRUSTED_PROXY_HEADER` | Which header your reverse proxy manages for the client IP: `x-forwarded-for` or `x-real-ip` | `x-forwarded-for` |
+| `TRUSTED_PROXY_COUNT` | Number of trusted reverse proxy hops in front of the app, used to pick the real client IP out of `X-Forwarded-For` for rate limiting (ignored when `TRUSTED_PROXY_HEADER` is `x-real-ip`) | `1` |
 
 ## Web push notifications (VAPID)
 
@@ -117,15 +118,24 @@ Replacing the keys later invalidates every existing browser subscription at once
 
 The old subscription rows are not removed automatically when you do this. A push service reports a genuinely dead subscription differently from one that just has the wrong key, so the cleanup that prunes dead subscriptions does not fire on a key mismatch. Each device still needs to re-subscribe. After 10 consecutive failed nightly runs against the same device, Nametag stops attempting delivery to it automatically instead of retrying forever. The row is not deleted: re-subscribing that device, or removing it from Settings, are still the only ways to clear it out.
 
-## Trusted proxy count and rate limiting
+## Trusted proxy configuration and rate limiting
 
-Every rate limit in Nametag (login, registration, password reset, and more) keys on the client's IP address. A Web `Request` handler has no direct access to the TCP peer address, so the only source for that IP is the `X-Forwarded-For` header set by whatever reverse proxy sits in front of the app. That header can be set by the client itself, so the app has to know how many proxy hops to trust before it can tell a proxy-appended value apart from a client-forged one.
+Every rate limit in Nametag (login, registration, password reset, and more) keys on the client's IP address. A Web `Request` handler has no direct access to the TCP peer address, so the only source for that IP is a header set by whatever reverse proxy sits in front of the app, and that header can be set by the client itself if the proxy does not manage it. Two settings tell the app how to trust it: `TRUSTED_PROXY_HEADER` (which header) and `TRUSTED_PROXY_COUNT` (how many hops, when that header is a chain).
 
-**This is only meaningful if the app is unreachable except through that proxy.** Counting trusted hops in a header assumes every request genuinely passed through it. The default `docker-compose.yml` publishes the app's port on every interface, which lets anyone who can reach the host skip the proxy, and the header it sets, entirely. See [Reverse Proxy](/self-hosting/reverse-proxy/#trusted-proxy-count) for how to bind that port to localhost once you have a proxy in front.
+**This is only meaningful if the app is unreachable except through that proxy.** Trusting a header assumes every request genuinely passed through it. The default `docker-compose.yml` publishes the app's port on every interface, which lets anyone who can reach the host skip the proxy, and the header it sets, entirely. See [Reverse Proxy](/self-hosting/reverse-proxy/#trusted-proxy-configuration) for how to bind that port to localhost once you have a proxy in front.
 
-`TRUSTED_PROXY_COUNT` is that number. With `X-Forwarded-For`, the app counts from the right: the client's real address is the Nth entry from the end, where N is `TRUSTED_PROXY_COUNT`, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Reading from the left, which looks like the natural choice, is exactly what an attacker-supplied value would occupy.
+### TRUSTED_PROXY_HEADER: which header your proxy manages
 
-`X-Real-IP` is never used for this, even though it is a common header for a proxy to set and even though the documented Nginx config sets it. A proxy that manages `X-Real-IP` but not `X-Forwarded-For` cannot be distinguished, from header content alone, from a client forging `X-Forwarded-For` directly, so Nametag does not trust `X-Real-IP` as a substitute or a fallback under any configuration. Make sure your reverse proxy explicitly manages `X-Forwarded-For` (both documented configs do); if it only sets `X-Real-IP`, requests resolve to no trusted IP and fall back to the shared bucket described below.
+This cannot be inferred from a request. A proxy that appends to `X-Forwarded-For` and a proxy that only replaces `X-Real-IP` (and never touches `X-Forwarded-For`) can each produce a request that is indistinguishable, by header content alone, from the other: in the second case, whatever `X-Forwarded-For` a client sends passes straight through untouched, so it looks exactly like a value the first kind of proxy would have produced. Guessing which topology applies is wrong for one of the two no matter which way the guess goes, so `TRUSTED_PROXY_HEADER` makes the operator say which one is true instead.
+
+- **`x-forwarded-for`** (default): matches both documented reverse-proxy configs (nginx with `proxy_add_x_forwarded_for`, Caddy). Use this unless you have specifically confirmed your proxy manages `X-Real-IP` instead. See [Reverse Proxy](/self-hosting/reverse-proxy/#which-header-does-your-proxy-actually-manage) for how to check your own proxy's configuration rather than assume.
+- **`x-real-ip`**: for a proxy that replaces `X-Real-IP` (via something like `proxy_set_header X-Real-IP $remote_addr;`) but does not also manage `X-Forwarded-For`. In this mode `X-Forwarded-For` is ignored entirely, since it would be wholly client-supplied; `TRUSTED_PROXY_COUNT` also does not apply, since `X-Real-IP` carries a single replaced value, not a chain of appended hops.
+
+**If your proxy sets neither header**, or `TRUSTED_PROXY_HEADER` points at one your proxy never touches, every request resolves to no trusted IP. Rate limits with no other identifier fall back to a single shared bucket for the whole instance, and a warning naming both settings is logged once. This is a fail-safe degradation, not a silently trusted attacker value.
+
+### TRUSTED_PROXY_COUNT: how many hops to trust
+
+Only applies when `TRUSTED_PROXY_HEADER` is `x-forwarded-for` (the default). The app counts from the right: the client's real address is the Nth entry from the end, where N is `TRUSTED_PROXY_COUNT`, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Reading from the left, which looks like the natural choice, is exactly what an attacker-supplied value would occupy.
 
 The default of `1` matches both reverse-proxy configurations in these docs: a single nginx or Caddy instance terminating TLS directly in front of the app. See [Reverse Proxy](/self-hosting/reverse-proxy/) for the concrete number to use with additional layers such as a CDN or load balancer.
 
@@ -134,7 +144,7 @@ Getting the count wrong produces the same symptom in both directions: a warning 
 - **Too low** (for example `0` with a proxy actually in front, or `1` with two proxies in front): the app cannot find enough trustworthy header entries, so every unauthenticated request with no other identifier collapses into the shared bucket. A single warning is logged the first time this happens; watch for it after changing your proxy setup.
 - **Too high** (for example `2` with only one proxy): this causes both problems at once, not just one. An attacker who supplies extra `X-Forwarded-For` entries gets an entry that a client, not a proxy, put there, the exact spoofing this setting exists to prevent. An honest client, who normally sends no `X-Forwarded-For` of their own, has too few entries for the configured count and also falls into the shared bucket, exactly like the "too low" case above.
 
-A proxy that writes something other than a bare IP address, such as an `ip:port` pair (seen on some Azure App Service configurations) or a bracketed IPv6 literal (seen on some HAProxy and IIS setups), also resolves to no trusted IP. Nametag validates that the resolved value is a plain IP address before trusting it, rather than assuming the format.
+A proxy that writes something other than a bare IP address to whichever header is configured, such as an `ip:port` pair (seen on some Azure App Service configurations) or a bracketed IPv6 literal (seen on some HAProxy and IIS setups), also resolves to no trusted IP. Nametag validates that the resolved value is a plain IP address before trusting it, rather than assuming the format.
 
 ## Rotating NEXTAUTH_SECRET
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -97,7 +97,7 @@ If `DATABASE_URL` is set, it takes precedence over the individual `DB_*` variabl
 | `VAPID_PUBLIC_KEY` | Public key for browser push notifications | Not set |
 | `VAPID_PRIVATE_KEY` | Private key for browser push notifications | Not set |
 | `VAPID_SUBJECT` | Contact URI for push services, must be a `mailto:` address | Not set |
-| `TRUSTED_PROXY_HEADER` | Which header your reverse proxy manages for the client IP: `x-forwarded-for` or `x-real-ip` | `x-forwarded-for` |
+| `TRUSTED_PROXY_HEADER` | Which header your reverse proxy manages for the client IP: `x-forwarded-for`, `x-real-ip`, or `cf-connecting-ip` | `x-forwarded-for` |
 | `TRUSTED_PROXY_COUNT` | Number of trusted reverse proxy hops in front of the app, used to pick the real client IP out of `X-Forwarded-For` for rate limiting (ignored when `TRUSTED_PROXY_HEADER` is `x-real-ip`) | `1` |
 
 ## Web push notifications (VAPID)
@@ -128,16 +128,17 @@ Every rate limit in Nametag (login, registration, password reset, and more) keys
 
 This cannot be inferred from a request. A proxy that appends to `X-Forwarded-For` and a proxy that only replaces `X-Real-IP` (and never touches `X-Forwarded-For`) can each produce a request that is indistinguishable, by header content alone, from the other: in the second case, whatever `X-Forwarded-For` a client sends passes straight through untouched, so it looks exactly like a value the first kind of proxy would have produced. Guessing which topology applies is wrong for one of the two no matter which way the guess goes, so `TRUSTED_PROXY_HEADER` makes the operator say which one is true instead.
 
-- **`x-forwarded-for`** (default): matches both documented reverse-proxy configs (nginx with `proxy_add_x_forwarded_for`, Caddy). Use this unless you have specifically confirmed your proxy manages `X-Real-IP` instead. See [Reverse Proxy](/self-hosting/reverse-proxy/#which-header-does-your-proxy-actually-manage) for how to check your own proxy's configuration rather than assume.
-- **`x-real-ip`**: for a proxy that replaces `X-Real-IP` (via something like `proxy_set_header X-Real-IP $remote_addr;`) but does not also manage `X-Forwarded-For`. In this mode `X-Forwarded-For` is ignored entirely, since it would be wholly client-supplied; `TRUSTED_PROXY_COUNT` also does not apply, since `X-Real-IP` carries a single replaced value, not a chain of appended hops.
+- **`x-forwarded-for`** (default): matches both documented reverse-proxy configs (nginx with `proxy_add_x_forwarded_for`, Caddy). Use this unless you have specifically confirmed your proxy manages `X-Real-IP` or is Cloudflare. See [Reverse Proxy](/self-hosting/reverse-proxy/#which-header-does-your-proxy-actually-manage) for how to check your own proxy's configuration rather than assume.
+- **`x-real-ip`**: for a proxy that replaces `X-Real-IP` (via something like `proxy_set_header X-Real-IP $remote_addr;`) but does not also manage `X-Forwarded-For`. In this mode `X-Forwarded-For` is ignored entirely, since it would be wholly client-supplied; `TRUSTED_PROXY_COUNT` also does not apply, since `X-Real-IP` carries a single replaced value, not a chain of appended hops. **Do not use this behind Cloudflare**: an origin proxy's `X-Real-IP` records the Cloudflare edge address, not the visitor, so every visitor through the same edge shares one bucket. See [Cloudflare](/self-hosting/reverse-proxy/#cloudflare) for the correct option.
+- **`cf-connecting-ip`**: for deployments behind Cloudflare, which overwrites `CF-Connecting-IP` with the visitor's address on every request rather than appending to it, so there is no hop count to get wrong (`TRUSTED_PROXY_COUNT` does not apply here either). This mode's entire security model is that the origin refuses connections that did not come from Cloudflare; see [Cloudflare](/self-hosting/reverse-proxy/#cloudflare) for why that precondition is not optional and the three ways to enforce it.
 
-**If your proxy sets neither header**, or `TRUSTED_PROXY_HEADER` points at one your proxy never touches, every request resolves to no trusted IP. Rate limits with no other identifier fall back to a single shared bucket for the whole instance, and a warning naming both settings is logged once. This is a fail-safe degradation, not a silently trusted attacker value.
+**If your proxy sets none of these headers**, or `TRUSTED_PROXY_HEADER` points at one your proxy never touches, every request resolves to no trusted IP. Rate limits with no other identifier fall back to a single shared bucket for the whole instance, and a warning naming both settings is logged once. This is a fail-safe degradation, not a silently trusted attacker value.
 
 ### TRUSTED_PROXY_COUNT: how many hops to trust
 
 Only applies when `TRUSTED_PROXY_HEADER` is `x-forwarded-for` (the default). The app counts from the right: the client's real address is the Nth entry from the end, where N is `TRUSTED_PROXY_COUNT`, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Reading from the left, which looks like the natural choice, is exactly what an attacker-supplied value would occupy.
 
-The default of `1` matches both reverse-proxy configurations in these docs: a single nginx or Caddy instance terminating TLS directly in front of the app. See [Reverse Proxy](/self-hosting/reverse-proxy/) for the concrete number to use with additional layers such as a CDN or load balancer.
+The default of `1` matches both reverse-proxy configurations in these docs: a single nginx or Caddy instance terminating TLS directly in front of the app. See [Reverse Proxy](/self-hosting/reverse-proxy/) for the concrete number to use with additional layers such as a load balancer. If that additional layer is specifically Cloudflare, `TRUSTED_PROXY_HEADER=cf-connecting-ip` above is a better fit than counting it as a hop; see [Cloudflare](/self-hosting/reverse-proxy/#cloudflare).
 
 Getting the count wrong produces the same symptom in both directions: a warning in the logs, and requests falling into a single shared rate-limit bucket for the whole instance.
 

--- a/docs/src/content/docs/self-hosting/configuration.md
+++ b/docs/src/content/docs/self-hosting/configuration.md
@@ -119,16 +119,22 @@ The old subscription rows are not removed automatically when you do this. A push
 
 ## Trusted proxy count and rate limiting
 
-Every rate limit in Nametag (login, registration, password reset, and more) keys on the client's IP address. A Web `Request` handler has no direct access to the TCP peer address, so the only source for that IP is the `X-Forwarded-For` or `X-Real-IP` header set by whatever reverse proxy sits in front of the app. Both headers can be set by the client itself, so the app has to know how many proxy hops to trust before it can tell a proxy-set value apart from a client-forged one.
+Every rate limit in Nametag (login, registration, password reset, and more) keys on the client's IP address. A Web `Request` handler has no direct access to the TCP peer address, so the only source for that IP is the `X-Forwarded-For` header set by whatever reverse proxy sits in front of the app. That header can be set by the client itself, so the app has to know how many proxy hops to trust before it can tell a proxy-appended value apart from a client-forged one.
+
+**This is only meaningful if the app is unreachable except through that proxy.** Counting trusted hops in a header assumes every request genuinely passed through it. The default `docker-compose.yml` publishes the app's port on every interface, which lets anyone who can reach the host skip the proxy, and the header it sets, entirely. See [Reverse Proxy](/self-hosting/reverse-proxy/#trusted-proxy-count) for how to bind that port to localhost once you have a proxy in front.
 
 `TRUSTED_PROXY_COUNT` is that number. With `X-Forwarded-For`, the app counts from the right: the client's real address is the Nth entry from the end, where N is `TRUSTED_PROXY_COUNT`, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Reading from the left, which looks like the natural choice, is exactly what an attacker-supplied value would occupy.
 
+`X-Real-IP` is never used for this, even though it is a common header for a proxy to set and even though the documented Nginx config sets it. A proxy that manages `X-Real-IP` but not `X-Forwarded-For` cannot be distinguished, from header content alone, from a client forging `X-Forwarded-For` directly, so Nametag does not trust `X-Real-IP` as a substitute or a fallback under any configuration. Make sure your reverse proxy explicitly manages `X-Forwarded-For` (both documented configs do); if it only sets `X-Real-IP`, requests resolve to no trusted IP and fall back to the shared bucket described below.
+
 The default of `1` matches both reverse-proxy configurations in these docs: a single nginx or Caddy instance terminating TLS directly in front of the app. See [Reverse Proxy](/self-hosting/reverse-proxy/) for the concrete number to use with additional layers such as a CDN or load balancer.
 
-Getting this wrong fails in one of two directions:
+Getting the count wrong produces the same symptom in both directions: a warning in the logs, and requests falling into a single shared rate-limit bucket for the whole instance.
 
-- **Too low** (for example `0` with a proxy actually in front): the app cannot find a trustworthy header value at all, so every unauthenticated request with no other identifier collapses into one shared rate-limit bucket instance-wide. A single warning is logged the first time this happens; watch for it after changing your proxy setup.
-- **Too high** (for example `2` with only one proxy): the app reads a header entry that is still attacker-controlled, which reintroduces the original problem: an attacker can rotate that value to get a fresh rate-limit bucket on every request.
+- **Too low** (for example `0` with a proxy actually in front, or `1` with two proxies in front): the app cannot find enough trustworthy header entries, so every unauthenticated request with no other identifier collapses into the shared bucket. A single warning is logged the first time this happens; watch for it after changing your proxy setup.
+- **Too high** (for example `2` with only one proxy): this causes both problems at once, not just one. An attacker who supplies extra `X-Forwarded-For` entries gets an entry that a client, not a proxy, put there, the exact spoofing this setting exists to prevent. An honest client, who normally sends no `X-Forwarded-For` of their own, has too few entries for the configured count and also falls into the shared bucket, exactly like the "too low" case above.
+
+A proxy that writes something other than a bare IP address, such as an `ip:port` pair (seen on some Azure App Service configurations) or a bracketed IPv6 literal (seen on some HAProxy and IIS setups), also resolves to no trusted IP. Nametag validates that the resolved value is a plain IP address before trusting it, rather than assuming the format.
 
 ## Rotating NEXTAUTH_SECRET
 

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -53,32 +53,45 @@ Add a second `server` block listening on port 80 that redirects to HTTPS, or han
 certbot certonly --standalone -d yourdomain.com
 ```
 
-## Trusted proxy count
+## Trusted proxy configuration
 
-Nametag's rate limiting (login, registration, password reset, and more) identifies a client by IP address, read from the `X-Forwarded-For` header your proxy sets. That header is otherwise attacker-controlled, so the app needs to know how many proxy hops to trust before it can pick out the real client address: set with `TRUSTED_PROXY_COUNT` (see [Configuration](/self-hosting/configuration/#trusted-proxy-count-and-rate-limiting)).
+Nametag's rate limiting (login, registration, password reset, and more) identifies a client by IP address. A Web `Request` handler has no direct access to the TCP connection, so the only source for that address is a header your reverse proxy sets, and that header is otherwise attacker-controlled. Two settings tell the app how to trust it correctly: `TRUSTED_PROXY_COUNT` and `TRUSTED_PROXY_HEADER` (see [Configuration](/self-hosting/configuration/#trusted-proxy-configuration-and-rate-limiting)).
 
-**This only works if the app cannot be reached except through that proxy.** Counting hops in a header only means something if every request genuinely passed through the proxy that adds them. The `app` service in `docker-compose.yml` publishes port 3000 on every interface by default (`3000:3000`), which anyone on the same network, or the same host, can connect to directly, bypassing your proxy and the header it sets entirely. If you run a reverse proxy in front of Nametag, bind the app's port to localhost instead, so only the proxy on the same host can reach it:
+**This only works if the app cannot be reached except through that proxy.** Trusting a header only means something if every request genuinely passed through the proxy that sets it. The `app` service in `docker-compose.yml` publishes port 3000 on every interface by default (`3000:3000`), which anyone on the same network, or the same host, can connect to directly, bypassing your proxy and the header it sets entirely. If you run a reverse proxy in front of Nametag, bind the app's port to localhost instead, so only the proxy on the same host can reach it:
 
 ```yaml
 ports:
   - "127.0.0.1:3000:3000"
 ```
 
-The compose file ships with a commented example of this next to the `3000:3000` line. This is not something `TRUSTED_PROXY_COUNT` can protect against by itself: it changes which header entry is trusted, not who is allowed to talk to the app directly.
+The compose file ships with a commented example of this next to the `3000:3000` line. This is not something `TRUSTED_PROXY_COUNT` or `TRUSTED_PROXY_HEADER` can protect against by itself: they change which header, and which entry in it, is trusted, not who is allowed to talk to the app directly.
 
-Both configurations above add exactly one trusted hop, and both explicitly manage `X-Forwarded-For`:
+### Which header does your proxy actually manage?
 
-- **Caddy**'s `reverse_proxy` appends to `X-Forwarded-For` automatically.
-- **Nginx**'s `proxy_add_x_forwarded_for` (used above) appends to any existing value rather than replacing it.
+This is not something Nametag can reliably detect from a request: a proxy that appends to `X-Forwarded-For`, and a proxy that only replaces `X-Real-IP` and never touches `X-Forwarded-For` at all, can each produce a request that looks like a valid instance of the other. In the second case, whatever `X-Forwarded-For` a client sends passes straight through untouched, and nothing distinguishes "the proxy added this" from "the client sent exactly this." Guessing is wrong for one of the two setups no matter which way you guess, so you tell Nametag which header your proxy manages with `TRUSTED_PROXY_HEADER`, rather than have it infer one.
 
-`X-Forwarded-For` is the only header Nametag trusts for this. **`X-Real-IP` is never trusted for rate limiting**, even though Nginx's config above also sets it. A proxy that manages `X-Real-IP` but not `X-Forwarded-For` is not a supported configuration: Nametag has no way to tell that setup apart, from the header content alone, from one where a client is forging `X-Forwarded-For` directly, so it resolves to no trusted IP rather than risk trusting the wrong one. The practical effect is a request that falls back to the shared bucket and a warning in the logs, not a silently trusted attacker value, but the underlying misconfiguration still needs fixing: make sure your proxy sets `X-Forwarded-For`, not just `X-Real-IP`.
+To find out which one is true for your proxy, look at your own config, not at this page's examples:
 
-`TRUSTED_PROXY_COUNT` defaults to `1`, which matches both of these as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`. Getting the count wrong in either direction has a real cost, and both directions produce the same symptom (a warning in the logs and a shared bucket), so read the warning as "check this number," not as pointing to one direction specifically:
+- **Nginx**: look for a `proxy_set_header` line. `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` (or the `proxy_add_x_forwarded_for` directive) means your proxy manages `X-Forwarded-For`, use the default. `proxy_set_header X-Real-IP $remote_addr;` **with no line handling `X-Forwarded-For`** means your proxy only manages `X-Real-IP`; set `TRUSTED_PROXY_HEADER=x-real-ip`. The example config below sets both, which means `X-Forwarded-For` is managed (use the default) even though `X-Real-IP` is also set.
+- **Caddy**: `reverse_proxy` manages `X-Forwarded-For` automatically and does not set `X-Real-IP` at all. Use the default.
+- **Any other proxy** (Traefik, HAProxy, a cloud load balancer, etc.): check its documentation or its own configuration for which of these two headers it sets, the same way. If it sets neither, or you cannot tell, treat it as unconfigured: see below.
+
+**If your proxy sets neither header** (or you leave `TRUSTED_PROXY_HEADER` pointed at a header your proxy never touches), Nametag cannot determine a trustworthy client IP for any request. Every rate limit with no other identifier (see [Configuration](/self-hosting/configuration/#trusted-proxy-configuration-and-rate-limiting) for which routes have one) falls back to a single shared bucket for the whole instance, and a warning naming both settings is logged once. This degrades rate limiting; it does not silently trust an attacker-supplied value.
+
+The Nginx config in the [Nginx](#nginx) section above sets both `X-Real-IP` and `X-Forwarded-For`, but only `X-Forwarded-For` is managed the way Nametag needs (appended to, not replaced from a single value): `X-Real-IP` is set there too, but that is incidental to what Nametag reads. Use the default `TRUSTED_PROXY_HEADER` (`x-forwarded-for`) with that config, not `x-real-ip`, even though the header is present.
+
+### TRUSTED_PROXY_COUNT: how many hops to trust
+
+`TRUSTED_PROXY_COUNT` only applies when `TRUSTED_PROXY_HEADER` is `x-forwarded-for` (the default). It counts entries in that header from the right: the client's real address is the `TRUSTED_PROXY_COUNT`th entry from the end, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Both configurations above add exactly one trusted hop, so the default of `1` matches both as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`.
+
+`TRUSTED_PROXY_COUNT` does not apply in `x-real-ip` mode: `X-Real-IP` is a single value a proxy replaces, not a chain of appended hops, so there is nothing to count. A count of `0` still disables trust entirely regardless of which header is configured.
+
+Getting the count wrong in `x-forwarded-for` mode has a real cost in either direction, and both directions produce the same symptom (a warning in the logs and a shared bucket), so read the warning as "check this number," not as pointing to one direction specifically:
 
 - **Too low** (for example `0`, or `1` with two proxies in front): the app cannot trust any part of the header, so every rate limit with no other identifier degrades to a single instance-wide shared bucket for every client.
 - **Too high** (for example `2` with only one proxy): this produces both failure modes at once, not just one. A request from an attacker who supplies extra `X-Forwarded-For` entries gets an entry that a client, not a proxy, put there, the exact spoofing this setting exists to prevent. A request from an honest client, who normally sends no `X-Forwarded-For` at all, has too few entries for the configured count and also falls back to the shared bucket, exactly like the "too low" case.
 
-A proxy that writes something other than a bare IP address to `X-Forwarded-For` or `X-Real-IP` also resolves to no trusted IP and falls back to the shared bucket. This includes an `ip:port` pair (some Azure App Service configurations do this) and a bracketed IPv6 literal from some HAProxy or IIS setups. Nametag validates the resolved value is a plain IP address before trusting it, rather than assuming the format.
+A proxy that writes something other than a bare IP address to whichever header is configured also resolves to no trusted IP and falls back to the shared bucket. This includes an `ip:port` pair (some Azure App Service configurations do this) and a bracketed IPv6 literal from some HAProxy or IIS setups. Nametag validates the resolved value is a plain IP address before trusting it, rather than assuming the format.
 
 ## After adding a proxy
 

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -74,6 +74,7 @@ To find out which one is true for your proxy, look at your own config, not at th
 
 - **Nginx**: look for a `proxy_set_header` line. `proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;` (or the `proxy_add_x_forwarded_for` directive) means your proxy manages `X-Forwarded-For`, use the default. `proxy_set_header X-Real-IP $remote_addr;` **with no line handling `X-Forwarded-For`** means your proxy only manages `X-Real-IP`; set `TRUSTED_PROXY_HEADER=x-real-ip`. The example config below sets both, which means `X-Forwarded-For` is managed (use the default) even though `X-Real-IP` is also set.
 - **Caddy**: `reverse_proxy` manages `X-Forwarded-For` automatically and does not set `X-Real-IP` at all. Use the default.
+- **Cloudflare**: has its own, better option. See [Cloudflare](#cloudflare) below rather than picking between the two headers above.
 - **Any other proxy** (Traefik, HAProxy, a cloud load balancer, etc.): check its documentation or its own configuration for which of these two headers it sets, the same way. If it sets neither, or you cannot tell, treat it as unconfigured: see below.
 
 **If your proxy sets neither header** (or you leave `TRUSTED_PROXY_HEADER` pointed at a header your proxy never touches), Nametag cannot determine a trustworthy client IP for any request. Every rate limit with no other identifier (see [Configuration](/self-hosting/configuration/#trusted-proxy-configuration-and-rate-limiting) for which routes have one) falls back to a single shared bucket for the whole instance, and a warning naming both settings is logged once. This degrades rate limiting; it does not silently trust an attacker-supplied value.
@@ -82,9 +83,9 @@ The Nginx config in the [Nginx](#nginx) section above sets both `X-Real-IP` and 
 
 ### TRUSTED_PROXY_COUNT: how many hops to trust
 
-`TRUSTED_PROXY_COUNT` only applies when `TRUSTED_PROXY_HEADER` is `x-forwarded-for` (the default). It counts entries in that header from the right: the client's real address is the `TRUSTED_PROXY_COUNT`th entry from the end, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Both configurations above add exactly one trusted hop, so the default of `1` matches both as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`.
+`TRUSTED_PROXY_COUNT` only applies when `TRUSTED_PROXY_HEADER` is `x-forwarded-for` (the default). It counts entries in that header from the right: the client's real address is the `TRUSTED_PROXY_COUNT`th entry from the end, because each proxy hop appends its own view of the connection to the end of the header rather than replacing it. Both configurations above add exactly one trusted hop, so the default of `1` matches both as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`. If that additional hop is specifically Cloudflare, see [Cloudflare](#cloudflare) below for a better option than counting hops at all.
 
-`TRUSTED_PROXY_COUNT` does not apply in `x-real-ip` mode: `X-Real-IP` is a single value a proxy replaces, not a chain of appended hops, so there is nothing to count. A count of `0` still disables trust entirely regardless of which header is configured.
+`TRUSTED_PROXY_COUNT` does not apply in `x-real-ip` or `cf-connecting-ip` mode: both carry a single value a proxy replaces or overwrites, not a chain of appended hops, so there is nothing to count. A count of `0` still disables trust entirely regardless of which header is configured.
 
 Getting the count wrong in `x-forwarded-for` mode has a real cost in either direction, and both directions produce the same symptom (a warning in the logs and a shared bucket), so read the warning as "check this number," not as pointing to one direction specifically:
 
@@ -92,6 +93,22 @@ Getting the count wrong in `x-forwarded-for` mode has a real cost in either dire
 - **Too high** (for example `2` with only one proxy): this produces both failure modes at once, not just one. A request from an attacker who supplies extra `X-Forwarded-For` entries gets an entry that a client, not a proxy, put there, the exact spoofing this setting exists to prevent. A request from an honest client, who normally sends no `X-Forwarded-For` at all, has too few entries for the configured count and also falls back to the shared bucket, exactly like the "too low" case.
 
 A proxy that writes something other than a bare IP address to whichever header is configured also resolves to no trusted IP and falls back to the shared bucket. This includes an `ip:port` pair (some Azure App Service configurations do this) and a bracketed IPv6 literal from some HAProxy or IIS setups. Nametag validates the resolved value is a plain IP address before trusting it, rather than assuming the format.
+
+## Cloudflare
+
+If Cloudflare sits in front of your origin, `cf-connecting-ip` is the better choice over the header/count combination above, and it is what nametag.one itself uses.
+
+**Recommended: `TRUSTED_PROXY_HEADER=cf-connecting-ip`.** Cloudflare overwrites `CF-Connecting-IP` with the visitor's address on every request rather than appending to it, so there is no hop count to get right or wrong, and no need to recount if you later add or remove a layer (for example, an additional reverse proxy between Cloudflare and the app). `TRUSTED_PROXY_COUNT` is ignored in this mode.
+
+This mode's entire security model depends on one thing this setting cannot enforce by itself: **the origin must refuse any connection that did not come from Cloudflare.** If the app is reachable directly, by IP or by a domain that bypasses Cloudflare, anyone can set `CF-Connecting-IP` to whatever they like and Nametag will trust it completely; there is no chain or count to disagree with them the way there is in `x-forwarded-for` mode with a wrong count. This is not optional hardening for this mode, it **is** the security boundary. Enforce it one of these ways:
+
+- Restrict your origin firewall to [Cloudflare's published IP ranges](https://www.cloudflare.com/ips/), so only Cloudflare's edge can reach the app.
+- Enable [Authenticated Origin Pulls](https://developers.cloudflare.com/ssl/origin-configuration/authenticated-origin-pull/) (mTLS from the edge), so the origin verifies every connection is actually from Cloudflare.
+- Use a [Cloudflare Tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/) so the origin has no public address at all.
+
+**Alternative: leave `TRUSTED_PROXY_HEADER` at its default (`x-forwarded-for`)** and set `TRUSTED_PROXY_COUNT` to match your topology: `2` if Cloudflare reaches your origin through this reverse proxy (Cloudflare, then the proxy, then the app), or `1` if Cloudflare reaches the app directly with no other proxy in between. This works, but the count silently becomes wrong if you ever add or remove a layer, which `cf-connecting-ip` mode does not suffer from.
+
+**`x-real-ip` is the wrong choice behind Cloudflare, and it is worth naming because it looks plausible.** An origin Nginx setting `proxy_set_header X-Real-IP $remote_addr;` records the address of whatever connected to it directly, which behind Cloudflare is the **Cloudflare edge**, not the visitor. Every visitor arriving through the same edge node would then share a single rate-limit bucket, since they would all resolve to the same `X-Real-IP` value. Use `cf-connecting-ip` or the `x-forwarded-for` count instead.
 
 ## After adding a proxy
 

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -57,12 +57,28 @@ certbot certonly --standalone -d yourdomain.com
 
 Nametag's rate limiting (login, registration, password reset, and more) identifies a client by IP address, read from the `X-Forwarded-For` header your proxy sets. That header is otherwise attacker-controlled, so the app needs to know how many proxy hops to trust before it can pick out the real client address: set with `TRUSTED_PROXY_COUNT` (see [Configuration](/self-hosting/configuration/#trusted-proxy-count-and-rate-limiting)).
 
-Both configurations above add exactly one trusted hop:
+**This only works if the app cannot be reached except through that proxy.** Counting hops in a header only means something if every request genuinely passed through the proxy that adds them. The `app` service in `docker-compose.yml` publishes port 3000 on every interface by default (`3000:3000`), which anyone on the same network, or the same host, can connect to directly, bypassing your proxy and the header it sets entirely. If you run a reverse proxy in front of Nametag, bind the app's port to localhost instead, so only the proxy on the same host can reach it:
+
+```yaml
+ports:
+  - "127.0.0.1:3000:3000"
+```
+
+The compose file ships with a commented example of this next to the `3000:3000` line. This is not something `TRUSTED_PROXY_COUNT` can protect against by itself: it changes which header entry is trusted, not who is allowed to talk to the app directly.
+
+Both configurations above add exactly one trusted hop, and both explicitly manage `X-Forwarded-For`:
 
 - **Caddy**'s `reverse_proxy` appends to `X-Forwarded-For` automatically.
-- **Nginx**'s `proxy_add_x_forwarded_for` (used above) appends to any existing value rather than replacing it, and `X-Real-IP` is set from `$remote_addr`, the connection Nginx itself accepted.
+- **Nginx**'s `proxy_add_x_forwarded_for` (used above) appends to any existing value rather than replacing it.
 
-`TRUSTED_PROXY_COUNT` defaults to `1`, which matches both of these as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`. Getting the count wrong in either direction has a real cost: too low and the app cannot trust any part of the header, and every rate limit with no other identifier degrades to a single instance-wide bucket; too high and it reads an entry that a client, not a proxy, put there, which is the exact spoofing this setting exists to prevent.
+`X-Forwarded-For` is the only header Nametag trusts for this. **`X-Real-IP` is never trusted for rate limiting**, even though Nginx's config above also sets it. A proxy that manages `X-Real-IP` but not `X-Forwarded-For` is not a supported configuration: Nametag has no way to tell that setup apart, from the header content alone, from one where a client is forging `X-Forwarded-For` directly, so it resolves to no trusted IP rather than risk trusting the wrong one. The practical effect is a request that falls back to the shared bucket and a warning in the logs, not a silently trusted attacker value, but the underlying misconfiguration still needs fixing: make sure your proxy sets `X-Forwarded-For`, not just `X-Real-IP`.
+
+`TRUSTED_PROXY_COUNT` defaults to `1`, which matches both of these as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`. Getting the count wrong in either direction has a real cost, and both directions produce the same symptom (a warning in the logs and a shared bucket), so read the warning as "check this number," not as pointing to one direction specifically:
+
+- **Too low** (for example `0`, or `1` with two proxies in front): the app cannot trust any part of the header, so every rate limit with no other identifier degrades to a single instance-wide shared bucket for every client.
+- **Too high** (for example `2` with only one proxy): this produces both failure modes at once, not just one. A request from an attacker who supplies extra `X-Forwarded-For` entries gets an entry that a client, not a proxy, put there, the exact spoofing this setting exists to prevent. A request from an honest client, who normally sends no `X-Forwarded-For` at all, has too few entries for the configured count and also falls back to the shared bucket, exactly like the "too low" case.
+
+A proxy that writes something other than a bare IP address to `X-Forwarded-For` or `X-Real-IP` also resolves to no trusted IP and falls back to the shared bucket. This includes an `ip:port` pair (some Azure App Service configurations do this) and a bracketed IPv6 literal from some HAProxy or IIS setups. Nametag validates the resolved value is a plain IP address before trusting it, rather than assuming the format.
 
 ## After adding a proxy
 

--- a/docs/src/content/docs/self-hosting/reverse-proxy.md
+++ b/docs/src/content/docs/self-hosting/reverse-proxy.md
@@ -53,6 +53,17 @@ Add a second `server` block listening on port 80 that redirects to HTTPS, or han
 certbot certonly --standalone -d yourdomain.com
 ```
 
+## Trusted proxy count
+
+Nametag's rate limiting (login, registration, password reset, and more) identifies a client by IP address, read from the `X-Forwarded-For` header your proxy sets. That header is otherwise attacker-controlled, so the app needs to know how many proxy hops to trust before it can pick out the real client address: set with `TRUSTED_PROXY_COUNT` (see [Configuration](/self-hosting/configuration/#trusted-proxy-count-and-rate-limiting)).
+
+Both configurations above add exactly one trusted hop:
+
+- **Caddy**'s `reverse_proxy` appends to `X-Forwarded-For` automatically.
+- **Nginx**'s `proxy_add_x_forwarded_for` (used above) appends to any existing value rather than replacing it, and `X-Real-IP` is set from `$remote_addr`, the connection Nginx itself accepted.
+
+`TRUSTED_PROXY_COUNT` defaults to `1`, which matches both of these as written. You only need to change it if you add another hop in front of the one shown here, for example a CDN or a separate load balancer terminating TLS before it reaches this Nginx or Caddy instance. In that case, set `TRUSTED_PROXY_COUNT=2`. Getting the count wrong in either direction has a real cost: too low and the app cannot trust any part of the header, and every rate limit with no other identifier degrades to a single instance-wide bucket; too high and it reads an entry that a client, not a proxy, put there, which is the exact spoofing this setting exists to prevent.
+
 ## After adding a proxy
 
 Once Nametag is served over `https://yourdomain.com`, update your `.env`:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,7 +45,12 @@ const eslintConfig = defineConfig([
       "lib/**/*.ts",
       "instrumentation.ts",
     ],
-    ignores: ["lib/env.ts", "lib/client-features.ts", "lib/vcard-helpers.ts"],
+    ignores: [
+      "lib/env.ts",
+      "lib/client-features.ts",
+      "lib/vcard-helpers.ts",
+      "lib/net/client-ip.ts",
+    ],
     rules: {
       "no-console": "warn",
     },

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -6,6 +6,9 @@ import { logger, createModuleLogger } from './logger';
 import { validateOrigin } from '@/lib/csrf';
 import { runWithContext, updateContext } from '@/lib/logging/context';
 import { resolveApiToken } from '@/lib/api-tokens';
+import { getClientIp } from '@/lib/net/client-ip';
+
+export { getClientIp };
 
 /** HTTP methods that read but never mutate. Allowed for read-only API tokens. */
 const READ_ONLY_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);
@@ -204,23 +207,6 @@ export function handleApiError(
     : errorObj.message;
 
   return apiResponse.serverError(message);
-}
-
-/**
- * Get client IP from request for logging purposes
- */
-export function getClientIp(request: Request): string {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    return forwardedFor.split(',')[0].trim();
-  }
-
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
-
-  return 'unknown';
 }
 
 /**

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -7,12 +7,9 @@ import { validateOrigin } from '@/lib/csrf';
 import { runWithContext, updateContext } from '@/lib/logging/context';
 import { resolveApiToken } from '@/lib/api-tokens';
 import {
-  getClientIp,
   resolveTrustedClientIp,
   getRawTrustedProxyHeaderForLogging,
 } from '@/lib/net/client-ip';
-
-export { getClientIp };
 
 /** HTTP methods that read but never mutate. Allowed for read-only API tokens. */
 const READ_ONLY_METHODS = new Set(['GET', 'HEAD', 'OPTIONS']);

--- a/lib/api-utils.ts
+++ b/lib/api-utils.ts
@@ -6,7 +6,11 @@ import { logger, createModuleLogger } from './logger';
 import { validateOrigin } from '@/lib/csrf';
 import { runWithContext, updateContext } from '@/lib/logging/context';
 import { resolveApiToken } from '@/lib/api-tokens';
-import { getClientIp } from '@/lib/net/client-ip';
+import {
+  getClientIp,
+  resolveTrustedClientIp,
+  getRawTrustedProxyHeaderForLogging,
+} from '@/lib/net/client-ip';
 
 export { getClientIp };
 
@@ -275,7 +279,27 @@ export function withLogging<
       const start = Date.now();
       const method = request.method;
       const path = new URL(request.url).pathname;
-      const ip = getClientIp(request);
+
+      // The logged `ip` field must be the value the app actually trusted
+      // for rate limiting, not a client-supplied best-effort guess: a log
+      // line claiming to record "the client" while actually recording
+      // whatever the client typed is worse than no field at all, since it
+      // looks trustworthy without being trustworthy. When resolution fails,
+      // 'unknown' matches the fallback already used for the same case in
+      // lib/rate-limit-redis.ts's securityLogger argument, so there is one
+      // convention for "no trusted IP" across logs rather than two. The raw
+      // header is attached only in that failure case (see
+      // getRawTrustedProxyHeaderForLogging): it is exactly the untrusted
+      // value resolution rejected, useful for diagnosing a wrong
+      // TRUSTED_PROXY_COUNT or TRUSTED_PROXY_HEADER, and would be pure noise
+      // (and a log-flooding vector, since a client controls its length) on
+      // every request that resolves normally.
+      const trustedIp = resolveTrustedClientIp(request);
+      const ip = trustedIp ?? 'unknown';
+      const rawProxyHeader =
+        trustedIp === null ? getRawTrustedProxyHeaderForLogging(request) : undefined;
+      const diagnosticFields =
+        rawProxyHeader !== undefined ? { rawProxyHeader } : {};
 
       try {
         const response = await handler(...args);
@@ -287,6 +311,7 @@ export function withLogging<
             status: response.status,
             durationMs: Date.now() - start,
             ip,
+            ...diagnosticFields,
           },
           `${method} ${path} ${response.status}`
         );
@@ -300,6 +325,7 @@ export function withLogging<
             status: 500,
             durationMs: Date.now() - start,
             ip,
+            ...diagnosticFields,
             err: error instanceof Error ? error : new Error(String(error)),
           },
           `${method} ${path} 500`

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -100,6 +100,18 @@ const envSchema = z.object({
   // front). See docs/self-hosting/reverse-proxy.md for how to choose a
   // different value.
   TRUSTED_PROXY_COUNT: z.coerce.number().int().min(0).default(1),
+
+  // Which header the trusted proxy actually manages. This cannot be
+  // inferred from the request: a proxy that replaces X-Real-IP but never
+  // touches X-Forwarded-For, and a proxy that correctly appends to
+  // X-Forwarded-For, can produce headers that are indistinguishable at
+  // runtime from a single request. Guessing wrong in either direction
+  // trusts an attacker-controlled value, so the operator must say which
+  // header their proxy sets rather than have the app infer it.
+  // Defaults to 'x-forwarded-for', matching both documented reverse-proxy
+  // configs (nginx with proxy_add_x_forwarded_for, Caddy) and preserving
+  // pre-existing behaviour for anyone upgrading without setting this.
+  TRUSTED_PROXY_HEADER: z.enum(['x-forwarded-for', 'x-real-ip']).default('x-forwarded-for'),
 });
 
 /**

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -111,7 +111,15 @@ const envSchema = z.object({
   // Defaults to 'x-forwarded-for', matching both documented reverse-proxy
   // configs (nginx with proxy_add_x_forwarded_for, Caddy) and preserving
   // pre-existing behaviour for anyone upgrading without setting this.
-  TRUSTED_PROXY_HEADER: z.enum(['x-forwarded-for', 'x-real-ip']).default('x-forwarded-for'),
+  // 'cf-connecting-ip' is for deployments behind Cloudflare, which
+  // OVERWRITES CF-Connecting-IP with the visitor address on every request
+  // rather than appending to it. This mode is only sound when the origin
+  // refuses connections that did not come from Cloudflare (IP allowlist,
+  // Authenticated Origin Pulls, or a Cloudflare Tunnel); see
+  // docs/self-hosting/reverse-proxy.md.
+  TRUSTED_PROXY_HEADER: z
+    .enum(['x-forwarded-for', 'x-real-ip', 'cf-connecting-ip'])
+    .default('x-forwarded-for'),
 });
 
 /**

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -93,6 +93,13 @@ const envSchema = z.object({
   VAPID_PUBLIC_KEY: z.string().min(1).optional(),
   VAPID_PRIVATE_KEY: z.string().min(1).optional(),
   VAPID_SUBJECT: z.string().min(1).optional(),
+
+  // Number of reverse proxy hops in front of this app that are trusted to
+  // append to X-Forwarded-For (or set X-Real-IP). Defaults to 1, matching
+  // both documented reverse-proxy configs (a single nginx or Caddy in
+  // front). See docs/self-hosting/reverse-proxy.md for how to choose a
+  // different value.
+  TRUSTED_PROXY_COUNT: z.coerce.number().int().min(0).default(1),
 });
 
 /**

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -255,6 +255,43 @@ function resolveFromCfConnectingIp(request: Request): string | null {
   return net.isIP(trimmed) !== 0 ? trimmed : null;
 }
 
+/**
+ * A client can send an arbitrarily long header value; without a bound, that
+ * is a free way to inflate every log line that includes it. This is
+ * generous enough to hold a realistic x-forwarded-for chain (several dozen
+ * IPv6 addresses) while still capping the worst case.
+ */
+const MAX_LOGGED_RAW_HEADER_LENGTH = 500;
+
+/**
+ * Get the raw value of whichever header TRUSTED_PROXY_HEADER is configured
+ * to read, truncated to a bounded length, for DIAGNOSTIC LOGGING ONLY.
+ *
+ * Callers should only include this in a log entry when
+ * `resolveTrustedClientIp` returned `null` for the same request, never on
+ * every request: this is exactly the raw, untrusted value that resolution
+ * failed to validate, so its only purpose is letting an operator see what
+ * actually arrived and work out the right TRUSTED_PROXY_COUNT or
+ * TRUSTED_PROXY_HEADER value. Logging it unconditionally would both add
+ * noise to every request and let a client inflate every log line by sending
+ * a long header, which the truncation here bounds but does not eliminate on
+ * its own.
+ *
+ * Returns `undefined` (not `null`) when the configured header is absent,
+ * so callers can spread it into a log object and have the key disappear
+ * entirely rather than appearing with an empty value.
+ */
+export function getRawTrustedProxyHeaderForLogging(request: Request): string | undefined {
+  const value = request.headers.get(env.TRUSTED_PROXY_HEADER);
+  if (!value) {
+    return undefined;
+  }
+
+  return value.length > MAX_LOGGED_RAW_HEADER_LENGTH
+    ? `${value.slice(0, MAX_LOGGED_RAW_HEADER_LENGTH)}...(truncated)`
+    : value;
+}
+
 let warnedMissingTrustedIp = false;
 
 /**

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -16,9 +16,32 @@
  * standalone Node server, so a route handler only ever sees a Web `Request`
  * with no peer address attached. The only IP information available at all
  * comes from headers a reverse proxy may set, which means it is only as
- * trustworthy as the proxy configuration in front of the app. `TRUSTED_PROXY_COUNT`
- * (see lib/env.ts) is how an operator tells this module how many proxy hops
- * to trust.
+ * trustworthy as the proxy configuration in front of the app.
+ *
+ * Two settings in lib/env.ts govern this:
+ *
+ * - `TRUSTED_PROXY_COUNT`: how many proxy hops to trust.
+ * - `TRUSTED_PROXY_HEADER`: which single header the trusted proxy actually
+ *   manages, `x-forwarded-for` (default) or `x-real-ip`.
+ *
+ * The header setting exists because the two possible proxy topologies are
+ * indistinguishable from the request alone. A proxy that appends to
+ * `x-forwarded-for` (nginx with `proxy_add_x_forwarded_for`, or Caddy) and a
+ * proxy that only replaces `x-real-ip` (`proxy_set_header X-Real-IP
+ * $remote_addr` with no `x-forwarded-for` handling at all) can each produce
+ * a request that looks, byte for byte, like a syntactically valid instance
+ * of the other topology: in the second case, the client's own
+ * `x-forwarded-for` passes straight through untouched, and there is no way
+ * to tell "the proxy appended this" from "the client sent exactly this and
+ * nothing touched it" by inspecting the header's contents. Earlier versions
+ * of this function tried to infer which topology was in play (prefer
+ * `x-forwarded-for` when present, or fall back to `x-real-ip` when absent)
+ * and each inference was wrong for one of the two topologies: it either let
+ * an `x-real-ip`-only proxy's attacker send a raw `x-forwarded-for` straight
+ * through as if trusted, or it broke honest clients behind an
+ * `x-real-ip`-only proxy by refusing to read the one header that proxy
+ * actually manages. There is no inference that is correct for both, so the
+ * operator declares which one applies instead of the app guessing.
  */
 
 import net from 'net';
@@ -75,74 +98,112 @@ export function resolveTrustedClientIp(request: Request): string | null {
   const trustedProxyCount = env.TRUSTED_PROXY_COUNT;
 
   if (trustedProxyCount === 0) {
-    // No reverse proxy is trusted to have set these headers. Both
-    // x-forwarded-for and x-real-ip come straight from whoever made the
-    // request in that case, so neither is trustworthy for anything.
+    // No reverse proxy is trusted to have set either header, regardless of
+    // TRUSTED_PROXY_HEADER. Both x-forwarded-for and x-real-ip come
+    // straight from whoever made the request in that case, so neither is
+    // trustworthy for anything.
     return null;
   }
 
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    const hops = forwardedFor
-      .split(',')
-      .map((hop) => hop.trim())
-      .filter((hop) => hop.length > 0);
-
-    // The documented reverse-proxy configs (nginx's proxy_add_x_forwarded_for,
-    // Caddy's reverse_proxy) APPEND to any x-forwarded-for value the client
-    // already sent rather than replacing it. A value the client fabricated
-    // therefore always stays on the LEFT, and each proxy hop the request
-    // legitimately passes through adds exactly one real entry on the RIGHT.
-    // With N trusted proxies in front of this app, the real client address is
-    // the Nth entry counting from the right, i.e. index (length - N). Reading
-    // the leftmost entry, which looks like the natural choice, is precisely
-    // the vulnerability this function exists to close: it lets an attacker
-    // pick their own rate-limit bucket just by rotating that value.
-    const clientIndex = hops.length - trustedProxyCount;
-
-    if (clientIndex < 0) {
-      // Fewer hops are present than the configured number of trusted
-      // proxies. Either TRUSTED_PROXY_COUNT does not match this deployment,
-      // or something stripped entries out of the header before it reached
-      // us. Either way we cannot identify which entry, if any, is the real
-      // client, and falling back to the leftmost one would hand back exactly
-      // the attacker-controlled value this function must not return.
-      return null;
-    }
-
-    const candidate = hops[clientIndex];
-
-    // The candidate's position in the header is now trustworthy, but its
-    // content is still attacker-influenced text until validated. An
-    // unvalidated value would become part of a rate-limit bucket key, which
-    // would let an attacker who cannot move the position still poison the
-    // keyspace with garbage instead of an IP.
-    return net.isIP(candidate) !== 0 ? candidate : null;
+  if (env.TRUSTED_PROXY_HEADER === 'x-real-ip') {
+    return resolveFromRealIp(request);
   }
 
-  // x-real-ip is deliberately never consulted here, not even as a fallback
-  // when x-forwarded-for is absent. An earlier version of this function did
-  // exactly that, reasoning that nginx's proxy_set_header (unlike
-  // proxy_add_x_forwarded_for) REPLACES a client-supplied value, so it
-  // should be safe for a single trusted hop. That reasoning only holds for a
-  // proxy that also manages x-forwarded-for. A proxy that sets x-real-ip but
-  // never touches x-forwarded-for (no proxy_add_x_forwarded_for and no
-  // explicit proxy_set_header for it) passes through whatever
-  // x-forwarded-for value the client sent, completely unmodified, and this
-  // function has no way to distinguish that from a proxy that correctly
-  // appends its own view: both look like a syntactically valid header. Once
-  // x-real-ip is trusted as a fallback, a proxy configured exactly that way
-  // hands an attacker's own x-forwarded-for straight through as if it were
-  // trustworthy. The two documented reverse-proxy configs (nginx with
-  // proxy_add_x_forwarded_for, Caddy) both manage x-forwarded-for, so
-  // restricting this function to that one header, and never x-real-ip, keeps
-  // both working. A proxy that manages only x-real-ip does not match the
-  // documented configuration (see docs/self-hosting/reverse-proxy.md); a
-  // request through it resolves to null here, which fails into the shared
-  // bucket and fires warnNoTrustedClientIp rather than silently trusting
-  // whatever the client sent. x-real-ip remains available in getClientIp for
-  // logging, where a best-effort value is fine.
-  return null;
+  return resolveFromForwardedFor(request, trustedProxyCount);
+}
+
+/**
+ * Resolve via x-forwarded-for, counting `trustedProxyCount` entries from the
+ * right. Used when TRUSTED_PROXY_HEADER is 'x-forwarded-for' (the default).
+ *
+ * x-real-ip is not consulted here at all, not even when x-forwarded-for is
+ * absent. An earlier version of this function fell back to x-real-ip in
+ * exactly that case, reasoning that nginx's proxy_set_header (unlike
+ * proxy_add_x_forwarded_for) REPLACES a client-supplied value, so it should
+ * be safe for a single trusted hop. That reasoning is correct on its own,
+ * but it silently assumes the proxy in front is the x-forwarded-for-managing
+ * kind; it says nothing about whether *this* deployment's proxy is that
+ * kind or the x-real-ip-only kind, and the request gives no way to tell the
+ * two apart. Falling back to x-real-ip here means an x-real-ip-only proxy's
+ * attacker, who controls the entirety of x-forwarded-for because that
+ * proxy passes it through untouched, gets treated as trusted purely because
+ * x-forwarded-for happened to be absent from *their specific request*
+ * (typically it would not be, since they are the one crafting it). The only
+ * sound fix is to stop guessing: a deployment behind an x-real-ip-only
+ * proxy sets TRUSTED_PROXY_HEADER=x-real-ip and is handled by
+ * resolveFromRealIp instead, never by this function.
+ */
+function resolveFromForwardedFor(request: Request, trustedProxyCount: number): string | null {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (!forwardedFor) {
+    return null;
+  }
+
+  const hops = forwardedFor
+    .split(',')
+    .map((hop) => hop.trim())
+    .filter((hop) => hop.length > 0);
+
+  // The documented reverse-proxy configs (nginx's proxy_add_x_forwarded_for,
+  // Caddy's reverse_proxy) APPEND to any x-forwarded-for value the client
+  // already sent rather than replacing it. A value the client fabricated
+  // therefore always stays on the LEFT, and each proxy hop the request
+  // legitimately passes through adds exactly one real entry on the RIGHT.
+  // With N trusted proxies in front of this app, the real client address is
+  // the Nth entry counting from the right, i.e. index (length - N). Reading
+  // the leftmost entry, which looks like the natural choice, is precisely
+  // the vulnerability this function exists to close: it lets an attacker
+  // pick their own rate-limit bucket just by rotating that value.
+  const clientIndex = hops.length - trustedProxyCount;
+
+  if (clientIndex < 0) {
+    // Fewer hops are present than the configured number of trusted
+    // proxies. Either TRUSTED_PROXY_COUNT does not match this deployment,
+    // or something stripped entries out of the header before it reached
+    // us. Either way we cannot identify which entry, if any, is the real
+    // client, and falling back to the leftmost one would hand back exactly
+    // the attacker-controlled value this function must not return.
+    return null;
+  }
+
+  const candidate = hops[clientIndex];
+
+  // The candidate's position in the header is now trustworthy, but its
+  // content is still attacker-influenced text until validated. An
+  // unvalidated value would become part of a rate-limit bucket key, which
+  // would let an attacker who cannot move the position still poison the
+  // keyspace with garbage instead of an IP.
+  return net.isIP(candidate) !== 0 ? candidate : null;
+}
+
+/**
+ * Resolve via x-real-ip only. Used when TRUSTED_PROXY_HEADER is
+ * 'x-real-ip', i.e. the operator has declared that their proxy manages this
+ * header (via proxy_set_header, which REPLACES a client-supplied value)
+ * rather than x-forwarded-for.
+ *
+ * x-forwarded-for is not consulted here at all, not even as a fallback. In
+ * this topology the proxy does not manage x-forwarded-for, so any value
+ * present in it passed straight through from the client unmodified: every
+ * entry, at every position, is attacker-controlled. Reading the rightmost
+ * entry the way resolveFromForwardedFor does is no safer here, since an
+ * attacker who knows the count simply sends that many entries and controls
+ * whichever one lands in the trusted position. There is exactly one
+ * trustworthy value in this topology, and it is x-real-ip itself.
+ *
+ * TRUSTED_PROXY_COUNT does not apply to this path (beyond the count === 0
+ * check already handled by the caller). proxy_set_header REPLACES the
+ * header with a single value; there is no chain of appended hops to count
+ * through, only one value that is either the proxy's own or nothing.
+ */
+function resolveFromRealIp(request: Request): string | null {
+  const realIp = request.headers.get('x-real-ip');
+  if (!realIp) {
+    return null;
+  }
+
+  const trimmed = realIp.trim();
+  return net.isIP(trimmed) !== 0 ? trimmed : null;
 }
 
 let warnedMissingTrustedIp = false;
@@ -164,7 +225,9 @@ export function warnNoTrustedClientIp(): void {
   console.warn(
     '[rate-limit] No trusted client IP could be determined for a rate-limited request. ' +
       'Falling back to a single shared bucket for every request with no other ' +
-      'identifier, which weakens rate limiting fleet-wide. Check TRUSTED_PROXY_COUNT: ' +
-      'it must equal the number of reverse proxies in front of Nametag that append to X-Forwarded-For.'
+      'identifier, which weakens rate limiting fleet-wide. Check TRUSTED_PROXY_COUNT ' +
+      '(must equal the number of reverse proxies in front of Nametag) and ' +
+      'TRUSTED_PROXY_HEADER (must match the header your proxy actually manages, ' +
+      'x-forwarded-for or x-real-ip).'
   );
 }

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -20,11 +20,12 @@
  *
  * Two settings in lib/env.ts govern this:
  *
- * - `TRUSTED_PROXY_COUNT`: how many proxy hops to trust.
+ * - `TRUSTED_PROXY_COUNT`: how many proxy hops to trust (only meaningful in
+ *   `x-forwarded-for` mode; see below).
  * - `TRUSTED_PROXY_HEADER`: which single header the trusted proxy actually
- *   manages, `x-forwarded-for` (default) or `x-real-ip`.
+ *   manages: `x-forwarded-for` (default), `x-real-ip`, or `cf-connecting-ip`.
  *
- * The header setting exists because the two possible proxy topologies are
+ * The header setting exists because the possible proxy topologies are
  * indistinguishable from the request alone. A proxy that appends to
  * `x-forwarded-for` (nginx with `proxy_add_x_forwarded_for`, or Caddy) and a
  * proxy that only replaces `x-real-ip` (`proxy_set_header X-Real-IP
@@ -40,8 +41,23 @@
  * an `x-real-ip`-only proxy's attacker send a raw `x-forwarded-for` straight
  * through as if trusted, or it broke honest clients behind an
  * `x-real-ip`-only proxy by refusing to read the one header that proxy
- * actually manages. There is no inference that is correct for both, so the
- * operator declares which one applies instead of the app guessing.
+ * actually manages. There is no inference that is correct for all of them,
+ * so the operator declares which one applies instead of the app guessing.
+ *
+ * `cf-connecting-ip` is the third option, for deployments behind Cloudflare.
+ * Cloudflare OVERWRITES `CF-Connecting-IP` with the visitor's address on
+ * every request that reaches it, rather than appending the way it does with
+ * `X-Forwarded-For`, so there is no hop count to get wrong: either the
+ * request came through Cloudflare's edge and the header is trustworthy, or
+ * it did not and the header should not exist at all. That "or" is the whole
+ * of this mode's security model, and it depends entirely on something this
+ * function cannot see: whether the origin can be reached any other way. If
+ * it can, an attacker sets `CF-Connecting-IP` directly and this function has
+ * no chain, no count, and no second opinion to catch that, unlike
+ * `x-forwarded-for` mode, where a wrong hop count still often lands on a
+ * real address among several. See docs/self-hosting/reverse-proxy.md for
+ * the three ways to enforce that precondition (origin firewall restricted to
+ * Cloudflare's ranges, Authenticated Origin Pulls, or a Cloudflare Tunnel).
  */
 
 import net from 'net';
@@ -98,15 +114,19 @@ export function resolveTrustedClientIp(request: Request): string | null {
   const trustedProxyCount = env.TRUSTED_PROXY_COUNT;
 
   if (trustedProxyCount === 0) {
-    // No reverse proxy is trusted to have set either header, regardless of
-    // TRUSTED_PROXY_HEADER. Both x-forwarded-for and x-real-ip come
-    // straight from whoever made the request in that case, so neither is
-    // trustworthy for anything.
+    // No reverse proxy is trusted to have set any of these headers,
+    // regardless of TRUSTED_PROXY_HEADER. x-forwarded-for, x-real-ip, and
+    // cf-connecting-ip all come straight from whoever made the request in
+    // that case, so none of them is trustworthy for anything.
     return null;
   }
 
   if (env.TRUSTED_PROXY_HEADER === 'x-real-ip') {
     return resolveFromRealIp(request);
+  }
+
+  if (env.TRUSTED_PROXY_HEADER === 'cf-connecting-ip') {
+    return resolveFromCfConnectingIp(request);
   }
 
   return resolveFromForwardedFor(request, trustedProxyCount);
@@ -206,6 +226,35 @@ function resolveFromRealIp(request: Request): string | null {
   return net.isIP(trimmed) !== 0 ? trimmed : null;
 }
 
+/**
+ * Resolve via cf-connecting-ip only. Used when TRUSTED_PROXY_HEADER is
+ * 'cf-connecting-ip', i.e. the operator has declared that Cloudflare sits
+ * directly in front of the origin and traffic cannot reach the origin any
+ * other way (see the module doc comment and
+ * docs/self-hosting/reverse-proxy.md for why that precondition is the
+ * entire security model of this mode).
+ *
+ * x-forwarded-for and x-real-ip are not consulted here at all, not even as
+ * a fallback. Behind Cloudflare, a client can put anything it likes in
+ * either of those two headers and Cloudflare will pass them through to the
+ * origin proxy unchanged; only cf-connecting-ip is the one Cloudflare
+ * itself overwrites.
+ *
+ * TRUSTED_PROXY_COUNT does not apply to this path either, for the same
+ * reason it does not apply to resolveFromRealIp: Cloudflare OVERWRITES this
+ * header with the visitor's address on every request rather than appending
+ * to a chain, so there is a single value to trust, not a count of hops.
+ */
+function resolveFromCfConnectingIp(request: Request): string | null {
+  const cfConnectingIp = request.headers.get('cf-connecting-ip');
+  if (!cfConnectingIp) {
+    return null;
+  }
+
+  const trimmed = cfConnectingIp.trim();
+  return net.isIP(trimmed) !== 0 ? trimmed : null;
+}
+
 let warnedMissingTrustedIp = false;
 
 /**
@@ -227,7 +276,7 @@ export function warnNoTrustedClientIp(): void {
       'Falling back to a single shared bucket for every request with no other ' +
       'identifier, which weakens rate limiting fleet-wide. Check TRUSTED_PROXY_COUNT ' +
       '(must equal the number of reverse proxies in front of Nametag) and ' +
-      'TRUSTED_PROXY_HEADER (must match the header your proxy actually manages, ' +
-      'x-forwarded-for or x-real-ip).'
+      'TRUSTED_PROXY_HEADER (must match the header your proxy actually manages: ' +
+      'x-forwarded-for, x-real-ip, or cf-connecting-ip).'
   );
 }

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -120,18 +120,28 @@ export function resolveTrustedClientIp(request: Request): string | null {
     return net.isIP(candidate) !== 0 ? candidate : null;
   }
 
-  // x-real-ip is only considered when x-forwarded-for is absent. Nginx's
-  // proxy_set_header (unlike proxy_add_x_forwarded_for) REPLACES any
-  // client-supplied value, so behind the documented config it always carries
-  // the proxy's own view of the connecting peer for a single trusted hop.
-  // We already returned above when trustedProxyCount is 0, so by this point
-  // at least one hop is trusted.
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    const trimmed = realIp.trim();
-    return net.isIP(trimmed) !== 0 ? trimmed : null;
-  }
-
+  // x-real-ip is deliberately never consulted here, not even as a fallback
+  // when x-forwarded-for is absent. An earlier version of this function did
+  // exactly that, reasoning that nginx's proxy_set_header (unlike
+  // proxy_add_x_forwarded_for) REPLACES a client-supplied value, so it
+  // should be safe for a single trusted hop. That reasoning only holds for a
+  // proxy that also manages x-forwarded-for. A proxy that sets x-real-ip but
+  // never touches x-forwarded-for (no proxy_add_x_forwarded_for and no
+  // explicit proxy_set_header for it) passes through whatever
+  // x-forwarded-for value the client sent, completely unmodified, and this
+  // function has no way to distinguish that from a proxy that correctly
+  // appends its own view: both look like a syntactically valid header. Once
+  // x-real-ip is trusted as a fallback, a proxy configured exactly that way
+  // hands an attacker's own x-forwarded-for straight through as if it were
+  // trustworthy. The two documented reverse-proxy configs (nginx with
+  // proxy_add_x_forwarded_for, Caddy) both manage x-forwarded-for, so
+  // restricting this function to that one header, and never x-real-ip, keeps
+  // both working. A proxy that manages only x-real-ip does not match the
+  // documented configuration (see docs/self-hosting/reverse-proxy.md); a
+  // request through it resolves to null here, which fails into the shared
+  // bucket and fires warnNoTrustedClientIp rather than silently trusting
+  // whatever the client sent. x-real-ip remains available in getClientIp for
+  // logging, where a best-effort value is fine.
   return null;
 }
 

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -1,16 +1,20 @@
 /**
  * Client IP resolution.
  *
- * There are exactly two ways to read a client IP from a request in this app,
- * and they must never be confused for one another:
- *
- * - `resolveTrustedClientIp` is for security decisions (rate limiting, bans,
- *   anything that gates behaviour on "who is this"). It returns `null` when
- *   it cannot vouch for the result, and callers MUST treat `null` as "no
- *   trustworthy IP", never coerce it to a placeholder string.
- * - `getClientIp` is for logging only. It always returns a string, including
- *   a client-supplied one, because a human reading logs benefits from a
- *   best-effort value even when it cannot be trusted.
+ * `resolveTrustedClientIp` is for security decisions (rate limiting, bans,
+ * anything that gates behaviour on "who is this"). It returns `null` when
+ * it cannot vouch for the result, and callers MUST treat `null` as "no
+ * trustworthy IP", never coerce it to a placeholder string. There is no
+ * best-effort, untrusted alternative in this module: an earlier version
+ * exported one for logging, but nothing enforced that its callers only ever
+ * logged it, and it was deleted once logging switched to the trusted
+ * resolver (falling back to `getRawTrustedProxyHeaderForLogging` below when
+ * resolution fails). Do not reintroduce a function that returns a
+ * client-supplied IP string as if it were trustworthy; if a caller needs a
+ * best-effort value for a human to read, it should call
+ * `resolveTrustedClientIp` and handle `null` explicitly, or use
+ * `getRawTrustedProxyHeaderForLogging` for the specific diagnostic case that
+ * function exists for.
  *
  * Background: Next.js 16 removed `NextRequest.ip`, and this app runs as a
  * standalone Node server, so a route handler only ever sees a Web `Request`
@@ -68,36 +72,6 @@ import { env } from '@/lib/env';
 // mock '@/lib/logger' around without providing every export (much like
 // lib/env.ts itself falls back to plain console output for the same
 // layering reason). console.warn keeps this warning dependency-free.
-
-/**
- * Get a best-effort client IP for LOGGING ONLY.
- *
- * NEVER use this for a security decision (rate limiting, allow/deny lists,
- * lockouts, anything that partitions behaviour by "who sent this"). It reads
- * `x-forwarded-for` (the leftmost entry) and falls back to `x-real-ip`, then
- * `'unknown'`. Both headers are attacker-supplied on any request that reaches
- * this process, and the leftmost `x-forwarded-for` entry in particular is
- * exactly the value a client can set to whatever it wants: a reverse proxy
- * that appends to the header (the documented nginx and Caddy configs both do)
- * only ever adds entries to the right, so the leftmost one is never
- * validated by anything we control. That is fine for a log line a human will
- * read, and disqualifying for anything that gates behaviour.
- *
- * Use `resolveTrustedClientIp` for security decisions instead.
- */
-export function getClientIp(request: Request): string {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    return forwardedFor.split(',')[0].trim();
-  }
-
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
-
-  return 'unknown';
-}
 
 /**
  * Resolve a client IP that is safe to use for a security decision, or

--- a/lib/net/client-ip.ts
+++ b/lib/net/client-ip.ts
@@ -1,0 +1,160 @@
+/**
+ * Client IP resolution.
+ *
+ * There are exactly two ways to read a client IP from a request in this app,
+ * and they must never be confused for one another:
+ *
+ * - `resolveTrustedClientIp` is for security decisions (rate limiting, bans,
+ *   anything that gates behaviour on "who is this"). It returns `null` when
+ *   it cannot vouch for the result, and callers MUST treat `null` as "no
+ *   trustworthy IP", never coerce it to a placeholder string.
+ * - `getClientIp` is for logging only. It always returns a string, including
+ *   a client-supplied one, because a human reading logs benefits from a
+ *   best-effort value even when it cannot be trusted.
+ *
+ * Background: Next.js 16 removed `NextRequest.ip`, and this app runs as a
+ * standalone Node server, so a route handler only ever sees a Web `Request`
+ * with no peer address attached. The only IP information available at all
+ * comes from headers a reverse proxy may set, which means it is only as
+ * trustworthy as the proxy configuration in front of the app. `TRUSTED_PROXY_COUNT`
+ * (see lib/env.ts) is how an operator tells this module how many proxy hops
+ * to trust.
+ */
+
+import net from 'net';
+import { env } from '@/lib/env';
+
+// Deliberately not the pino logger from '@/lib/logger'. This module sits
+// underneath both rate limiters, which a large number of existing tests
+// mock '@/lib/logger' around without providing every export (much like
+// lib/env.ts itself falls back to plain console output for the same
+// layering reason). console.warn keeps this warning dependency-free.
+
+/**
+ * Get a best-effort client IP for LOGGING ONLY.
+ *
+ * NEVER use this for a security decision (rate limiting, allow/deny lists,
+ * lockouts, anything that partitions behaviour by "who sent this"). It reads
+ * `x-forwarded-for` (the leftmost entry) and falls back to `x-real-ip`, then
+ * `'unknown'`. Both headers are attacker-supplied on any request that reaches
+ * this process, and the leftmost `x-forwarded-for` entry in particular is
+ * exactly the value a client can set to whatever it wants: a reverse proxy
+ * that appends to the header (the documented nginx and Caddy configs both do)
+ * only ever adds entries to the right, so the leftmost one is never
+ * validated by anything we control. That is fine for a log line a human will
+ * read, and disqualifying for anything that gates behaviour.
+ *
+ * Use `resolveTrustedClientIp` for security decisions instead.
+ */
+export function getClientIp(request: Request): string {
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    return forwardedFor.split(',')[0].trim();
+  }
+
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) {
+    return realIp;
+  }
+
+  return 'unknown';
+}
+
+/**
+ * Resolve a client IP that is safe to use for a security decision, or
+ * `null` if none can be determined.
+ *
+ * `null` is a real, expected outcome, not an error. Callers that need a
+ * bucket key for a rate limiter or similar must decide for themselves how to
+ * behave without an IP (fall back to another identifier, or a shared bucket
+ * with a loud warning); they must never paper over `null` with a placeholder
+ * string, because a placeholder is exactly what turns "we couldn't tell"
+ * into "everyone shares a bucket" without anyone noticing.
+ */
+export function resolveTrustedClientIp(request: Request): string | null {
+  const trustedProxyCount = env.TRUSTED_PROXY_COUNT;
+
+  if (trustedProxyCount === 0) {
+    // No reverse proxy is trusted to have set these headers. Both
+    // x-forwarded-for and x-real-ip come straight from whoever made the
+    // request in that case, so neither is trustworthy for anything.
+    return null;
+  }
+
+  const forwardedFor = request.headers.get('x-forwarded-for');
+  if (forwardedFor) {
+    const hops = forwardedFor
+      .split(',')
+      .map((hop) => hop.trim())
+      .filter((hop) => hop.length > 0);
+
+    // The documented reverse-proxy configs (nginx's proxy_add_x_forwarded_for,
+    // Caddy's reverse_proxy) APPEND to any x-forwarded-for value the client
+    // already sent rather than replacing it. A value the client fabricated
+    // therefore always stays on the LEFT, and each proxy hop the request
+    // legitimately passes through adds exactly one real entry on the RIGHT.
+    // With N trusted proxies in front of this app, the real client address is
+    // the Nth entry counting from the right, i.e. index (length - N). Reading
+    // the leftmost entry, which looks like the natural choice, is precisely
+    // the vulnerability this function exists to close: it lets an attacker
+    // pick their own rate-limit bucket just by rotating that value.
+    const clientIndex = hops.length - trustedProxyCount;
+
+    if (clientIndex < 0) {
+      // Fewer hops are present than the configured number of trusted
+      // proxies. Either TRUSTED_PROXY_COUNT does not match this deployment,
+      // or something stripped entries out of the header before it reached
+      // us. Either way we cannot identify which entry, if any, is the real
+      // client, and falling back to the leftmost one would hand back exactly
+      // the attacker-controlled value this function must not return.
+      return null;
+    }
+
+    const candidate = hops[clientIndex];
+
+    // The candidate's position in the header is now trustworthy, but its
+    // content is still attacker-influenced text until validated. An
+    // unvalidated value would become part of a rate-limit bucket key, which
+    // would let an attacker who cannot move the position still poison the
+    // keyspace with garbage instead of an IP.
+    return net.isIP(candidate) !== 0 ? candidate : null;
+  }
+
+  // x-real-ip is only considered when x-forwarded-for is absent. Nginx's
+  // proxy_set_header (unlike proxy_add_x_forwarded_for) REPLACES any
+  // client-supplied value, so behind the documented config it always carries
+  // the proxy's own view of the connecting peer for a single trusted hop.
+  // We already returned above when trustedProxyCount is 0, so by this point
+  // at least one hop is trusted.
+  const realIp = request.headers.get('x-real-ip');
+  if (realIp) {
+    const trimmed = realIp.trim();
+    return net.isIP(trimmed) !== 0 ? trimmed : null;
+  }
+
+  return null;
+}
+
+let warnedMissingTrustedIp = false;
+
+/**
+ * Log, once per process, that a rate limiter could not determine a trusted
+ * client IP and is falling back to a shared bucket.
+ *
+ * This exists because a silently shared bucket is how a rate limit stays
+ * broken for months: every unauthenticated request with no other identifier
+ * collapses into one counter, and nothing about that is visible unless an
+ * operator goes looking. Logging it once (rather than per request) keeps a
+ * misconfigured deployment from flooding its own logs while still surfacing
+ * the problem.
+ */
+export function warnNoTrustedClientIp(): void {
+  if (warnedMissingTrustedIp) return;
+  warnedMissingTrustedIp = true;
+  console.warn(
+    '[rate-limit] No trusted client IP could be determined for a rate-limited request. ' +
+      'Falling back to a single shared bucket for every request with no other ' +
+      'identifier, which weakens rate limiting fleet-wide. Check TRUSTED_PROXY_COUNT: ' +
+      'it must equal the number of reverse proxies in front of Nametag that append to X-Forwarded-For.'
+  );
+}

--- a/lib/rate-limit-redis.ts
+++ b/lib/rate-limit-redis.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
 import { getRedis, isRedisConnected } from './redis';
 import { securityLogger } from './logger';
-import { rateLimitConfigs, type RateLimitType } from './rate-limit';
+import { rateLimitConfigs, buildRateLimitKey, type RateLimitType } from './rate-limit';
+import { resolveTrustedClientIp } from '@/lib/net/client-ip';
 
 /**
  * Redis-based distributed rate limiting
@@ -39,24 +40,12 @@ function cleanupMemoryStore() {
 }
 
 /**
- * Get client IP from request
- */
-function getClientIp(request: Request): string {
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    return forwardedFor.split(',')[0].trim();
-  }
-
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
-  }
-
-  return 'unknown';
-}
-
-/**
  * Check rate limit using Redis
+ *
+ * `ip` here is a logging annotation only (passed through to
+ * securityLogger). The bucket `key` is built by the caller from a trusted
+ * IP resolution, so this function never uses `ip` for anything that gates
+ * behaviour.
  */
 async function checkRateLimitRedis(
   key: string,
@@ -226,14 +215,14 @@ export async function checkRateLimit(
   identifier?: string
 ): Promise<NextResponse | null> {
   const config = rateLimitConfigs[type];
-  const ip = getClientIp(request);
-  const key = identifier ? `ratelimit:${type}:${ip}:${identifier}` : `ratelimit:${type}:${ip}`;
+  const ip = resolveTrustedClientIp(request);
+  const key = `ratelimit:${buildRateLimitKey(type, ip, identifier)}`;
 
   return checkRateLimitRedis(
     key,
     config.maxAttempts,
     config.windowMs,
-    ip,
+    ip ?? 'unknown',
     type,
     identifier
   );
@@ -248,15 +237,15 @@ export async function resetRateLimit(
   identifier?: string
 ): Promise<void> {
   const redis = getRedis();
-  const ip = getClientIp(request);
-  const key = identifier ? `ratelimit:${type}:${ip}:${identifier}` : `ratelimit:${type}:${ip}`;
+  const ip = resolveTrustedClientIp(request);
+  const key = `ratelimit:${buildRateLimitKey(type, ip, identifier)}`;
 
   if (redis && isRedisConnected()) {
     try {
       await redis.del(key);
     } catch (error) {
       // Log but don't throw
-      securityLogger.suspiciousActivity(ip, 'Failed to reset rate limit', {
+      securityLogger.suspiciousActivity(ip ?? 'unknown', 'Failed to reset rate limit', {
         type,
         identifier,
         error: error instanceof Error ? error.message : 'Unknown error',

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { securityLogger } from './logger';
+import { resolveTrustedClientIp, warnNoTrustedClientIp } from '@/lib/net/client-ip';
 
 interface RateLimitEntry {
   count: number;
@@ -105,23 +106,31 @@ export const rateLimitConfigs = {
 export type RateLimitType = keyof typeof rateLimitConfigs;
 
 /**
- * Get the client's IP address from the request
+ * Build the storage key for a rate-limit bucket.
+ *
+ * With a trusted IP, the key is IP-scoped, optionally narrowed further by an
+ * identifier such as an email. Without a trusted IP, an identifier alone is
+ * still a real per-account bound, so it is used on its own rather than
+ * discarded. With neither, there is nothing to partition on: every such
+ * request collapses into one shared bucket rather than being exempted from
+ * rate limiting altogether, which is why a shared bucket is logged loudly
+ * instead of happening quietly.
  */
-function getClientIp(request: Request): string {
-  // Check various headers that might contain the real IP
-  const forwardedFor = request.headers.get('x-forwarded-for');
-  if (forwardedFor) {
-    // x-forwarded-for can contain multiple IPs, take the first one
-    return forwardedFor.split(',')[0].trim();
+export function buildRateLimitKey(
+  type: RateLimitType,
+  ip: string | null,
+  identifier?: string
+): string {
+  if (ip) {
+    return identifier ? `${type}:${ip}:${identifier}` : `${type}:${ip}`;
   }
 
-  const realIp = request.headers.get('x-real-ip');
-  if (realIp) {
-    return realIp;
+  if (identifier) {
+    return `${type}:${identifier}`;
   }
 
-  // Fallback to a default (this shouldn't happen in production)
-  return 'unknown';
+  warnNoTrustedClientIp();
+  return `${type}:shared`;
 }
 
 /**
@@ -136,10 +145,9 @@ export function checkRateLimit(
   cleanupExpiredEntries();
 
   const config = rateLimitConfigs[type];
-  const ip = getClientIp(request);
+  const ip = resolveTrustedClientIp(request);
 
-  // Create a unique key combining IP, type, and optional identifier
-  const key = identifier ? `${type}:${ip}:${identifier}` : `${type}:${ip}`;
+  const key = buildRateLimitKey(type, ip, identifier);
 
   const now = Date.now();
   const entry = rateLimitStore.get(key);
@@ -158,8 +166,10 @@ export function checkRateLimit(
     const retryAfterSeconds = Math.ceil((entry.resetTime - now) / 1000);
     const retryAfterMinutes = Math.ceil(retryAfterSeconds / 60);
 
-    // Log the rate limit violation
-    securityLogger.rateLimitExceeded(ip, type, {
+    // Log the rate limit violation. The IP here is best-effort context for a
+    // human reading logs, not a security decision, so 'unknown' is fine when
+    // there is no trusted value.
+    securityLogger.rateLimitExceeded(ip ?? 'unknown', type, {
       attempts: entry.count,
       maxAttempts: config.maxAttempts,
       retryAfterSeconds,
@@ -193,7 +203,7 @@ export function resetRateLimit(
   type: RateLimitType,
   identifier?: string
 ): void {
-  const ip = getClientIp(request);
-  const key = identifier ? `${type}:${ip}:${identifier}` : `${type}:${ip}`;
+  const ip = resolveTrustedClientIp(request);
+  const key = buildRateLimitKey(type, ip, identifier);
   rateLimitStore.delete(key);
 }

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -238,6 +238,47 @@ describe('Auth API', () => {
       expect(response.status).toBe(400);
     });
 
+    it('should return the same status as today for a malformed body, not a 500', async () => {
+      // Catches: moving body parsing outside the try/catch when reordering
+      // it ahead of the rate limit check, which would turn a client mistake
+      // into an unhandled exception.
+      const request = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: '{not valid json',
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const response = await register(request);
+
+      expect(response.status).toBe(400);
+      expect(mocks.checkRateLimitAsync).not.toHaveBeenCalled();
+    });
+
+    it('should rate limit by the normalized email, so two casings share a bucket', async () => {
+      // Catches: passing the raw (un-normalized) email as the rate-limit
+      // identifier, which would let "Foo@x.com" and "foo@x.com" bypass a
+      // shared limit by alternating case.
+      mocks.userFindUnique.mockResolvedValue(null);
+      mocks.userCreate.mockResolvedValue({ id: 'user-123', email: 'case@example.com', name: 'Test' });
+
+      const upper = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'Case@Example.COM', password: 'ValidPassword123!', name: 'Test' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      const lower = new Request('http://localhost/api/auth/register', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'case@example.com', password: 'ValidPassword123!', name: 'Test' }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await register(upper);
+      await register(lower);
+
+      const identifiers = mocks.checkRateLimitAsync.mock.calls.map((call) => call[2]);
+      expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
+    });
+
     it('should hash the password before storing', async () => {
       mocks.userFindUnique.mockResolvedValue(null);
       mocks.userCreate.mockResolvedValue({ id: 'user-123', email: 'test@example.com', name: 'Test' });
@@ -900,6 +941,46 @@ describe('Auth API', () => {
       const response = await forgotPassword(request);
 
       expect(response.status).toBe(400);
+    });
+
+    it('should return the same status as today for a malformed body, not a 500', async () => {
+      // Catches: moving body parsing outside the try/catch when reordering
+      // it ahead of the rate limit check, which would turn a client mistake
+      // into an unhandled exception.
+      const request = new Request('http://localhost/api/auth/forgot-password', {
+        method: 'POST',
+        body: '{not valid json',
+        headers: { 'content-type': 'application/json' },
+      });
+
+      const response = await forgotPassword(request);
+
+      expect(response.status).toBe(400);
+      expect(mocks.checkRateLimitSync).not.toHaveBeenCalled();
+    });
+
+    it('should rate limit by the normalized email, so two casings share a bucket', async () => {
+      // Catches: passing the raw (un-normalized) email as the rate-limit
+      // identifier, which would let "Foo@x.com" and "foo@x.com" bypass a
+      // shared limit by alternating case.
+      mocks.userFindUnique.mockResolvedValue(null);
+
+      const upper = new Request('http://localhost/api/auth/forgot-password', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'Case@Example.COM' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      const lower = new Request('http://localhost/api/auth/forgot-password', {
+        method: 'POST',
+        body: JSON.stringify({ email: 'case@example.com' }),
+        headers: { 'content-type': 'application/json' },
+      });
+
+      await forgotPassword(upper);
+      await forgotPassword(lower);
+
+      const identifiers = mocks.checkRateLimitSync.mock.calls.map((call) => call[2]);
+      expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
     });
 
     describe('Email Case Sensitivity', () => {

--- a/tests/api/auth.test.ts
+++ b/tests/api/auth.test.ts
@@ -238,10 +238,13 @@ describe('Auth API', () => {
       expect(response.status).toBe(400);
     });
 
-    it('should return the same status as today for a malformed body, not a 500', async () => {
+    it('should return the same status as today for a malformed body, not a 500, and still consume the unkeyed rate limit', async () => {
       // Catches: moving body parsing outside the try/catch when reordering
-      // it ahead of the rate limit check, which would turn a client mistake
-      // into an unhandled exception.
+      // it ahead of the email-keyed rate limit check, which would turn a
+      // client mistake into an unhandled exception. Also catches: dropping
+      // the unkeyed pre-parse check entirely, which would let a flood of
+      // malformed bodies (never reaching the email-keyed check) bypass rate
+      // limiting altogether.
       const request = new Request('http://localhost/api/auth/register', {
         method: 'POST',
         body: '{not valid json',
@@ -251,7 +254,8 @@ describe('Auth API', () => {
       const response = await register(request);
 
       expect(response.status).toBe(400);
-      expect(mocks.checkRateLimitAsync).not.toHaveBeenCalled();
+      expect(mocks.checkRateLimitAsync).toHaveBeenCalledTimes(1);
+      expect(mocks.checkRateLimitAsync).toHaveBeenCalledWith(request, 'register');
     });
 
     it('should rate limit by the normalized email, so two casings share a bucket', async () => {
@@ -275,7 +279,12 @@ describe('Auth API', () => {
       await register(upper);
       await register(lower);
 
-      const identifiers = mocks.checkRateLimitAsync.mock.calls.map((call) => call[2]);
+      // Each request makes two calls: an unkeyed pre-parse check (no third
+      // argument) and an email-keyed check after parsing. Only the keyed
+      // calls are relevant to bucket sharing.
+      const identifiers = mocks.checkRateLimitAsync.mock.calls
+        .map((call) => call[2])
+        .filter((identifier): identifier is string => identifier !== undefined);
       expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
     });
 
@@ -673,9 +682,24 @@ describe('Auth API', () => {
         expect(mocks.userCreate).not.toHaveBeenCalled();
       });
 
-      it('should check user count before rate limiting when DISABLE_REGISTRATION is true', async () => {
+      it('rate limits by IP before parsing, then by email, before the DISABLE_REGISTRATION user-count check', async () => {
+        // Pins the deliberate order: an unkeyed IP check runs first (before
+        // the body is parsed), then an email-keyed check once the body is
+        // parsed and validated, and only then is the user count queried.
+        // Getting this backwards either lets a flood of requests reach the
+        // database count query before any rate limit applies, or (the
+        // original bug this route was fixed for) never rate limits a
+        // request that DISABLE_REGISTRATION would go on to block anyway.
         process.env.DISABLE_REGISTRATION = 'true';
-        mocks.userCount.mockResolvedValue(1);
+        const callOrder: string[] = [];
+        mocks.checkRateLimitAsync.mockImplementation(async () => {
+          callOrder.push('rateLimit');
+          return null;
+        });
+        mocks.userCount.mockImplementation(async () => {
+          callOrder.push('userCount');
+          return 1;
+        });
 
         const request = new Request('http://localhost/api/auth/register', {
           method: 'POST',
@@ -690,8 +714,9 @@ describe('Auth API', () => {
         const response = await register(request);
 
         expect(response.status).toBe(403);
-        // Should block before validation, so rate limit should still be called
-        expect(mocks.checkRateLimitAsync).toHaveBeenCalled();
+        expect(callOrder).toEqual(['rateLimit', 'rateLimit', 'userCount']);
+        expect(mocks.checkRateLimitAsync).toHaveBeenNthCalledWith(1, request, 'register');
+        expect(mocks.checkRateLimitAsync).toHaveBeenNthCalledWith(2, request, 'register', 'test@example.com');
       });
     });
 
@@ -943,10 +968,13 @@ describe('Auth API', () => {
       expect(response.status).toBe(400);
     });
 
-    it('should return the same status as today for a malformed body, not a 500', async () => {
+    it('should return the same status as today for a malformed body, not a 500, and still consume the unkeyed rate limit', async () => {
       // Catches: moving body parsing outside the try/catch when reordering
-      // it ahead of the rate limit check, which would turn a client mistake
-      // into an unhandled exception.
+      // it ahead of the email-keyed rate limit check, which would turn a
+      // client mistake into an unhandled exception. Also catches: dropping
+      // the unkeyed pre-parse check entirely, which would let a flood of
+      // malformed bodies (never reaching the email-keyed check) bypass rate
+      // limiting altogether.
       const request = new Request('http://localhost/api/auth/forgot-password', {
         method: 'POST',
         body: '{not valid json',
@@ -956,7 +984,8 @@ describe('Auth API', () => {
       const response = await forgotPassword(request);
 
       expect(response.status).toBe(400);
-      expect(mocks.checkRateLimitSync).not.toHaveBeenCalled();
+      expect(mocks.checkRateLimitSync).toHaveBeenCalledTimes(1);
+      expect(mocks.checkRateLimitSync).toHaveBeenCalledWith(request, 'forgotPassword');
     });
 
     it('should rate limit by the normalized email, so two casings share a bucket', async () => {
@@ -979,7 +1008,12 @@ describe('Auth API', () => {
       await forgotPassword(upper);
       await forgotPassword(lower);
 
-      const identifiers = mocks.checkRateLimitSync.mock.calls.map((call) => call[2]);
+      // Each request makes two calls: an unkeyed pre-parse check (no third
+      // argument) and an email-keyed check after parsing. Only the keyed
+      // calls are relevant to bucket sharing.
+      const identifiers = mocks.checkRateLimitSync.mock.calls
+        .map((call) => call[2])
+        .filter((identifier): identifier is string => identifier !== undefined);
       expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
     });
 

--- a/tests/api/cron-reminders-unsubscribe.test.ts
+++ b/tests/api/cron-reminders-unsubscribe.test.ts
@@ -124,7 +124,6 @@ vi.mock('../../lib/api-utils', () => ({
       { status: 500, headers: { 'Content-Type': 'application/json' } }
     );
   }),
-  getClientIp: vi.fn(() => '127.0.0.1'),
   withLogging: vi.fn((fn: (...args: unknown[]) => unknown) => fn),
 }));
 

--- a/tests/api/profile-email-change-token-hash.test.ts
+++ b/tests/api/profile-email-change-token-hash.test.ts
@@ -45,6 +45,11 @@ vi.mock('../../lib/logger', () => ({
 
 vi.mock('../../lib/env', () => ({
   getAppUrl: vi.fn(() => 'http://localhost:3000'),
+  // withLogging (lib/api-utils.ts) resolves the trusted client IP for every
+  // request via lib/net/client-ip.ts, which reads these two directly off
+  // `env`. Without them the mock has no "env" export at all and the real
+  // resolver throws trying to read a property off undefined.
+  env: { TRUSTED_PROXY_COUNT: 1, TRUSTED_PROXY_HEADER: 'x-forwarded-for' },
 }));
 
 import { PUT } from '../../app/api/user/profile/route';

--- a/tests/api/resend-verification-token-hash.test.ts
+++ b/tests/api/resend-verification-token-hash.test.ts
@@ -111,10 +111,13 @@ describe('POST /api/auth/resend-verification - token hashing', () => {
     expect(emailCall.text).toBeDefined();
   });
 
-  it('should return the same status as today for a malformed body, not a 500', async () => {
+  it('should return the same status as today for a malformed body, not a 500, and still consume the unkeyed rate limit', async () => {
     // Catches: moving body parsing outside the try/catch when reordering it
-    // ahead of the rate limit check, which would turn a client mistake into
-    // an unhandled exception.
+    // ahead of the email-keyed rate limit check, which would turn a client
+    // mistake into an unhandled exception. Also catches: dropping the
+    // unkeyed pre-parse check entirely, which would let a flood of
+    // malformed bodies (never reaching the email-keyed check) bypass rate
+    // limiting altogether.
     const request = new Request('http://localhost/api/auth/resend-verification', {
       method: 'POST',
       body: '{not valid json',
@@ -124,7 +127,8 @@ describe('POST /api/auth/resend-verification - token hashing', () => {
     const response = await POST(request);
 
     expect(response.status).toBe(400);
-    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+    expect(mocks.checkRateLimit).toHaveBeenCalledTimes(1);
+    expect(mocks.checkRateLimit).toHaveBeenCalledWith(request, 'resendVerification');
   });
 
   it('should rate limit by the normalized email, so two casings share a bucket', async () => {
@@ -147,7 +151,12 @@ describe('POST /api/auth/resend-verification - token hashing', () => {
     await POST(upper);
     await POST(lower);
 
-    const identifiers = mocks.checkRateLimit.mock.calls.map((call) => call[2]);
+    // Each request makes two calls: an unkeyed pre-parse check (no third
+    // argument) and an email-keyed check after parsing. Only the keyed
+    // calls are relevant to bucket sharing.
+    const identifiers = mocks.checkRateLimit.mock.calls
+      .map((call) => call[2])
+      .filter((identifier): identifier is string => identifier !== undefined);
     expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
   });
 });

--- a/tests/api/resend-verification-token-hash.test.ts
+++ b/tests/api/resend-verification-token-hash.test.ts
@@ -110,4 +110,44 @@ describe('POST /api/auth/resend-verification - token hashing', () => {
     // The text body should contain a token parameter in the URL
     expect(emailCall.text).toBeDefined();
   });
+
+  it('should return the same status as today for a malformed body, not a 500', async () => {
+    // Catches: moving body parsing outside the try/catch when reordering it
+    // ahead of the rate limit check, which would turn a client mistake into
+    // an unhandled exception.
+    const request = new Request('http://localhost/api/auth/resend-verification', {
+      method: 'POST',
+      body: '{not valid json',
+      headers: { 'content-type': 'application/json' },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    expect(mocks.checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('should rate limit by the normalized email, so two casings share a bucket', async () => {
+    // Catches: passing the raw (un-normalized) email as the rate-limit
+    // identifier, which would let "Foo@x.com" and "foo@x.com" bypass a
+    // shared limit by alternating case.
+    mocks.userFindUnique.mockResolvedValue(null);
+
+    const upper = new Request('http://localhost/api/auth/resend-verification', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'Case@Example.COM' }),
+      headers: { 'content-type': 'application/json' },
+    });
+    const lower = new Request('http://localhost/api/auth/resend-verification', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'case@example.com' }),
+      headers: { 'content-type': 'application/json' },
+    });
+
+    await POST(upper);
+    await POST(lower);
+
+    const identifiers = mocks.checkRateLimit.mock.calls.map((call) => call[2]);
+    expect(identifiers).toEqual(['case@example.com', 'case@example.com']);
+  });
 });

--- a/tests/components/NotificationEndpointsCard.test.tsx
+++ b/tests/components/NotificationEndpointsCard.test.tsx
@@ -690,7 +690,14 @@ describe('NotificationEndpointsCard', () => {
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toHaveAttribute('aria-modal', 'true');
-      expect(dialog.contains(document.activeElement)).toBe(true);
+
+      // Focus moves in an effect, which is a later tick than the one that puts
+      // the dialog in the document. Asserting it synchronously passes on a fast
+      // machine and loses the race on a slow one, so wait for it rather than
+      // assuming the two happen together.
+      await waitFor(() => {
+        expect(dialog.contains(document.activeElement)).toBe(true);
+      });
     });
 
     it('closing the secret dialog via Escape also clears the secret from state, not only the button dismiss', async () => {

--- a/tests/lib/api-utils.test.ts
+++ b/tests/lib/api-utils.test.ts
@@ -5,7 +5,6 @@ import {
   InvalidJsonError,
   apiResponse,
   handleApiError,
-  getClientIp,
   MAX_REQUEST_SIZE,
 } from '@/lib/api-utils';
 
@@ -292,44 +291,6 @@ describe('api-utils', () => {
     });
   });
 
-  describe('getClientIp', () => {
-    it('should get IP from x-forwarded-for header', () => {
-      const request = new Request('http://localhost/api/test', {
-        headers: {
-          'x-forwarded-for': '192.168.1.1, 10.0.0.1',
-        },
-      });
-
-      expect(getClientIp(request)).toBe('192.168.1.1');
-    });
-
-    it('should get IP from x-real-ip header', () => {
-      const request = new Request('http://localhost/api/test', {
-        headers: {
-          'x-real-ip': '192.168.1.2',
-        },
-      });
-
-      expect(getClientIp(request)).toBe('192.168.1.2');
-    });
-
-    it('should prefer x-forwarded-for over x-real-ip', () => {
-      const request = new Request('http://localhost/api/test', {
-        headers: {
-          'x-forwarded-for': '192.168.1.1',
-          'x-real-ip': '192.168.1.2',
-        },
-      });
-
-      expect(getClientIp(request)).toBe('192.168.1.1');
-    });
-
-    it('should return unknown when no IP headers', () => {
-      const request = new Request('http://localhost/api/test');
-      expect(getClientIp(request)).toBe('unknown');
-    });
-  });
-
   describe('withAuth', () => {
     beforeEach(() => {
       vi.resetModules();
@@ -609,10 +570,11 @@ describe('api-utils', () => {
 
       it('logs the real address behind a spoofed prefix, not the spoofed one, with a correct proxy count', async () => {
         // This is the test that proves the log is now trustworthy. Before
-        // this change, withLogging used getClientIp (the leftmost
-        // x-forwarded-for entry), which is exactly the attacker-controlled
-        // value a spoofed prefix supplies. Catches: reverting withLogging to
-        // getClientIp, or anything else that logs the untrusted value.
+        // this change, withLogging used a best-effort, untrusted helper (the
+        // leftmost x-forwarded-for entry), which is exactly the
+        // attacker-controlled value a spoofed prefix supplies. Catches:
+        // reverting withLogging to an untrusted helper, or anything else
+        // that logs an unvalidated header value.
         process.env.TRUSTED_PROXY_COUNT = '1';
         const { withLogging } = await import('@/lib/api-utils');
         const { createModuleLogger } = await import('@/lib/logger');

--- a/tests/lib/api-utils.test.ts
+++ b/tests/lib/api-utils.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   parseRequestBody,
   RequestTooLargeError,
@@ -588,6 +588,123 @@ describe('api-utils', () => {
         expect.objectContaining({ ip: '1.2.3.4' }),
         expect.any(String)
       );
+    });
+
+    describe('logged ip is the trusted value, not the untrusted best-effort one', () => {
+      const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+      const originalTrustedProxyHeader = process.env.TRUSTED_PROXY_HEADER;
+
+      afterEach(() => {
+        if (originalTrustedProxyCount === undefined) {
+          delete process.env.TRUSTED_PROXY_COUNT;
+        } else {
+          process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+        }
+        if (originalTrustedProxyHeader === undefined) {
+          delete process.env.TRUSTED_PROXY_HEADER;
+        } else {
+          process.env.TRUSTED_PROXY_HEADER = originalTrustedProxyHeader;
+        }
+      });
+
+      it('logs the real address behind a spoofed prefix, not the spoofed one, with a correct proxy count', async () => {
+        // This is the test that proves the log is now trustworthy. Before
+        // this change, withLogging used getClientIp (the leftmost
+        // x-forwarded-for entry), which is exactly the attacker-controlled
+        // value a spoofed prefix supplies. Catches: reverting withLogging to
+        // getClientIp, or anything else that logs the untrusted value.
+        process.env.TRUSTED_PROXY_COUNT = '1';
+        const { withLogging } = await import('@/lib/api-utils');
+        const { createModuleLogger } = await import('@/lib/logger');
+        const httpLog = createModuleLogger('http');
+
+        const handler = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        const wrapped = withLogging(handler);
+
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { 'x-forwarded-for': '6.6.6.6, 203.0.113.9' },
+        });
+        await wrapped(request);
+
+        expect(httpLog.info).toHaveBeenCalledWith(
+          expect.objectContaining({ ip: '203.0.113.9' }),
+          expect.any(String)
+        );
+        expect(httpLog.info).not.toHaveBeenCalledWith(
+          expect.objectContaining({ ip: '6.6.6.6' }),
+          expect.any(String)
+        );
+      });
+
+      it('logs "unknown" and includes the raw header when no trusted IP can be resolved', async () => {
+        // Fewer x-forwarded-for entries than the configured trusted proxy
+        // count resolves to no trusted IP (see lib/net/client-ip.ts). The
+        // raw header is attached here specifically so an operator can see
+        // what arrived and work out the right count.
+        process.env.TRUSTED_PROXY_COUNT = '2';
+        const { withLogging } = await import('@/lib/api-utils');
+        const { createModuleLogger } = await import('@/lib/logger');
+        const httpLog = createModuleLogger('http');
+
+        const handler = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        const wrapped = withLogging(handler);
+
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { 'x-forwarded-for': '203.0.113.9' },
+        });
+        await wrapped(request);
+
+        expect(httpLog.info).toHaveBeenCalledWith(
+          expect.objectContaining({ ip: 'unknown', rawProxyHeader: '203.0.113.9' }),
+          expect.any(String)
+        );
+      });
+
+      it('truncates the raw header when it is very long', async () => {
+        // A client controls the length of this header. Without a bound,
+        // failing resolution would be a way to inflate every log line
+        // arbitrarily, which is itself a log-flooding vector.
+        process.env.TRUSTED_PROXY_COUNT = '1';
+        const { withLogging } = await import('@/lib/api-utils');
+
+        const handler = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        const wrapped = withLogging(handler);
+
+        const veryLongGarbage = 'a'.repeat(5000);
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { 'x-forwarded-for': veryLongGarbage },
+        });
+        await wrapped(request);
+
+        const call = mockHttpLog.info.mock.calls.find(
+          (c) => (c[0] as { event?: string }).event === 'http.request.completed'
+        );
+        const loggedField = (call?.[0] as { rawProxyHeader?: string } | undefined)?.rawProxyHeader;
+        expect(loggedField).toBeDefined();
+        expect(loggedField!.length).toBeLessThan(veryLongGarbage.length);
+      });
+
+      it('does not include the raw header on the normal success path', async () => {
+        process.env.TRUSTED_PROXY_COUNT = '1';
+        const { withLogging } = await import('@/lib/api-utils');
+
+        const handler = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+        const wrapped = withLogging(handler);
+
+        const request = new Request('http://localhost/api/test', {
+          method: 'GET',
+          headers: { 'x-forwarded-for': '203.0.113.9' },
+        });
+        await wrapped(request);
+
+        const call = mockHttpLog.info.mock.calls.find(
+          (c) => (c[0] as { event?: string }).event === 'http.request.completed'
+        );
+        expect(call?.[0]).not.toHaveProperty('rawProxyHeader');
+      });
     });
   });
 

--- a/tests/lib/net/client-ip.test.ts
+++ b/tests/lib/net/client-ip.test.ts
@@ -462,15 +462,6 @@ describe('resolveTrustedClientIp', () => {
   });
 });
 
-describe('getClientIp (logging only)', () => {
-  it('never throws and always returns a string, even for garbage input', async () => {
-    const { getClientIp } = await import('@/lib/net/client-ip');
-    const request = requestWith({ 'x-forwarded-for': 'garbage, more-garbage' });
-
-    expect(getClientIp(request)).toBe('garbage');
-  });
-});
-
 describe('warnNoTrustedClientIp', () => {
   it('logs at most once per process, not once per call', async () => {
     // Catches: dropping the `warnedMissingTrustedIp` guard and logging on

--- a/tests/lib/net/client-ip.test.ts
+++ b/tests/lib/net/client-ip.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+/**
+ * These tests exercise `resolveTrustedClientIp`, the function that decides
+ * which entry in a proxy-set header is safe to use for a security decision
+ * (rate limiting, in this codebase). Each test names the mutation of the
+ * resolver it would catch if that mutation were reintroduced.
+ */
+
+function requestWith(headers: Record<string, string>): Request {
+  return new Request('http://localhost/api/test', { headers });
+}
+
+async function freshClientIp() {
+  vi.resetModules();
+  return import('@/lib/net/client-ip');
+}
+
+describe('resolveTrustedClientIp', () => {
+  const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+
+  afterEach(() => {
+    if (originalTrustedProxyCount === undefined) {
+      delete process.env.TRUSTED_PROXY_COUNT;
+    } else {
+      process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+    }
+  });
+
+  describe('the spoofing vulnerability (GHSA-x7jp-pjg9-x996)', () => {
+    it('resolves the rightmost entry, not the attacker-supplied leftmost one', async () => {
+      // Catches: reverting to `forwardedFor.split(',')[0]` (leftmost entry).
+      // This is the exact vulnerability: a client can set x-forwarded-for to
+      // "anything, <real ip>" and a leftmost read would trust "anything".
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '1.2.3.4, 203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+      expect(resolveTrustedClientIp(request)).not.toBe('1.2.3.4');
+    });
+
+    it('does not change when the attacker rotates the spoofed prefix', async () => {
+      // Catches: any implementation that derives the bucket key from
+      // anything other than the fixed-position rightmost entry, e.g. hashing
+      // the whole header or reading a variable-length prefix.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const first = resolveTrustedClientIp(
+        requestWith({ 'x-forwarded-for': '1.2.3.4, 203.0.113.9' })
+      );
+      const second = resolveTrustedClientIp(
+        requestWith({ 'x-forwarded-for': '9.9.9.9, 203.0.113.9' })
+      );
+      const third = resolveTrustedClientIp(
+        requestWith({ 'x-forwarded-for': 'not-even-an-ip, 203.0.113.9' })
+      );
+
+      expect(first).toBe('203.0.113.9');
+      expect(second).toBe('203.0.113.9');
+      expect(third).toBe('203.0.113.9');
+    });
+  });
+
+  describe('TRUSTED_PROXY_COUNT = 0', () => {
+    it('ignores x-forwarded-for entirely', async () => {
+      // Catches: falling through to header parsing when the count is 0
+      // instead of returning null immediately.
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('ignores x-real-ip entirely', async () => {
+      // Catches: consulting x-real-ip unconditionally instead of gating it
+      // on trustedProxyCount >= 1.
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': '203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe('fewer hops than TRUSTED_PROXY_COUNT', () => {
+    it('returns null rather than falling back to the leftmost entry', async () => {
+      // Catches: clamping a negative index to 0 (or to the leftmost entry)
+      // instead of returning null. That fallback would hand back exactly
+      // the attacker-controlled value this function must refuse.
+      process.env.TRUSTED_PROXY_COUNT = '2';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('resolves correctly once enough hops are present', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '2';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '1.2.3.4, 203.0.113.9, 198.51.100.7',
+      });
+
+      // length 3, count 2 -> index 1 -> '203.0.113.9'
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+  });
+
+  describe('non-IP values', () => {
+    it('rejects a non-IP candidate from x-forwarded-for', async () => {
+      // Catches: skipping the net.isIP validation on the resolved candidate.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': 'definitely-not-an-ip' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('rejects a non-IP value in x-real-ip', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': 'also-not-an-ip' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe('x-real-ip fallback', () => {
+    it('is used only when x-forwarded-for is absent', async () => {
+      // Catches: preferring x-real-ip over a present x-forwarded-for, or
+      // merging the two.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '203.0.113.9',
+        'x-real-ip': '198.51.100.7',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+
+    it('is used when x-forwarded-for is absent and the count is at least 1', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': '198.51.100.7' });
+
+      expect(resolveTrustedClientIp(request)).toBe('198.51.100.7');
+    });
+
+    it('is not consulted at all when the count is 0, even alone', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': '198.51.100.7' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe('no headers at all', () => {
+    it('returns null rather than a placeholder string', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = new Request('http://localhost/api/test');
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe('default TRUSTED_PROXY_COUNT', () => {
+    it('defaults to 1 when unset', async () => {
+      delete process.env.TRUSTED_PROXY_COUNT;
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '1.2.3.4, 203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+  });
+});
+
+describe('getClientIp (logging only)', () => {
+  it('never throws and always returns a string, even for garbage input', async () => {
+    const { getClientIp } = await import('@/lib/net/client-ip');
+    const request = requestWith({ 'x-forwarded-for': 'garbage, more-garbage' });
+
+    expect(getClientIp(request)).toBe('garbage');
+  });
+});
+
+describe('warnNoTrustedClientIp', () => {
+  it('logs at most once per process, not once per call', async () => {
+    // Catches: dropping the `warnedMissingTrustedIp` guard and logging on
+    // every call, which is the per-request log spam this function exists to
+    // avoid.
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const mod = await import('@/lib/net/client-ip');
+
+    mod.warnNoTrustedClientIp();
+    mod.warnNoTrustedClientIp();
+    mod.warnNoTrustedClientIp();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    warnSpy.mockRestore();
+  });
+});

--- a/tests/lib/net/client-ip.test.ts
+++ b/tests/lib/net/client-ip.test.ts
@@ -18,12 +18,19 @@ async function freshClientIp() {
 
 describe('resolveTrustedClientIp', () => {
   const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+  const originalTrustedProxyHeader = process.env.TRUSTED_PROXY_HEADER;
 
   afterEach(() => {
     if (originalTrustedProxyCount === undefined) {
       delete process.env.TRUSTED_PROXY_COUNT;
     } else {
       process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+    }
+
+    if (originalTrustedProxyHeader === undefined) {
+      delete process.env.TRUSTED_PROXY_HEADER;
+    } else {
+      process.env.TRUSTED_PROXY_HEADER = originalTrustedProxyHeader;
     }
   });
 
@@ -127,18 +134,22 @@ describe('resolveTrustedClientIp', () => {
 
   });
 
-  describe('x-real-ip is never trusted (a proxy that manages only x-real-ip is a misconfiguration)', () => {
+  describe("TRUSTED_PROXY_HEADER = 'x-forwarded-for' (default): x-real-ip is never trusted", () => {
     it('is not used as a fallback when x-forwarded-for is absent, even with a trusted proxy count', async () => {
       // Catches: reintroducing the "consult x-real-ip when x-forwarded-for is
-      // absent" fallback. That fallback is exploitable against a proxy that
-      // manages x-real-ip (via proxy_set_header, which replaces) but never
-      // touches x-forwarded-for: such a proxy passes an attacker's own
+      // absent" fallback in the x-forwarded-for mode. That fallback is
+      // exploitable against a proxy that manages x-real-ip (via
+      // proxy_set_header, which replaces) but never touches
+      // x-forwarded-for: such a proxy passes an attacker's own
       // x-forwarded-for straight through untouched, and a resolver that
       // falls back to x-real-ip only when x-forwarded-for is *absent* would
       // never even notice, because in the exploit case x-forwarded-for is
       // present (it's the attacker's). This test pins the simpler,
       // observable half of that: with no x-forwarded-for at all, a present
-      // x-real-ip must not be trusted.
+      // x-real-ip must not be trusted while in the default header mode.
+      // (A deployment that is genuinely behind an x-real-ip-only proxy
+      // should instead set TRUSTED_PROXY_HEADER=x-real-ip; see the sibling
+      // describe block below for that mode's own tests.)
       process.env.TRUSTED_PROXY_COUNT = '1';
       const { resolveTrustedClientIp } = await freshClientIp();
 
@@ -148,15 +159,15 @@ describe('resolveTrustedClientIp', () => {
     });
 
     it('does not affect resolution when x-forwarded-for is present, including a spoofed value matching the attacker prefix', async () => {
-      // The regression scenario from the security review: a proxy sets a
-      // genuine x-real-ip, but the x-forwarded-for chain it forwards has an
-      // attacker-supplied entry. Catches: any code path that reads,
-      // prefers, cross-checks against, or is otherwise influenced by
-      // x-real-ip when resolving via x-forwarded-for. The correct,
-      // rightmost x-forwarded-for entry must win regardless of what
-      // x-real-ip says, including when x-real-ip has been set (by the
-      // attacker, or coincidentally) to the same value as the spoofed
-      // prefix.
+      // This is the case a Caddy operator's attacker would try: Caddy sets
+      // x-forwarded-for and no x-real-ip at all, so an attacker who injects
+      // their own x-real-ip header must not be able to influence the
+      // result. Catches: any code path that reads, prefers, cross-checks
+      // against, or is otherwise influenced by x-real-ip when resolving via
+      // x-forwarded-for in the default mode. The correct, rightmost
+      // x-forwarded-for entry must win regardless of what x-real-ip says,
+      // including when x-real-ip has been set (by the attacker, or
+      // coincidentally) to the same value as the spoofed prefix.
       process.env.TRUSTED_PROXY_COUNT = '1';
       const { resolveTrustedClientIp } = await freshClientIp();
 
@@ -175,6 +186,97 @@ describe('resolveTrustedClientIp', () => {
       const { resolveTrustedClientIp } = await freshClientIp();
 
       const request = requestWith({ 'x-real-ip': '198.51.100.7' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe("TRUSTED_PROXY_HEADER = 'x-real-ip'", () => {
+    it('resolves the genuine x-real-ip even when x-forwarded-for is entirely attacker-supplied', async () => {
+      // The topology this mode exists for: a proxy that replaces x-real-ip
+      // (proxy_set_header, trustworthy) but never manages x-forwarded-for,
+      // so every entry in x-forwarded-for, at every position, is whatever
+      // the client put there. Catches: still reading x-forwarded-for in
+      // this mode (e.g. forgetting to branch on TRUSTED_PROXY_HEADER), which
+      // would hand back an attacker-chosen entry instead of the genuine
+      // x-real-ip value.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '6.6.6.6, 7.7.7.7',
+        'x-real-ip': '203.0.113.9',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+
+    it('does not change when the attacker rotates the spoofed x-forwarded-for entries', async () => {
+      // Catches: any code path in x-real-ip mode that is influenced, even
+      // partially, by x-forwarded-for content. Rotating attacker-controlled
+      // entries must have zero effect on the result in this mode.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const first = resolveTrustedClientIp(
+        requestWith({ 'x-forwarded-for': '6.6.6.6, 7.7.7.7', 'x-real-ip': '203.0.113.9' })
+      );
+      const second = resolveTrustedClientIp(
+        requestWith({ 'x-forwarded-for': '8.8.8.8', 'x-real-ip': '203.0.113.9' })
+      );
+      const third = resolveTrustedClientIp(
+        requestWith({ 'x-real-ip': '203.0.113.9' }) // no x-forwarded-for at all
+      );
+
+      expect(first).toBe('203.0.113.9');
+      expect(second).toBe('203.0.113.9');
+      expect(third).toBe('203.0.113.9');
+    });
+
+    it('resolves an honest client with no x-forwarded-for correctly (the regression this mode exists to fix)', async () => {
+      // Before TRUSTED_PROXY_HEADER existed, dropping x-real-ip from the
+      // trusted path entirely (to close the Caddy-mirror flaw) broke every
+      // honest client behind a genuinely x-real-ip-only proxy: they send no
+      // x-forwarded-for of their own, so the app had nothing left to read
+      // and fell back to the shared bucket. Catches: this mode failing to
+      // actually restore that resolution.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': '203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+
+    it('rejects a non-IP value', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': 'not-an-ip' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('resolves to null when x-real-ip is absent, rather than falling back to x-forwarded-for', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '6.6.6.6, 7.7.7.7' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('still ignores everything when the count is 0, regardless of the header setting', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-real-ip': '203.0.113.9' });
 
       expect(resolveTrustedClientIp(request)).toBeNull();
     });

--- a/tests/lib/net/client-ip.test.ts
+++ b/tests/lib/net/client-ip.test.ts
@@ -282,6 +282,129 @@ describe('resolveTrustedClientIp', () => {
     });
   });
 
+  describe("TRUSTED_PROXY_HEADER = 'cf-connecting-ip'", () => {
+    it('resolves the genuine cf-connecting-ip, ignoring a spoofed x-forwarded-for and x-real-ip entirely', async () => {
+      // Cloudflare overwrites CF-Connecting-IP with the visitor address on
+      // every request, but a client reaching Cloudflare can still put
+      // whatever it wants in x-forwarded-for and x-real-ip; Cloudflare
+      // passes those through to the origin unchanged. Catches: still
+      // reading either of those headers in this mode (e.g. forgetting to
+      // branch on TRUSTED_PROXY_HEADER, or a copy-paste of the
+      // x-forwarded-for or x-real-ip logic), which would hand back an
+      // attacker-chosen value instead of the genuine cf-connecting-ip one.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '6.6.6.6, 7.7.7.7',
+        'x-real-ip': '8.8.8.8',
+        'cf-connecting-ip': '203.0.113.9',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+
+    it('does not change when the attacker rotates either spoofed header', async () => {
+      // Catches: any code path in cf-connecting-ip mode that is influenced,
+      // even partially, by x-forwarded-for or x-real-ip content. Rotating
+      // either attacker-controlled header must have zero effect on the
+      // result in this mode.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const first = resolveTrustedClientIp(
+        requestWith({
+          'x-forwarded-for': '6.6.6.6, 7.7.7.7',
+          'x-real-ip': '8.8.8.8',
+          'cf-connecting-ip': '203.0.113.9',
+        })
+      );
+      const second = resolveTrustedClientIp(
+        requestWith({
+          'x-forwarded-for': '9.9.9.9',
+          'x-real-ip': '10.10.10.10',
+          'cf-connecting-ip': '203.0.113.9',
+        })
+      );
+      const third = resolveTrustedClientIp(
+        requestWith({ 'cf-connecting-ip': '203.0.113.9' }) // neither spoofed header at all
+      );
+
+      expect(first).toBe('203.0.113.9');
+      expect(second).toBe('203.0.113.9');
+      expect(third).toBe('203.0.113.9');
+    });
+
+    it('resolves to null when cf-connecting-ip is absent, rather than falling back to x-forwarded-for or x-real-ip', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '6.6.6.6, 7.7.7.7',
+        'x-real-ip': '8.8.8.8',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('rejects a non-IP value', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'cf-connecting-ip': 'not-an-ip' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('still ignores everything when the count is 0, regardless of the header setting', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'cf-connecting-ip': '203.0.113.9' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+  });
+
+  describe('cf-connecting-ip is ignored outside cf-connecting-ip mode', () => {
+    it('cannot influence resolution in the default (x-forwarded-for) mode', async () => {
+      // A Cloudflare-shaped header must not leak into a deployment that
+      // never declared itself to be behind Cloudflare. Catches: any shared
+      // code path that reads cf-connecting-ip unconditionally instead of
+      // only inside resolveFromCfConnectingIp.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      delete process.env.TRUSTED_PROXY_HEADER;
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '1.2.3.4, 203.0.113.9',
+        'cf-connecting-ip': '198.51.100.7',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+      expect(resolveTrustedClientIp(request)).not.toBe('198.51.100.7');
+    });
+
+    it('cannot influence resolution in x-real-ip mode', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'x-real-ip';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-real-ip': '203.0.113.9',
+        'cf-connecting-ip': '198.51.100.7',
+      });
+
+      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+      expect(resolveTrustedClientIp(request)).not.toBe('198.51.100.7');
+    });
+  });
+
   describe('no headers at all', () => {
     it('returns null rather than a placeholder string', async () => {
       process.env.TRUSTED_PROXY_COUNT = '1';

--- a/tests/lib/net/client-ip.test.ts
+++ b/tests/lib/net/client-ip.test.ts
@@ -125,38 +125,49 @@ describe('resolveTrustedClientIp', () => {
       expect(resolveTrustedClientIp(request)).toBeNull();
     });
 
-    it('rejects a non-IP value in x-real-ip', async () => {
-      process.env.TRUSTED_PROXY_COUNT = '1';
-      const { resolveTrustedClientIp } = await freshClientIp();
-
-      const request = requestWith({ 'x-real-ip': 'also-not-an-ip' });
-
-      expect(resolveTrustedClientIp(request)).toBeNull();
-    });
   });
 
-  describe('x-real-ip fallback', () => {
-    it('is used only when x-forwarded-for is absent', async () => {
-      // Catches: preferring x-real-ip over a present x-forwarded-for, or
-      // merging the two.
-      process.env.TRUSTED_PROXY_COUNT = '1';
-      const { resolveTrustedClientIp } = await freshClientIp();
-
-      const request = requestWith({
-        'x-forwarded-for': '203.0.113.9',
-        'x-real-ip': '198.51.100.7',
-      });
-
-      expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
-    });
-
-    it('is used when x-forwarded-for is absent and the count is at least 1', async () => {
+  describe('x-real-ip is never trusted (a proxy that manages only x-real-ip is a misconfiguration)', () => {
+    it('is not used as a fallback when x-forwarded-for is absent, even with a trusted proxy count', async () => {
+      // Catches: reintroducing the "consult x-real-ip when x-forwarded-for is
+      // absent" fallback. That fallback is exploitable against a proxy that
+      // manages x-real-ip (via proxy_set_header, which replaces) but never
+      // touches x-forwarded-for: such a proxy passes an attacker's own
+      // x-forwarded-for straight through untouched, and a resolver that
+      // falls back to x-real-ip only when x-forwarded-for is *absent* would
+      // never even notice, because in the exploit case x-forwarded-for is
+      // present (it's the attacker's). This test pins the simpler,
+      // observable half of that: with no x-forwarded-for at all, a present
+      // x-real-ip must not be trusted.
       process.env.TRUSTED_PROXY_COUNT = '1';
       const { resolveTrustedClientIp } = await freshClientIp();
 
       const request = requestWith({ 'x-real-ip': '198.51.100.7' });
 
-      expect(resolveTrustedClientIp(request)).toBe('198.51.100.7');
+      expect(resolveTrustedClientIp(request)).toBeNull();
+    });
+
+    it('does not affect resolution when x-forwarded-for is present, including a spoofed value matching the attacker prefix', async () => {
+      // The regression scenario from the security review: a proxy sets a
+      // genuine x-real-ip, but the x-forwarded-for chain it forwards has an
+      // attacker-supplied entry. Catches: any code path that reads,
+      // prefers, cross-checks against, or is otherwise influenced by
+      // x-real-ip when resolving via x-forwarded-for. The correct,
+      // rightmost x-forwarded-for entry must win regardless of what
+      // x-real-ip says, including when x-real-ip has been set (by the
+      // attacker, or coincidentally) to the same value as the spoofed
+      // prefix.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({
+        'x-forwarded-for': '6.6.6.6, 203.0.113.9',
+        'x-real-ip': '6.6.6.6',
+      });
+
+      const result = resolveTrustedClientIp(request);
+      expect(result).toBe('203.0.113.9');
+      expect(result).not.toBe('6.6.6.6');
     });
 
     it('is not consulted at all when the count is 0, even alone', async () => {
@@ -188,6 +199,40 @@ describe('resolveTrustedClientIp', () => {
       const request = requestWith({ 'x-forwarded-for': '1.2.3.4, 203.0.113.9' });
 
       expect(resolveTrustedClientIp(request)).toBe('203.0.113.9');
+    });
+  });
+
+  describe('IPv6 addresses', () => {
+    it('accepts a valid IPv6 candidate', async () => {
+      // Catches: replacing net.isIP with an IPv4-only validator (e.g. a
+      // dotted-quad regex). There is no other IPv6 coverage in this file,
+      // so an IPv4-only check would otherwise pass every test here while
+      // quietly rejecting every real IPv6 client into the shared bucket,
+      // which is exactly this design's failure mode.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '2001:db8::1' });
+
+      expect(resolveTrustedClientIp(request)).toBe('2001:db8::1');
+    });
+
+    it('resolves the rightmost entry from a chain mixing IPv4 and IPv6 hops', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '1.2.3.4, 2001:db8::9' });
+
+      expect(resolveTrustedClientIp(request)).toBe('2001:db8::9');
+    });
+
+    it('rejects a malformed IPv6-looking candidate', async () => {
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { resolveTrustedClientIp } = await freshClientIp();
+
+      const request = requestWith({ 'x-forwarded-for': '2001:db8::zzzz' });
+
+      expect(resolveTrustedClientIp(request)).toBeNull();
     });
   });
 });

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -126,7 +126,14 @@ describe('rate-limit', () => {
       expect(checkRateLimit(request, 'login', 'email2@test.com')).toBeNull();
     });
 
-    it('should read IP from x-real-ip header as fallback', async () => {
+    it('does not trust x-real-ip, so a request carrying only it shares the fallback bucket', async () => {
+      // x-real-ip is never part of the trusted resolution path (see
+      // lib/net/client-ip.ts), so a request with no x-forwarded-for
+      // resolves to no trusted IP at all, regardless of x-real-ip, and
+      // shares the "no trusted IP" bucket with every other such request
+      // for this rate-limit type. This still blocks after maxAttempts, but
+      // for a different reason than the old (incorrect) "reads x-real-ip as
+      // a fallback" behavior this test used to pin.
       const { checkRateLimit, rateLimitConfigs } = await import('@/lib/rate-limit');
 
       const request = new Request('http://localhost/api/test', {
@@ -135,7 +142,6 @@ describe('rate-limit', () => {
         },
       });
 
-      // Should work without x-forwarded-for
       for (let i = 0; i < rateLimitConfigs.login.maxAttempts; i++) {
         checkRateLimit(request, 'login');
       }
@@ -252,6 +258,69 @@ describe('rate-limit', () => {
       const result = checkRateLimit(requestWithChain('10.0.0.2'), 'login');
       expect(result).not.toBeNull();
       expect(result?.status).toBe(429);
+    });
+  });
+
+  describe('buildRateLimitKey', () => {
+    it('keys on the identifier alone when there is no trusted IP', async () => {
+      // Catches: deleting the `if (identifier)` branch, which is the entire
+      // reason the auth routes (forgot-password, resend-verification,
+      // register) narrow their bucket by email: without it, any request
+      // with no trusted IP collapses into the shared bucket regardless of
+      // the identifier passed in, silently undoing that fix.
+      const { buildRateLimitKey } = await import('@/lib/rate-limit');
+
+      const key = buildRateLimitKey('forgotPassword', null, 'user@example.com');
+
+      expect(key).toBe('forgotPassword:user@example.com');
+      expect(key).not.toContain('shared');
+    });
+
+    it('still distinguishes two different identifiers when there is no trusted IP', async () => {
+      const { buildRateLimitKey } = await import('@/lib/rate-limit');
+
+      const keyA = buildRateLimitKey('forgotPassword', null, 'a@example.com');
+      const keyB = buildRateLimitKey('forgotPassword', null, 'b@example.com');
+
+      expect(keyA).not.toBe(keyB);
+    });
+
+    it('falls back to a shared bucket only when there is neither a trusted IP nor an identifier', async () => {
+      const { buildRateLimitKey } = await import('@/lib/rate-limit');
+
+      const key = buildRateLimitKey('login', null, undefined);
+
+      expect(key).toBe('login:shared');
+    });
+  });
+
+  describe('warnNoTrustedClientIp integration', () => {
+    const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+
+    afterEach(() => {
+      if (originalTrustedProxyCount === undefined) {
+        delete process.env.TRUSTED_PROXY_COUNT;
+      } else {
+        process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+      }
+    });
+
+    it('checkRateLimit emits the operator warning when it falls back to the shared bucket', async () => {
+      // Catches: deleting the warnNoTrustedClientIp() call from the rate
+      // limiter (or from buildRateLimitKey). That call is the only signal
+      // an operator gets that TRUSTED_PROXY_COUNT is misconfigured and
+      // every unauthenticated request with no other identifier is sharing
+      // one bucket; losing it makes that condition silent.
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { checkRateLimit } = await import('@/lib/rate-limit');
+
+      checkRateLimit(new Request('http://localhost/api/test'), 'login');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('TRUSTED_PROXY_COUNT');
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -296,12 +296,19 @@ describe('rate-limit', () => {
 
   describe('warnNoTrustedClientIp integration', () => {
     const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+    const originalTrustedProxyHeader = process.env.TRUSTED_PROXY_HEADER;
 
     afterEach(() => {
       if (originalTrustedProxyCount === undefined) {
         delete process.env.TRUSTED_PROXY_COUNT;
       } else {
         process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+      }
+
+      if (originalTrustedProxyHeader === undefined) {
+        delete process.env.TRUSTED_PROXY_HEADER;
+      } else {
+        process.env.TRUSTED_PROXY_HEADER = originalTrustedProxyHeader;
       }
     });
 
@@ -319,6 +326,32 @@ describe('rate-limit', () => {
 
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy.mock.calls[0][0]).toContain('TRUSTED_PROXY_COUNT');
+
+      warnSpy.mockRestore();
+    });
+
+    it('fires the same warning, not a silently trusted value, when an x-real-ip-only proxy is left in the default header mode', async () => {
+      // The misconfiguration scenario from the security review: the proxy
+      // in front only manages x-real-ip (a real, common setup), but
+      // TRUSTED_PROXY_HEADER is left at its default of x-forwarded-for. A
+      // genuine client sends no x-forwarded-for of its own (browsers do not
+      // set this header), so the app has nothing to read in the mode it is
+      // configured for, and must fail into the shared bucket with a loud
+      // warning rather than silently trusting x-real-ip (which would only
+      // be correct if the operator had actually declared that mode).
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      delete process.env.TRUSTED_PROXY_HEADER;
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { checkRateLimit } = await import('@/lib/rate-limit');
+
+      const request = new Request('http://localhost/api/test', {
+        headers: { 'x-real-ip': '203.0.113.9' },
+      });
+      const result = checkRateLimit(request, 'login');
+
+      expect(result).toBeNull(); // first request in the shared bucket, still allowed
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('TRUSTED_PROXY_HEADER');
 
       warnSpy.mockRestore();
     });

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('rate-limit', () => {
   beforeEach(() => {
@@ -189,6 +189,69 @@ describe('rate-limit', () => {
 
       // Should be allowed again
       expect(checkRateLimit(request, 'login', email)).toBeNull();
+    });
+  });
+
+  describe('trusted proxy resolution (GHSA-x7jp-pjg9-x996 regression)', () => {
+    const originalTrustedProxyCount = process.env.TRUSTED_PROXY_COUNT;
+
+    afterEach(() => {
+      if (originalTrustedProxyCount === undefined) {
+        delete process.env.TRUSTED_PROXY_COUNT;
+      } else {
+        process.env.TRUSTED_PROXY_COUNT = originalTrustedProxyCount;
+      }
+    });
+
+    function requestWithChain(chain: string): Request {
+      return new Request('http://localhost/api/test', {
+        headers: { 'x-forwarded-for': chain },
+      });
+    }
+
+    it('does not let an attacker get a fresh bucket by rotating the spoofed prefix', async () => {
+      // Catches: reading the leftmost x-forwarded-for entry instead of the
+      // rightmost trusted one. Without the fix, each distinct prefix below
+      // produces a distinct bucket and none of them would ever see a 429.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      const { checkRateLimit, rateLimitConfigs } = await import('@/lib/rate-limit');
+
+      const realClientIp = '203.0.113.42';
+
+      // Exhaust the bucket using one spoofed prefix.
+      for (let i = 0; i < rateLimitConfigs.login.maxAttempts; i++) {
+        const result = checkRateLimit(requestWithChain(`1.1.1.1, ${realClientIp}`), 'login');
+        expect(result).toBeNull();
+      }
+
+      // A "new" attacker request with a different spoofed prefix, but the
+      // same real client IP behind it, must already be blocked.
+      const blocked = checkRateLimit(requestWithChain(`2.2.2.2, ${realClientIp}`), 'login');
+      expect(blocked).not.toBeNull();
+      expect(blocked?.status).toBe(429);
+
+      // A genuinely different real client IP is unaffected.
+      const otherClient = checkRateLimit(
+        requestWithChain(`3.3.3.3, 198.51.100.5`),
+        'login'
+      );
+      expect(otherClient).toBeNull();
+    });
+
+    it('falls back to a shared bucket, not the leftmost entry, when TRUSTED_PROXY_COUNT is 0', async () => {
+      // Catches: still parsing x-forwarded-for when the count is 0.
+      process.env.TRUSTED_PROXY_COUNT = '0';
+      const { checkRateLimit, rateLimitConfigs } = await import('@/lib/rate-limit');
+
+      // Two different callers, distinguished only by x-forwarded-for, share
+      // the same bucket because no IP is trusted at all with count 0.
+      for (let i = 0; i < rateLimitConfigs.login.maxAttempts; i++) {
+        checkRateLimit(requestWithChain('10.0.0.1'), 'login');
+      }
+
+      const result = checkRateLimit(requestWithChain('10.0.0.2'), 'login');
+      expect(result).not.toBeNull();
+      expect(result?.status).toBe(429);
     });
   });
 

--- a/tests/lib/rate-limit.test.ts
+++ b/tests/lib/rate-limit.test.ts
@@ -355,6 +355,32 @@ describe('rate-limit', () => {
 
       warnSpy.mockRestore();
     });
+
+    it('fires the warning, not a silently trusted value, when cf-connecting-ip mode is configured but the header is absent', async () => {
+      // cf-connecting-ip mode has no chain to fall back on: if Cloudflare
+      // (or whatever set TRUSTED_PROXY_HEADER=cf-connecting-ip) did not
+      // attach the header, there is nothing else in this mode to read, and
+      // the request must fail into the shared bucket with a warning rather
+      // than silently trying x-forwarded-for or x-real-ip instead.
+      process.env.TRUSTED_PROXY_COUNT = '1';
+      process.env.TRUSTED_PROXY_HEADER = 'cf-connecting-ip';
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const { checkRateLimit } = await import('@/lib/rate-limit');
+
+      const request = new Request('http://localhost/api/test', {
+        headers: {
+          'x-forwarded-for': '203.0.113.9',
+          'x-real-ip': '203.0.113.9',
+        },
+      });
+      const result = checkRateLimit(request, 'login');
+
+      expect(result).toBeNull(); // first request in the shared bucket, still allowed
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('TRUSTED_PROXY_HEADER');
+
+      warnSpy.mockRestore();
+    });
   });
 
   describe('rateLimitConfigs', () => {


### PR DESCRIPTION
## What

Rate limiting derived the client IP from proxy headers without any notion of which proxy, if any, was trusted to set them. Because those headers arrive with the request, the value used as the rate-limit bucket key was not reliably the caller's. This makes every limit in the app weaker than intended: login, registration, password reset, email verification, CardDAV, error reporting, push subscription, and the notification endpoints.

This adds a trust boundary, de-duplicates the three copies of the resolution logic, and stops the limits resting entirely on the IP.

## Upgrade notes

No action required. The defaults match both reverse proxy configurations in our own documentation, so existing deployments behave the same after upgrading.

Two new optional settings, both documented in `self-hosting/configuration.md` and `self-hosting/reverse-proxy.md`:

- `TRUSTED_PROXY_COUNT` (default `1`): how many proxies sit in front of Nametag. Set `0` if none, `2` for a CDN in front of a load balancer.
- `TRUSTED_PROXY_HEADER` (default `x-forwarded-for`): which header your proxy sets. Set `x-real-ip` if your proxy sets that one instead.

## Why two settings rather than one

The two topologies cannot be told apart at runtime, and each makes the *other* header untrustworthy:

- A proxy that sets `X-Forwarded-For` (our documented nginx and Caddy configs both do) passes any client-supplied `X-Real-IP` straight through.
- A proxy that sets only `X-Real-IP` passes any client-supplied `X-Forwarded-For` straight through.

Preferring either header by default is therefore wrong for somebody, and wrong silently. So the operator declares it, with the default matching what our own documentation prescribes.

## How the resolution works

- With `x-forwarded-for`, entries are counted from the **right**. The documented nginx config uses `proxy_add_x_forwarded_for`, which appends, so anything a client supplied stays to the left of what the proxy adds.
- With `x-real-ip`, that header is read alone. It carries a single value the proxy replaces rather than appends, so the hop count does not apply.
- The result must parse as an IP address, otherwise arbitrary text becomes a bucket key.
- A count of `0` ignores both headers entirely.
- When no trustworthy IP can be determined the resolver returns `null` rather than a placeholder, and the app logs a warning naming both settings, because a silently shared bucket is how this stays broken.

There is an inherent limit worth stating: with one trusted proxy, a single-entry header is indistinguishable from a compliant proxy's single appended hop. Hop counting is only sound if the app cannot be reached except through the proxy. That precondition is now stated in the documentation, with a commented `127.0.0.1` binding in `docker-compose.yml` for operators who front the app with a proxy.

## Cloudflare

`TRUSTED_PROXY_HEADER` also accepts `cf-connecting-ip`. Cloudflare **overwrites** that header with the visitor address on every request, rather than appending the way it does with `X-Forwarded-For`, so in that mode there is no chain to count and no hop number to get wrong when a layer is added or removed.

**That mode moves the entire security boundary to your origin.** With `x-forwarded-for`, a wrong hop count degrades gracefully: an attacker supplies one forged entry among several and the resolver usually still lands on a real address. `CF-Connecting-IP` has no such cushion. Anyone who can reach the origin without passing through Cloudflare can set that header to anything, and nothing contradicts them. Use it only with the origin locked down, by restricting the firewall to Cloudflare's published ranges, enabling Authenticated Origin Pulls, or running a Cloudflare Tunnel so the origin has no public address at all.

If you would rather not depend on that, leave the header at its default and set `TRUSTED_PROXY_COUNT` to the number of appending hops instead: `2` for Cloudflare in front of your own reverse proxy, `1` if Cloudflare reaches the app directly.

Do **not** use `x-real-ip` behind Cloudflare. An origin Nginx setting `X-Real-IP $remote_addr` records the Cloudflare **edge** address, so every visitor arriving through the same edge would share a single rate-limit bucket.

## Trusted versus untrusted

`resolveTrustedClientIp` is for security decisions and returns `null` when it cannot be sure. `getClientIp` keeps its previous best-effort behaviour and is now documented as being for log lines only. Every remaining caller of the latter was checked individually and is a logging argument.

## Reducing the reliance on the IP at all

Three routes previously keyed on the IP alone. `forgot-password`, `resend-verification` and `register` now also key on the normalised email address, so a per-account bound holds even where the IP cannot be trusted. These are the paths that send mail to an address supplied in the request.

Each of them checks the limit twice: an unkeyed check before the body is parsed, and an email-keyed check after. Without the first, a malformed body would consume no limit at all.

`login` is deliberately unchanged: its body must reach the auth handler intact, and a per-email key would not bound password spraying, which is one password tried against many addresses. Per-account lockout already covers repeated guesses against a single account. `reset-password` and `verify-email` carry only a token, which would produce a fresh key per guess.

## Testing

`npm run verify` passes: lint, typecheck, 3437 tests, production build, plus the docs site build.

The resolver is covered against spoofed prefixes and rotation in both modes, hop counts of 0, 1 and 2, chains shorter than the configured count, non-address values, IPv6, whitespace and empty entries, and each mode ignoring the other's header.

